### PR TITLE
fix(theme): tokenise the accents, so light stops painting dark-tuned colour (#402)

### DIFF
--- a/docs/ui/theming.md
+++ b/docs/ui/theming.md
@@ -56,7 +56,7 @@ editor frame — is written in the semantic tokens of `src/styles/theme.css`. Tw
 | Surface | `canvas` · `sunken` · `surface` · `raised` · `overlay` (plus `panel`, the translucent card ground) |
 | Text | `fg-bright` · `fg` · `fg-secondary` · `fg-tertiary` · `fg-muted` · `fg-subtle` · `fg-faint` |
 | Accent, state | `brand` · `warning` · `success` · `danger`, each with `-bright`, `-tint`, `-solid`, `-solid-hover` |
-| Accent, identity | `hue-<name>` for fifteen hues, some with `-alt` and `-tint` |
+| Accent, identity | `hue-<name>`, one per hue the app uses, some with `-alt` (a second step) and `-tint` (its wash) |
 
 Alongside them: `hairline` / `hairline-strong` for structural rules, `edge` / `edge-hover` for
 the border of a control the user is meant to see, and `fill-subtle` / `fill` / `fill-strong`

--- a/docs/ui/theming.md
+++ b/docs/ui/theming.md
@@ -55,6 +55,8 @@ editor frame — is written in the semantic tokens of `src/styles/theme.css`. Tw
 |------|-----------------------------------------------------|
 | Surface | `canvas` · `sunken` · `surface` · `raised` · `overlay` (plus `panel`, the translucent card ground) |
 | Text | `fg-bright` · `fg` · `fg-secondary` · `fg-tertiary` · `fg-muted` · `fg-subtle` · `fg-faint` |
+| Accent, state | `brand` · `warning` · `success` · `danger`, each with `-bright`, `-tint`, `-solid`, `-solid-hover` |
+| Accent, identity | `hue-<name>` for fifteen hues, some with `-alt` and `-tint` |
 
 Alongside them: `hairline` / `hairline-strong` for structural rules, `edge` / `edge-hover` for
 the border of a control the user is meant to see, and `fill-subtle` / `fill` / `fill-strong`
@@ -66,6 +68,34 @@ In dark, elevation means lighter; in light it means whiter, and the text ramp in
 literals the components carried before the layer existed, so **moving a component onto a token
 must be a no-op in dark** — any visible dark-mode change is a bug unless it is deliberate and
 called out.
+
+### State or identity
+
+The two accent families answer different questions, and picking the wrong one is the mistake
+that costs something later. Note the state family is `brand`, not `accent`: shadcn already owns
+`--accent` — its neutral hover ground, `#f5f5f5` — and `globals.css` maps `--color-accent` to it
+*after* importing this layer, so a studio token of that name loses the cascade silently and paints
+near-white text on a white page.
+
+- **State** — the colour tracks a changing condition. A run failed, a row is selected, a
+  statement is risky. Four roles: `brand`, `warning`, `success`, `danger`. `-bright` is the
+  emphasised step and inverts exactly like `fg-bright` — brighter than its base in dark, darker
+  in light, both meaning *further from the ground*.
+- **Identity** — the colour is a fixed label for a thing. Which engine, which bottom panel,
+  added versus removed, primary key versus foreign key, number versus boolean. `hue-<name>`, and
+  `hue-<name>-alt` where two identities share a hue: there are more engines than there are hues,
+  and `db-ui-config`'s own test asserts every engine colour differs.
+
+Folding an identity into a state role repaints nineteen engines in four colours. Folding a state
+into an identity hue means the next person to change what "error" looks like has to find every
+red in the codebase. The identity set is **selected per mode**, the way `lib/charts/palette.ts`
+selects rather than flipping a ramp — the two modes run out of room in different places, so a
+ramp flip produces collisions in one of them.
+
+`-tint` is the wash a role is painted over (`bg-brand-tint/15`) and is the same value in both
+palettes on purpose: a wash is alpha over whatever is behind it, so it already adapts. `-solid`
+is a filled control's ground, mode-independent for the same reason — a button's label sits on
+the button, not on the page.
 
 ### Surfaces that cannot read CSS
 
@@ -308,15 +338,17 @@ shadcn/ui buttons use theme variables automatically:
 
 ### Step 1: Define Variables
 
+Both palettes, always. A token declared in one resolves to nothing in the other, which is invalid
+at computed-value time — the ground falls to transparent, the hairline to `currentColor`, and only
+in the theme nobody happened to be looking at.
+
 ```css
 :root {
-  --warning: #f59e0b;
-  --warning-foreground: #ffffff;
+  --studio-hue-lime: #3f6212;
 }
 
 .dark {
-  --warning: #d97706;
-  --warning-foreground: #ffffff;
+  --studio-hue-lime: #9ae600;
 }
 ```
 
@@ -324,18 +356,35 @@ shadcn/ui buttons use theme variables automatically:
 
 ```css
 @theme inline {
-  --color-warning: var(--warning);
-  --color-warning-foreground: var(--warning-foreground);
+  --color-hue-lime: var(--studio-hue-lime);
 }
 ```
+
+`inline` is required: a plain `@theme` resolves the value at build time and freezes whichever
+palette was in scope.
 
 ### Step 3: Use in Components
 
 ```jsx
-<div className="bg-warning text-warning-foreground">
-  Warning message
-</div>
+<span className="text-hue-lime">…</span>
 ```
+
+### Step 4: Let the suite check it
+
+Do not verify a colour by eye, and do not write the ratio into a comment. `tests/unit/theme-accent-contrast.test.ts`
+measures every accent token on every ground it can land on, in both palettes, and
+`tests/unit/theme-token-usage.test.ts` fails on a colour literal in `src` and on a token nothing
+reaches. The bars a new token has to clear:
+
+- **4.5:1** on the five studio grounds, on a wash of its own hue up to `/20`, and on the brand
+  tile — WCAG AA for text, in both palettes.
+- **Separation** no tighter than the shipped dark set's own minimum, if it joins the identity
+  palette. The bar is measured, not chosen, so it moves if dark is ever retuned.
+- **A call site.** A token nobody uses is a value nobody has checked.
+
+The helper the tests measure with is `tests/helpers/contrast.ts`. It reads the Tailwind palette out
+of `node_modules` rather than transcribing it, so a Tailwind upgrade that restyles `blue-400`
+reports itself as the dark-mode change it is.
 
 ## Troubleshooting
 
@@ -413,4 +462,4 @@ shadcn/ui buttons use theme variables automatically:
 
 ---
 
-*Last updated: June 2026*
+*Last updated: September 2026*

--- a/docs/ui/theming.md
+++ b/docs/ui/theming.md
@@ -55,8 +55,8 @@ editor frame — is written in the semantic tokens of `src/styles/theme.css`. Tw
 |------|-----------------------------------------------------|
 | Surface | `canvas` · `sunken` · `surface` · `raised` · `overlay` (plus `panel`, the translucent card ground) |
 | Text | `fg-bright` · `fg` · `fg-secondary` · `fg-tertiary` · `fg-muted` · `fg-subtle` · `fg-faint` |
-| Accent, state | `brand` · `warning` · `success` · `danger`, each with `-bright`, `-tint`, `-solid`, `-solid-hover` |
-| Accent, identity | `hue-<name>`, one per hue the app uses, some with `-alt` (a second step) and `-tint` (its wash) |
+| Accent, state | `brand` · `warning` · `success` · `danger`, each with `-bright`, `-tint`, `-solid`, `-solid-hover` (plus `brand-solid-active`, the one filled ground that hovers darker) |
+| Accent, identity | `hue-<name>`, one per hue the app uses, some with `-alt` (a second step) and `-tint` (its wash); `hue-teal` and `hue-purple` also carry `-solid` / `-solid-hover` for the two filled controls painted in a panel's own hue |
 
 Alongside them: `hairline` / `hairline-strong` for structural rules, `edge` / `edge-hover` for
 the border of a control the user is meant to see, and `fill-subtle` / `fill` / `fill-strong`
@@ -86,7 +86,7 @@ near-white text on a white page.
   `hue-<name>-alt` where two identities share a hue: there are more engines than there are hues,
   and `db-ui-config`'s own test asserts every engine colour differs.
 
-Folding an identity into a state role repaints nineteen engines in four colours. Folding a state
+Folding an identity into a state role repaints seventeen engines in four colours. Folding a state
 into an identity hue means the next person to change what "error" looks like has to find every
 red in the codebase. The identity set is **selected per mode**, the way `lib/charts/palette.ts`
 selects rather than flipping a ramp — the two modes run out of room in different places, so a
@@ -376,8 +376,13 @@ measures every accent token on every ground it can land on, in both palettes, an
 `tests/unit/theme-token-usage.test.ts` fails on a colour literal in `src` and on a token nothing
 reaches. The bars a new token has to clear:
 
-- **4.5:1** on the five studio grounds, on a wash of its own hue up to `/20`, and on the brand
-  tile — WCAG AA for text, in both palettes.
+- **4.5:1** on the five studio grounds, on a wash of its own hue at every alpha the code
+  actually paints (scanned out of `src`, currently up to `/25`), and on the brand tile — WCAG AA
+  for text, in both palettes.
+- **No worse in light than in dark** if the token is ever used with a foreground opacity
+  (`text-warning/80`). An opacity modifier composites before anyone reads it, so a token that
+  clears AA opaque can fall under it faded; the suite measures those separately and pins the
+  ones that do not clear.
 - **Separation** no tighter than the shipped dark set's own minimum, if it joins the identity
   palette. The bar is measured, not chosen, so it moves if dark is ever retuned.
 - **A call site.** A token nobody uses is a value nobody has checked.

--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -18,7 +18,7 @@ export default function AdminError({ error, reset }: { error: Error & { digest?:
         <div className="flex gap-3 justify-center">
           <button
             onClick={reset}
-            className="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors"
+            className="px-5 py-2.5 bg-brand-solid hover:bg-brand-solid-active text-white rounded-lg text-sm font-medium transition-colors"
           >
             Try Again
           </button>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -19,7 +19,7 @@ export default function ErrorPage({ error, reset }: { error: Error & { digest?: 
         <div className="flex gap-3 justify-center">
           <button
             onClick={reset}
-            className="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors"
+            className="px-5 py-2.5 bg-brand-solid hover:bg-brand-solid-active text-white rounded-lg text-sm font-medium transition-colors"
           >
             Try Again
           </button>

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -93,8 +93,8 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
         />
 
         {/* Ambient glow orbs — blue accent family */}
-        <div className="absolute top-1/4 -left-20 w-80 h-80 bg-blue-500/[0.07] rounded-full blur-3xl" />
-        <div className="absolute bottom-1/3 right-10 w-64 h-64 bg-cyan-500/[0.05] rounded-full blur-3xl" />
+        <div className="absolute top-1/4 -left-20 w-80 h-80 bg-brand-tint/[0.07] rounded-full blur-3xl" />
+        <div className="absolute bottom-1/3 right-10 w-64 h-64 bg-hue-cyan-tint/[0.05] rounded-full blur-3xl" />
 
         {/* Right edge separator */}
         <div className="absolute right-0 top-0 bottom-0 w-px bg-fill-strong" />
@@ -109,9 +109,9 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
             className="flex items-center gap-3 group w-fit"
           >
             <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-fill-strong border border-hairline-strong group-hover:bg-fill-strong group-hover:border-hairline-strong transition-all duration-200">
-              <LibreDBLogo className="h-9 w-9 text-blue-400" />
+              <LibreDBLogo className="h-9 w-9 text-brand" />
             </div>
-            <span className="text-xl font-semibold text-white tracking-tight group-hover:text-blue-400 transition-colors duration-200">
+            <span className="text-xl font-semibold text-white tracking-tight group-hover:text-brand transition-colors duration-200">
               LibreDB Studio
             </span>
           </a>
@@ -186,13 +186,13 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
             className="flex flex-col items-center gap-4 lg:hidden group"
           >
             <div className="relative">
-              <div className="absolute -inset-2 rounded-full bg-blue-500/20 blur-lg" />
-              <div className="relative flex h-20 w-20 items-center justify-center rounded-2xl bg-raised border border-hairline-strong shadow-lg shadow-blue-500/10 group-hover:border-blue-500/20 transition-all duration-200">
-                <LibreDBLogo className="h-12 w-12 text-blue-400" />
+              <div className="absolute -inset-2 rounded-full bg-brand-tint/20 blur-lg" />
+              <div className="relative flex h-20 w-20 items-center justify-center rounded-2xl bg-raised border border-hairline-strong shadow-lg shadow-blue-500/10 group-hover:border-brand-tint/20 transition-all duration-200">
+                <LibreDBLogo className="h-12 w-12 text-brand" />
               </div>
             </div>
             <div className="text-center space-y-1">
-              <h2 className="text-2xl font-bold tracking-tight group-hover:text-blue-400 transition-colors duration-200">
+              <h2 className="text-2xl font-bold tracking-tight group-hover:text-brand transition-colors duration-200">
                 LibreDB Studio
               </h2>
               <p className="text-sm text-muted-foreground">Open-source SQL IDE for cloud-native teams</p>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -10,7 +10,7 @@ export default function NotFound() {
         <div className="flex gap-3 justify-center">
           <Link
             href="/"
-            className="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors"
+            className="px-5 py-2.5 bg-brand-solid hover:bg-brand-solid-active text-white rounded-lg text-sm font-medium transition-colors"
           >
             Go to Studio
           </Link>

--- a/src/components/CodeGenerator.tsx
+++ b/src/components/CodeGenerator.tsx
@@ -266,7 +266,7 @@ export function CodeGenerator({ isOpen, onClose, tableName, tableSchema, databas
       <div className="bg-overlay border border-hairline-strong rounded-xl shadow-2xl w-full max-w-xl mx-4 overflow-hidden">
         <div className="flex items-center justify-between px-5 py-3 border-b border-hairline">
           <div className="flex items-center gap-2">
-            <Code strokeWidth={1.5} className="w-3.5 h-3.5 text-purple-400" />
+            <Code strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-purple" />
             <span className="text-xs font-medium text-fg">Code Generator</span>
             <span className="text-xs text-fg-muted font-mono">{tableName}</span>
             {databaseType && <span className="text-xs text-fg-subtle font-mono uppercase">{databaseType}</span>}
@@ -296,7 +296,7 @@ export function CodeGenerator({ isOpen, onClose, tableName, tableSchema, databas
                     }}
                     className={cn(
                       "w-full text-left px-3 py-1.5 text-xs hover:bg-fill transition-colors",
-                      language === lang.id ? "text-purple-400" : "text-fg-tertiary",
+                      language === lang.id ? "text-hue-purple" : "text-fg-tertiary",
                     )}
                   >
                     {lang.label}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -113,7 +113,7 @@ export function CommandPalette({
         {/* Quick Actions */}
         <CommandGroup heading="Actions">
           <CommandItem onSelect={() => runAction(onExecuteQuery)}>
-            <Play strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />
+            <Play strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-blue" />
             <span>Run Query</span>
             <CommandShortcut>Ctrl+Enter</CommandShortcut>
           </CommandItem>
@@ -132,30 +132,30 @@ export function CommandPalette({
               carries the editor's statement in with it (review of #331 T3).
             */
             <CommandItem onSelect={() => runAction(onAskAgent)}>
-              <Bot strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />
+              <Bot strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-blue" />
               <span>Ask the agent about this query</span>
             </CommandItem>
           )}
           <CommandItem onSelect={() => runAction(onAddConnection)}>
-            <Plus strokeWidth={1.5} className="w-3.5 h-3.5 text-emerald-400" />
+            <Plus strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-emerald" />
             <span>New Connection</span>
           </CommandItem>
           <CommandItem onSelect={() => runAction(onNavigateHealth)}>
-            <Activity strokeWidth={1.5} className="w-3.5 h-3.5 text-emerald-400" />
+            <Activity strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-emerald" />
             <span>Health Dashboard</span>
           </CommandItem>
           <CommandItem onSelect={() => runAction(onNavigateMonitoring)}>
-            <Gauge strokeWidth={1.5} className="w-3.5 h-3.5 text-purple-400" />
+            <Gauge strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-purple" />
             <span>Monitoring</span>
           </CommandItem>
           {activeConnection && (
             <CommandItem onSelect={() => runAction(onShowDiagram)}>
-              <Layers strokeWidth={1.5} className="w-3.5 h-3.5 text-cyan-400" />
+              <Layers strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-cyan" />
               <span>Schema Diagram (ERD)</span>
             </CommandItem>
           )}
           <CommandItem onSelect={() => runAction(onLogout)}>
-            <LogOut strokeWidth={1.5} className="w-3.5 h-3.5 text-red-400" />
+            <LogOut strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-red" />
             <span>Logout</span>
           </CommandItem>
         </CommandGroup>
@@ -170,7 +170,7 @@ export function CommandPalette({
                   <Icon className="w-3.5 h-3.5" />
                   <span>{conn.name}</span>
                   {activeConnection?.id === conn.id && (
-                    <span className="ml-auto text-xs text-emerald-500 font-medium">Active</span>
+                    <span className="ml-auto text-xs text-success font-medium">Active</span>
                   )}
                 </CommandItem>
               );
@@ -199,7 +199,7 @@ export function CommandPalette({
           <CommandGroup heading="Saved Queries">
             {savedQueries.map((sq: SavedQuery) => (
               <CommandItem key={sq.id} onSelect={() => runAction(() => onLoadSavedQuery(sq.query))}>
-                <Bookmark strokeWidth={1.5} className="w-3.5 h-3.5 text-purple-400" />
+                <Bookmark strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-purple" />
                 <span>{sq.name}</span>
                 <span className="ml-auto text-xs text-fg-subtle truncate max-w-[150px]">
                   {sq.query.substring(0, 40)}...

--- a/src/components/ConnectionModal.tsx
+++ b/src/components/ConnectionModal.tsx
@@ -195,11 +195,11 @@ export function ConnectionModal({
   const formContent = (
     <>
       {/* Progress bar — fixed top */}
-      <div className="shrink-0 h-2 w-full bg-blue-600/20">
+      <div className="shrink-0 h-2 w-full bg-brand-solid/20">
         <motion.div
           initial={{ width: 0 }}
           animate={{ width: "100%" }}
-          className="h-full bg-blue-500 shadow-[0_0_15px_rgba(59,130,246,0.5)]"
+          className="h-full bg-brand-tint shadow-[0_0_15px_rgba(59,130,246,0.5)]"
         />
       </div>
 
@@ -207,8 +207,8 @@ export function ConnectionModal({
       <div className="flex-1 overflow-y-auto p-4 md:p-8">
         <div className="mb-4 md:mb-8">
           <div className="flex items-center gap-3 mb-2">
-            <div className="p-2 rounded-xl bg-blue-500/10 border border-blue-500/20">
-              <Zap strokeWidth={1.5} className="w-5 h-5 text-blue-400" />
+            <div className="p-2 rounded-xl bg-brand-tint/10 border border-brand-tint/20">
+              <Zap strokeWidth={1.5} className="w-5 h-5 text-brand" />
             </div>
             <h2 className="text-xs md:text-[0.8125rem] font-medium">
               {isEditMode ? "Edit Connection" : "New Connection"}
@@ -223,7 +223,7 @@ export function ConnectionModal({
             {!isEditMode && (
               <button
                 onClick={() => setShowPasteInput(!showPasteInput)}
-                className="flex items-center gap-1.5 text-xs font-mediumr text-blue-400 hover:text-blue-300 transition-colors px-2 py-1 rounded-md hover:bg-blue-500/10"
+                className="flex items-center gap-1.5 text-xs font-mediumr text-brand hover:text-brand-bright transition-colors px-2 py-1 rounded-md hover:bg-brand-tint/10"
               >
                 <ClipboardPaste strokeWidth={1.5} className="w-3 h-3" />
                 Paste URL
@@ -241,20 +241,20 @@ export function ConnectionModal({
               exit={{ height: 0, opacity: 0 }}
               className="mb-6 overflow-hidden"
             >
-              <div className="p-3 rounded-lg border border-blue-500/20 bg-blue-500/5 space-y-2">
-                <Label className="text-xs font-mediumr text-blue-400">Paste Connection URL</Label>
+              <div className="p-3 rounded-lg border border-brand-tint/20 bg-brand-tint/5 space-y-2">
+                <Label className="text-xs font-mediumr text-brand">Paste Connection URL</Label>
                 <div className="flex gap-2">
                   <Input
                     value={pasteInput}
                     onChange={(e) => setPasteInput(e.target.value)}
                     placeholder="postgres://user:pass@host:5432/db  or  mongodb://..."
-                    className="h-9 bg-panel border-hairline focus:border-blue-500/50 text-xs font-mono flex-1"
+                    className="h-9 bg-panel border-hairline focus:border-brand-tint/50 text-xs font-mono flex-1"
                     onKeyDown={(e) => e.key === "Enter" && handlePasteConnectionString()}
                   />
                   <Button
                     size="sm"
                     onClick={handlePasteConnectionString}
-                    className="bg-blue-600 hover:bg-blue-500 text-white h-9 px-4 text-xs font-medium"
+                    className="bg-brand-solid hover:bg-brand-solid-hover text-white h-9 px-4 text-xs font-medium"
                   >
                     Parse
                   </Button>
@@ -281,7 +281,7 @@ export function ConnectionModal({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="My Database"
-              className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs"
+              className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs"
             />
           </div>
 
@@ -322,7 +322,7 @@ export function ConnectionModal({
                 className={cn(
                   "flex flex-col items-center justify-center p-3 md:p-4 rounded-xl border transition-all duration-200 gap-2 group",
                   type === db.value
-                    ? "bg-blue-600/10 border-blue-500/50 shadow-[0_0_20px_rgba(59,130,246,0.1)]"
+                    ? "bg-brand-solid/10 border-brand-tint/50 shadow-[0_0_20px_rgba(59,130,246,0.1)]"
                     : "bg-panel border-hairline hover:border-hairline-strong hover:bg-raised",
                   isEditMode && type !== db.value && "opacity-30 cursor-not-allowed",
                 )}
@@ -353,7 +353,7 @@ export function ConnectionModal({
                     className={cn(
                       "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md text-xs font-medium transition-all",
                       mongoConnectionMode === "host"
-                        ? "bg-blue-600/20 text-blue-400 border border-blue-500/30"
+                        ? "bg-brand-solid/20 text-brand border border-brand-tint/30"
                         : "text-fg-muted hover:text-fg-secondary",
                     )}
                   >
@@ -365,7 +365,7 @@ export function ConnectionModal({
                     className={cn(
                       "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md text-xs font-medium transition-all",
                       mongoConnectionMode === "connectionString"
-                        ? "bg-blue-600/20 text-blue-400 border border-blue-500/30"
+                        ? "bg-brand-solid/20 text-brand border border-brand-tint/30"
                         : "text-fg-muted hover:text-fg-secondary",
                     )}
                   >
@@ -389,7 +389,7 @@ export function ConnectionModal({
                       value={connectionString}
                       onChange={(e) => setConnectionString(e.target.value)}
                       placeholder={connectionUriPlaceholder}
-                      className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs font-mono"
+                      className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs font-mono"
                     />
                   </div>
                   <div className="space-y-2">
@@ -404,7 +404,7 @@ export function ConnectionModal({
                       value={database}
                       onChange={(e) => setDatabase(e.target.value)}
                       placeholder="Extracted from URI if not provided"
-                      className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs font-mono"
+                      className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs font-mono"
                     />
                   </div>
                 </>
@@ -421,7 +421,7 @@ export function ConnectionModal({
                     value={database}
                     onChange={(e) => setDatabase(e.target.value)}
                     placeholder="/path/to/database file"
-                    className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs font-mono"
+                    className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs font-mono"
                   />
                 </div>
               ) : (
@@ -440,14 +440,14 @@ export function ConnectionModal({
                         onChange={(e) => setHost(e.target.value)}
                         placeholder="localhost"
                         autoComplete="off"
-                        className="md:col-span-3 h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs"
+                        className="md:col-span-3 h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs"
                       />
                       <Input
                         id="port"
                         value={port}
                         onChange={(e) => setPort(e.target.value)}
                         autoComplete="off"
-                        className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs font-mono"
+                        className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs font-mono"
                       />
                     </div>
                   </div>
@@ -472,7 +472,7 @@ export function ConnectionModal({
                           onChange={(e) => setUser(e.target.value)}
                           placeholder="user"
                           autoComplete="off"
-                          className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs"
+                          className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs"
                         />
                       </div>
                     )}
@@ -492,7 +492,7 @@ export function ConnectionModal({
                         // Server credential, not the user's own login: "new-password" is the only
                         // value Chrome honours to keep saved site passwords out of the field.
                         autoComplete="new-password"
-                        className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs"
+                        className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs"
                       />
                       {/*
                         Measured on Trino 476 with authentication DISABLED: a request
@@ -537,7 +537,7 @@ export function ConnectionModal({
                         value={database}
                         onChange={(e) => setDatabase(e.target.value)}
                         placeholder={databaseFieldPlaceholder}
-                        className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs font-mono"
+                        className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs font-mono"
                       />
                       {isTrino && (
                         <p className="text-xs text-fg-muted">
@@ -573,7 +573,7 @@ export function ConnectionModal({
                         value={authSource}
                         onChange={(e) => setAuthSource(e.target.value)}
                         placeholder="admin"
-                        className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs font-mono"
+                        className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs font-mono"
                       />
                       <p className="text-xs text-fg-muted">
                         The database the user was created in, usually admin. Leave empty when the credentials live in
@@ -602,7 +602,7 @@ export function ConnectionModal({
                         value={localDataCenter}
                         onChange={(e) => setLocalDataCenter(e.target.value)}
                         placeholder="datacenter1"
-                        className="h-10 bg-panel border-hairline focus:border-blue-500/50 transition-all text-xs font-mono"
+                        className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs font-mono"
                       />
                       <p className="text-xs text-fg-muted">
                         Required: the Cassandra driver refuses to connect without it. A stock single-node install
@@ -623,10 +623,10 @@ export function ConnectionModal({
                 onClick={() => setShowAdvanced(!showAdvanced)}
                 className="flex items-center gap-2 w-full px-3 py-2 rounded-lg border border-hairline hover:border-hairline-strong bg-panel text-xs font-medium text-fg-tertiary hover:text-fg transition-all"
               >
-                <Settings2 strokeWidth={1.5} className="w-3.5 h-3.5 text-orange-500" />
+                <Settings2 strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-orange" />
                 <span>Advanced</span>
                 {(serviceName || instanceName) && (
-                  <span className="ml-1 px-1.5 py-0.5 rounded text-[0.625rem] bg-orange-500/10 text-orange-400 border border-orange-500/20">
+                  <span className="ml-1 px-1.5 py-0.5 rounded text-[0.625rem] bg-hue-orange-tint/10 text-hue-orange border border-hue-orange-tint/20">
                     SET
                   </span>
                 )}
@@ -640,7 +640,7 @@ export function ConnectionModal({
                     exit={{ height: 0, opacity: 0 }}
                     className="overflow-hidden"
                   >
-                    <div className="p-3 rounded-lg border border-orange-500/10 bg-orange-500/5 space-y-3">
+                    <div className="p-3 rounded-lg border border-hue-orange-tint/10 bg-hue-orange-tint/5 space-y-3">
                       {type === "oracle" && (
                         <div className="space-y-1.5">
                           <Label className="text-xs font-mediumr text-fg-muted">Service Name</Label>
@@ -648,7 +648,7 @@ export function ConnectionModal({
                             value={serviceName}
                             onChange={(e) => setServiceName(e.target.value)}
                             placeholder="ORCL or XEPDB1"
-                            className="h-9 bg-panel border-hairline focus:border-orange-500/50 text-xs"
+                            className="h-9 bg-panel border-hairline focus:border-hue-orange-tint/50 text-xs"
                           />
                           <p className="text-xs text-fg-muted">
                             If empty, the Database Name field is used as the service name.
@@ -662,7 +662,7 @@ export function ConnectionModal({
                             value={instanceName}
                             onChange={(e) => setInstanceName(e.target.value)}
                             placeholder="SQLEXPRESS"
-                            className="h-9 bg-panel border-hairline focus:border-orange-500/50 text-xs"
+                            className="h-9 bg-panel border-hairline focus:border-hue-orange-tint/50 text-xs"
                           />
                           <p className="text-xs text-fg-muted">
                             For named instances (e.g. SQLEXPRESS). Leave empty for default instance.
@@ -685,10 +685,10 @@ export function ConnectionModal({
                 onClick={() => setShowSSL(!showSSL)}
                 className="flex items-center gap-2 w-full px-3 py-2 rounded-lg border border-hairline hover:border-hairline-strong bg-panel text-xs font-medium text-fg-tertiary hover:text-fg transition-all"
               >
-                <Lock strokeWidth={1.5} className="w-3.5 h-3.5 text-emerald-500" />
+                <Lock strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-emerald" />
                 <span>SSL / TLS</span>
                 {sslMode !== "disable" && (
-                  <span className="ml-1 px-1.5 py-0.5 rounded text-[0.625rem] bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
+                  <span className="ml-1 px-1.5 py-0.5 rounded text-[0.625rem] bg-hue-emerald-tint/10 text-hue-emerald border border-hue-emerald-tint/20">
                     {sslMode.toUpperCase()}
                   </span>
                 )}
@@ -702,7 +702,7 @@ export function ConnectionModal({
                     exit={{ height: 0, opacity: 0 }}
                     className="overflow-hidden"
                   >
-                    <div className="p-3 rounded-lg border border-emerald-500/10 bg-emerald-500/5 space-y-3">
+                    <div className="p-3 rounded-lg border border-hue-emerald-tint/10 bg-hue-emerald-tint/5 space-y-3">
                       <div className="space-y-2">
                         <Label className="text-xs font-mediumr text-fg-muted">SSL Mode</Label>
                         <div className="flex flex-wrap gap-1.5">
@@ -715,7 +715,7 @@ export function ConnectionModal({
                                 className={cn(
                                   "px-2.5 py-1.5 rounded-md text-xs font-mediumr transition-all border",
                                   sslMode === mode
-                                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                                    ? "border-hue-emerald-tint/30 bg-hue-emerald-tint/10 text-hue-emerald"
                                     : "border-transparent text-fg-muted hover:text-fg-secondary hover:bg-fill",
                                 )}
                               >
@@ -737,7 +737,7 @@ export function ConnectionModal({
                               onChange={(e) => setCaCert(e.target.value)}
                               placeholder="-----BEGIN CERTIFICATE-----&#10;Paste CA cert content here...&#10;-----END CERTIFICATE-----"
                               rows={3}
-                              className="w-full rounded-md bg-panel border border-hairline focus:border-emerald-500/50 text-xs font-mono text-fg-secondary p-2 resize-none placeholder:text-fg-subtle"
+                              className="w-full rounded-md bg-panel border border-hairline focus:border-hue-emerald-tint/50 text-xs font-mono text-fg-secondary p-2 resize-none placeholder:text-fg-subtle"
                             />
                           </div>
                           {(sslMode === "verify-ca" || sslMode === "verify-full") && (
@@ -749,7 +749,7 @@ export function ConnectionModal({
                                   onChange={(e) => setClientCert(e.target.value)}
                                   placeholder="-----BEGIN CERTIFICATE-----&#10;Optional client cert...&#10;-----END CERTIFICATE-----"
                                   rows={3}
-                                  className="w-full rounded-md bg-panel border border-hairline focus:border-emerald-500/50 text-xs font-mono text-fg-secondary p-2 resize-none placeholder:text-fg-subtle"
+                                  className="w-full rounded-md bg-panel border border-hairline focus:border-hue-emerald-tint/50 text-xs font-mono text-fg-secondary p-2 resize-none placeholder:text-fg-subtle"
                                 />
                               </div>
                               <div className="space-y-1.5">
@@ -759,7 +759,7 @@ export function ConnectionModal({
                                   onChange={(e) => setClientKey(e.target.value)}
                                   placeholder="-----BEGIN PRIVATE KEY-----&#10;Optional client key...&#10;-----END PRIVATE KEY-----"
                                   rows={3}
-                                  className="w-full rounded-md bg-panel border border-hairline focus:border-emerald-500/50 text-xs font-mono text-fg-secondary p-2 resize-none placeholder:text-fg-subtle"
+                                  className="w-full rounded-md bg-panel border border-hairline focus:border-hue-emerald-tint/50 text-xs font-mono text-fg-secondary p-2 resize-none placeholder:text-fg-subtle"
                                 />
                               </div>
                             </>
@@ -777,10 +777,10 @@ export function ConnectionModal({
                 onClick={() => setShowSSH(!showSSH)}
                 className="flex items-center gap-2 w-full px-3 py-2 rounded-lg border border-hairline hover:border-hairline-strong bg-panel text-xs font-medium text-fg-tertiary hover:text-fg transition-all"
               >
-                <Terminal strokeWidth={1.5} className="w-3.5 h-3.5 text-purple-500" />
+                <Terminal strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-purple" />
                 <span>SSH Tunnel</span>
                 {sshEnabled && (
-                  <span className="ml-1 px-1.5 py-0.5 rounded text-[0.625rem] bg-purple-500/10 text-purple-400 border border-purple-500/20">
+                  <span className="ml-1 px-1.5 py-0.5 rounded text-[0.625rem] bg-hue-purple-tint/10 text-hue-purple border border-hue-purple-tint/20">
                     ON
                   </span>
                 )}
@@ -794,7 +794,7 @@ export function ConnectionModal({
                     exit={{ height: 0, opacity: 0 }}
                     className="overflow-hidden"
                   >
-                    <div className="p-3 rounded-lg border border-purple-500/10 bg-purple-500/5 space-y-3">
+                    <div className="p-3 rounded-lg border border-hue-purple-tint/10 bg-hue-purple-tint/5 space-y-3">
                       <label className="flex items-center gap-2 cursor-pointer">
                         <input
                           type="checkbox"
@@ -814,7 +814,7 @@ export function ConnectionModal({
                                 onChange={(e) => setSSHHost(e.target.value)}
                                 placeholder="bastion.example.com"
                                 autoComplete="off"
-                                className="h-9 bg-panel border-hairline focus:border-purple-500/50 text-xs"
+                                className="h-9 bg-panel border-hairline focus:border-hue-purple-tint/50 text-xs"
                               />
                             </div>
                             <div className="space-y-1.5">
@@ -823,7 +823,7 @@ export function ConnectionModal({
                                 value={sshPort}
                                 onChange={(e) => setSSHPort(e.target.value)}
                                 autoComplete="off"
-                                className="h-9 bg-panel border-hairline focus:border-purple-500/50 text-xs font-mono"
+                                className="h-9 bg-panel border-hairline focus:border-hue-purple-tint/50 text-xs font-mono"
                               />
                             </div>
                           </div>
@@ -834,7 +834,7 @@ export function ConnectionModal({
                               onChange={(e) => setSSHUsername(e.target.value)}
                               placeholder="ubuntu"
                               autoComplete="off"
-                              className="h-9 bg-panel border-hairline focus:border-purple-500/50 text-xs"
+                              className="h-9 bg-panel border-hairline focus:border-hue-purple-tint/50 text-xs"
                             />
                           </div>
                           <div className="space-y-2">
@@ -846,7 +846,7 @@ export function ConnectionModal({
                                 className={cn(
                                   "flex-1 px-3 py-1.5 rounded-md text-xs font-mediumr transition-all border",
                                   sshAuthMethod === "password"
-                                    ? "border-purple-500/30 bg-purple-500/10 text-purple-400"
+                                    ? "border-hue-purple-tint/30 bg-hue-purple-tint/10 text-hue-purple"
                                     : "border-transparent text-fg-muted hover:text-fg-secondary hover:bg-fill",
                                 )}
                               >
@@ -858,7 +858,7 @@ export function ConnectionModal({
                                 className={cn(
                                   "flex-1 px-3 py-1.5 rounded-md text-xs font-mediumr transition-all border",
                                   sshAuthMethod === "privateKey"
-                                    ? "border-purple-500/30 bg-purple-500/10 text-purple-400"
+                                    ? "border-hue-purple-tint/30 bg-hue-purple-tint/10 text-hue-purple"
                                     : "border-transparent text-fg-muted hover:text-fg-secondary hover:bg-fill",
                                 )}
                               >
@@ -875,7 +875,7 @@ export function ConnectionModal({
                                 onChange={(e) => setSSHPassword(e.target.value)}
                                 placeholder="••••••••"
                                 autoComplete="new-password"
-                                className="h-9 bg-panel border-hairline focus:border-purple-500/50 text-xs"
+                                className="h-9 bg-panel border-hairline focus:border-hue-purple-tint/50 text-xs"
                               />
                             </div>
                           ) : (
@@ -887,7 +887,7 @@ export function ConnectionModal({
                                   onChange={(e) => setSSHPrivateKey(e.target.value)}
                                   placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;Paste private key here...&#10;-----END OPENSSH PRIVATE KEY-----"
                                   rows={4}
-                                  className="w-full rounded-md bg-panel border border-hairline focus:border-purple-500/50 text-xs font-mono text-fg-secondary p-2 resize-none placeholder:text-fg-subtle"
+                                  className="w-full rounded-md bg-panel border border-hairline focus:border-hue-purple-tint/50 text-xs font-mono text-fg-secondary p-2 resize-none placeholder:text-fg-subtle"
                                 />
                               </div>
                               <div className="space-y-1.5">
@@ -898,7 +898,7 @@ export function ConnectionModal({
                                   onChange={(e) => setSSHPassphrase(e.target.value)}
                                   placeholder="Key passphrase (if encrypted)"
                                   autoComplete="new-password"
-                                  className="h-9 bg-panel border-hairline focus:border-purple-500/50 text-xs"
+                                  className="h-9 bg-panel border-hairline focus:border-hue-purple-tint/50 text-xs"
                                 />
                               </div>
                             </div>
@@ -927,10 +927,10 @@ export function ConnectionModal({
                   className={cn(
                     "flex items-center gap-2 p-3 rounded-lg border text-xs",
                     testResult.tone === "success"
-                      ? "bg-emerald-500/5 border-emerald-500/20 text-emerald-400"
+                      ? "bg-success-tint/5 border-success-tint/20 text-success"
                       : testResult.tone === "warning"
-                        ? "bg-amber-500/5 border-amber-500/20 text-amber-400"
-                        : "bg-red-500/5 border-red-500/20 text-red-400",
+                        ? "bg-warning-tint/5 border-warning-tint/20 text-warning"
+                        : "bg-danger-tint/5 border-danger-tint/20 text-danger",
                   )}
                 >
                   {testResult.tone === "success" ? (
@@ -983,7 +983,7 @@ export function ConnectionModal({
                   mongoConnectionMode === "connectionString" &&
                   !connectionString.trim())
               }
-              className="w-full md:w-auto min-w-0 md:min-w-[140px] bg-blue-600 hover:bg-blue-500 text-white font-medium text-xs h-10 shadow-lg shadow-blue-900/20 group relative overflow-hidden"
+              className="w-full md:w-auto min-w-0 md:min-w-[140px] bg-brand-solid hover:bg-brand-solid-hover text-white font-medium text-xs h-10 shadow-lg shadow-blue-900/20 group relative overflow-hidden"
             >
               <AnimatePresence mode="wait">
                 {isTesting ? (

--- a/src/components/CreateTableModal.tsx
+++ b/src/components/CreateTableModal.tsx
@@ -107,8 +107,8 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
       <DialogContent className="max-w-3xl bg-surface border-hairline-strong text-fg p-0 overflow-hidden flex flex-col max-h-[90vh]">
         <DialogHeader className="px-6 py-4 border-b border-hairline bg-panel">
           <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20">
-              <TableIcon strokeWidth={1.5} className="w-5 h-5 text-blue-400" />
+            <div className="p-2 rounded-lg bg-brand-tint/10 border border-brand-tint/20">
+              <TableIcon strokeWidth={1.5} className="w-5 h-5 text-brand" />
             </div>
             <div>
               <DialogTitle className="text-xs font-medium">Create New Table</DialogTitle>
@@ -121,7 +121,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
           {/* Table Name Section */}
           <div className="space-y-4">
             <div className="flex items-center gap-2">
-              <Settings2 strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-500/50" />
+              <Settings2 strokeWidth={1.5} className="w-3.5 h-3.5 text-brand/50" />
               <Label className="text-xs font-medium text-fg-muted">General Settings</Label>
             </div>
             <div className="grid gap-2">
@@ -133,7 +133,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
                 placeholder="e.g. customers, orders, analytics_logs"
                 value={tableName}
                 onChange={(e) => setTableName(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, "_"))}
-                className="bg-raised border-hairline focus-visible:ring-blue-500/50"
+                className="bg-raised border-hairline focus-visible:ring-brand-tint/50"
               />
             </div>
           </div>
@@ -142,14 +142,14 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <Type strokeWidth={1.5} className="w-3.5 h-3.5 text-emerald-500/50" />
+                <Type strokeWidth={1.5} className="w-3.5 h-3.5 text-success/50" />
                 <Label className="text-xs font-medium text-fg-muted">Column Definitions</Label>
               </div>
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={addColumn}
-                className="h-7 text-xs font-medium gap-2 hover:bg-emerald-500/10 hover:text-emerald-400"
+                className="h-7 text-xs font-medium gap-2 hover:bg-success-tint/10 hover:text-success"
               >
                 <Plus strokeWidth={1.5} className="w-3 h-3" /> Add Column
               </Button>
@@ -186,7 +186,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
                           </SelectItem>
                         ))}
                         {col.isPrimary && (
-                          <SelectItem value="SERIAL" className="text-xs text-yellow-500">
+                          <SelectItem value="SERIAL" className="text-xs text-hue-yellow">
                             SERIAL (Auto-Inc)
                           </SelectItem>
                         )}
@@ -205,7 +205,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
                             isNullable: checked ? false : col.isNullable,
                           })
                         }
-                        className="border-edge data-[state=checked]:bg-yellow-500 data-[state=checked]:border-yellow-500"
+                        className="border-edge data-[state=checked]:bg-hue-yellow-tint data-[state=checked]:border-hue-yellow-tint"
                       />
                     </div>
                     <div className="flex flex-col items-center gap-1.5" title="Nullable">
@@ -213,7 +213,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
                       <Checkbox
                         checked={col.isNullable}
                         onCheckedChange={(checked) => updateColumn(index, { isNullable: !!checked })}
-                        className="border-edge data-[state=checked]:bg-blue-500 data-[state=checked]:border-blue-500"
+                        className="border-edge data-[state=checked]:bg-hue-blue-tint data-[state=checked]:border-hue-blue-tint"
                       />
                     </div>
                     <div className="flex flex-col items-center gap-1.5" title="Unique">
@@ -221,7 +221,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
                       <Checkbox
                         checked={col.isUnique}
                         onCheckedChange={(checked) => updateColumn(index, { isUnique: !!checked })}
-                        className="border-edge data-[state=checked]:bg-purple-500 data-[state=checked]:border-purple-500"
+                        className="border-edge data-[state=checked]:bg-hue-purple-tint data-[state=checked]:border-hue-purple-tint"
                       />
                     </div>
                   </div>
@@ -229,7 +229,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-8 w-8 text-fg-subtle hover:text-red-400 hover:bg-red-500/10 mb-0.5"
+                    className="h-8 w-8 text-fg-subtle hover:text-danger hover:bg-danger-tint/10 mb-0.5"
                     onClick={() => removeColumn(index)}
                   >
                     <Trash2 strokeWidth={1.5} className="w-3.5 h-3.5" />
@@ -243,12 +243,12 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
           <div className="p-4 rounded-lg bg-black border border-hairline font-mono">
             <div className="flex items-center justify-between mb-3">
               <div className="flex items-center gap-2">
-                <div className="w-2 h-2 rounded-full bg-blue-500" />
+                <div className="w-2 h-2 rounded-full bg-brand-tint" />
                 <span className="text-xs font-medium text-fg-muted">SQL Preview</span>
               </div>
               <span className="text-[0.625rem] text-fg-faint">Auto-generated</span>
             </div>
-            <pre className="text-xs text-blue-400/80 whitespace-pre-wrap leading-relaxed">
+            <pre className="text-xs text-brand/80 whitespace-pre-wrap leading-relaxed">
               {generateSQL() || "-- Name your table to see SQL"}
             </pre>
           </div>
@@ -261,7 +261,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
           <Button
             onClick={handleCreate}
             disabled={isSubmitting || !tableName}
-            className="bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium gap-2 px-6"
+            className="bg-brand-solid hover:bg-brand-solid-hover text-white text-xs font-medium gap-2 px-6"
           >
             {isSubmitting ? (
               <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />

--- a/src/components/CreateTableModal.tsx
+++ b/src/components/CreateTableModal.tsx
@@ -239,8 +239,13 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated }: CreateTabl
             </div>
           </div>
 
-          {/* Preview Section */}
-          <div className="p-4 rounded-lg bg-black border border-hairline font-mono">
+          {/*
+            A terminal, not a panel: the ground is a hard `bg-black` in both themes,
+            so the tokens inside it have to resolve their DARK values or the light
+            palette paints dark-on-black. Scoped the way the login hero scopes its
+            own pinned-dark column (#402).
+          */}
+          <div className="dark p-4 rounded-lg bg-black border border-hairline font-mono">
             <div className="flex items-center justify-between mb-3">
               <div className="flex items-center gap-2">
                 <div className="w-2 h-2 rounded-full bg-brand-tint" />

--- a/src/components/DataCharts.tsx
+++ b/src/components/DataCharts.tsx
@@ -696,7 +696,9 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
               onClick={() => setChartType(type)}
               className={cn(
                 "flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium transition-all",
-                chartType === type ? "bg-blue-600 text-white" : "text-fg-muted hover:text-fg-secondary hover:bg-fill",
+                chartType === type
+                  ? "bg-brand-solid text-white"
+                  : "text-fg-muted hover:text-fg-secondary hover:bg-fill",
               )}
               title={label}
             >
@@ -745,7 +747,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                 <DropdownMenuItem
                   key={field}
                   onClick={() => (chartType === "pie" ? setYAxis([field]) : toggleYAxis(field))}
-                  className={cn("text-xs cursor-pointer", yAxis.includes(field) && "bg-blue-600/20 text-blue-400")}
+                  className={cn("text-xs cursor-pointer", yAxis.includes(field) && "bg-brand-solid/20 text-brand")}
                 >
                   <Hash strokeWidth={1.5} className="w-3 h-3 mr-2" />
                   {field}
@@ -852,10 +854,10 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
               value={saveName}
               onChange={(e) => setSaveName(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleSaveChart()}
-              className="h-7 px-2 text-xs bg-fill border border-hairline-strong rounded text-fg-secondary focus:outline-none focus:border-blue-500"
+              className="h-7 px-2 text-xs bg-fill border border-hairline-strong rounded text-fg-secondary focus:outline-none focus:border-brand-tint"
               autoFocus
             />
-            <Button variant="ghost" size="sm" className="h-7 text-xs text-blue-400" onClick={handleSaveChart}>
+            <Button variant="ghost" size="sm" className="h-7 text-xs text-brand" onClick={handleSaveChart}>
               Save
             </Button>
             <Button
@@ -899,7 +901,7 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
                           e.stopPropagation();
                           deleteSavedChart(chart.id);
                         }}
-                        className="text-fg-subtle hover:text-red-400"
+                        className="text-fg-subtle hover:text-danger"
                       >
                         <X strokeWidth={1.5} className="w-3 h-3" />
                       </button>
@@ -1127,10 +1129,10 @@ export function DataCharts({ result, spec = null }: DataChartsProps) {
           Numeric: <span className="text-fg-tertiary font-mono">{analysis.numericFields.length}</span>
         </span>
         {chartType === "pie" && chartData.length > MAX_SERIES && (
-          <span className="text-amber-500">Showing top {MAX_SERIES} values</span>
+          <span className="text-warning">Showing top {MAX_SERIES} values</span>
         )}
         {MULTI_SERIES_CHART_TYPES.has(chartType) && droppedYAxisCount > 0 && (
-          <span className="text-amber-500">
+          <span className="text-warning">
             Showing first {MAX_SERIES} of {yAxis.length} series — see the Results grid for the rest
           </span>
         )}

--- a/src/components/DataImportModal.tsx
+++ b/src/components/DataImportModal.tsx
@@ -300,7 +300,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
       <DialogContent className="bg-surface border-hairline-strong text-fg max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Upload strokeWidth={1.5} className="w-5 h-5 text-blue-400" />
+            <Upload strokeWidth={1.5} className="w-5 h-5 text-brand" />
             {"Import Data"}
             {fileName && <span className="text-xs text-fg-muted font-normal ml-2">{fileName}</span>}
           </DialogTitle>
@@ -314,9 +314,9 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                 className={cn(
                   "flex items-center gap-1.5 text-xs font-mediumr",
                   step === s
-                    ? "text-blue-400"
+                    ? "text-brand"
                     : idx < ["upload", "preview", "configure", "ready"].indexOf(step)
-                      ? "text-emerald-400"
+                      ? "text-success"
                       : "text-fg-subtle",
                 )}
               >
@@ -324,9 +324,9 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                   className={cn(
                     "w-5 h-5 rounded-full flex items-center justify-center text-[0.625rem]",
                     step === s
-                      ? "bg-blue-500/20 border border-blue-500/40"
+                      ? "bg-brand-tint/20 border border-brand-tint/40"
                       : idx < ["upload", "preview", "configure", "ready"].indexOf(step)
-                        ? "bg-emerald-500/20 border border-emerald-500/40"
+                        ? "bg-success-tint/20 border border-success-tint/40"
                         : "bg-fill border border-hairline-strong",
                   )}
                 >
@@ -354,7 +354,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                 onDrop={handleDrop}
                 onDragOver={handleDragOver}
                 onClick={() => fileInputRef.current?.click()}
-                className="w-full border-2 border-dashed border-hairline-strong rounded-xl p-12 text-center cursor-pointer hover:border-blue-500/30 hover:bg-blue-500/5 transition-all"
+                className="w-full border-2 border-dashed border-hairline-strong rounded-xl p-12 text-center cursor-pointer hover:border-brand-tint/30 hover:bg-brand-tint/5 transition-all"
               >
                 <Upload strokeWidth={1.5} className="w-10 h-10 text-fg-subtle mx-auto mb-4" />
                 <p className="text-xs text-fg-tertiary mb-1">Drop a file here or click to browse</p>
@@ -381,9 +381,9 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                 }}
               />
               {error && (
-                <div className="mt-4 p-3 rounded-lg bg-red-500/10 border border-red-500/20 flex items-center gap-2">
-                  <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 text-red-400 shrink-0" />
-                  <span className="text-xs text-red-400">{error}</span>
+                <div className="mt-4 p-3 rounded-lg bg-danger-tint/10 border border-danger-tint/20 flex items-center gap-2">
+                  <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 text-danger shrink-0" />
+                  <span className="text-xs text-danger">{error}</span>
                 </div>
               )}
             </div>
@@ -395,9 +395,9 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                   {fileType === "json" ? (
-                    <FileBraces strokeWidth={1.5} className="w-5 h-5 text-amber-400" />
+                    <FileBraces strokeWidth={1.5} className="w-5 h-5 text-hue-amber" />
                   ) : (
-                    <FileText strokeWidth={1.5} className="w-5 h-5 text-emerald-400" />
+                    <FileText strokeWidth={1.5} className="w-5 h-5 text-hue-emerald" />
                   )}
                   <div>
                     <p className="text-xs font-medium">{fileName}</p>
@@ -458,7 +458,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
               <div className="flex justify-end">
                 <Button
                   size="sm"
-                  className="bg-blue-600 hover:bg-blue-500 h-8 text-xs gap-1"
+                  className="bg-brand-solid hover:bg-brand-solid-hover h-8 text-xs gap-1"
                   onClick={() => setStep("configure")}
                 >
                   Configure Import <ArrowRight strokeWidth={1.5} className="w-3 h-3" />
@@ -478,7 +478,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                     className={cn(
                       "flex-1 px-3 py-2 rounded-lg border text-xs text-left transition-all",
                       !createNewTable
-                        ? "border-blue-500/40 bg-blue-500/10 text-blue-400"
+                        ? "border-brand-tint/40 bg-brand-tint/10 text-brand"
                         : "border-hairline-strong text-fg-muted hover:bg-fill",
                     )}
                     onClick={() => setCreateNewTable(false)}
@@ -490,7 +490,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                     className={cn(
                       "flex-1 px-3 py-2 rounded-lg border text-xs text-left transition-all",
                       createNewTable
-                        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-400"
+                        ? "border-success-tint/40 bg-success-tint/10 text-success"
                         : "border-hairline-strong text-fg-muted hover:bg-fill",
                     )}
                     onClick={() => setCreateNewTable(true)}
@@ -523,7 +523,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                     id="import-target-table"
                     value={targetTable}
                     onChange={(e) => setTargetTable(e.target.value)}
-                    className="w-full mt-1 bg-overlay border border-hairline-strong rounded-md px-3 py-2 text-xs text-fg-secondary outline-none focus:border-blue-500/40"
+                    className="w-full mt-1 bg-overlay border border-hairline-strong rounded-md px-3 py-2 text-xs text-fg-secondary outline-none focus:border-brand-tint/40"
                   >
                     <option value="">-- Select a table --</option>
                     {tables.map((t) => (
@@ -576,7 +576,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                 </Button>
                 <Button
                   size="sm"
-                  className="bg-blue-600 hover:bg-blue-500 h-8 text-xs gap-1"
+                  className="bg-brand-solid hover:bg-brand-solid-hover h-8 text-xs gap-1"
                   onClick={() => setStep("ready")}
                   disabled={!createNewTable && !targetTable}
                 >
@@ -633,7 +633,7 @@ export function DataImportModal({ isOpen, onClose, onImport, tables, databaseTyp
                   />
                   <Button
                     size="sm"
-                    className="bg-emerald-600 hover:bg-emerald-500 h-8 text-xs gap-1"
+                    className="bg-success-solid hover:bg-success-solid-hover h-8 text-xs gap-1"
                     onClick={handleImport}
                     disabled={isImporting}
                   >

--- a/src/components/DataProfiler.tsx
+++ b/src/components/DataProfiler.tsx
@@ -208,7 +208,7 @@ export function DataProfiler({
         */}
         <div className="relative z-10 shrink-0 flex items-center justify-between gap-2 px-5 py-3 border-b border-hairline">
           <div className="flex min-w-0 items-center gap-2">
-            <ChartColumn strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0 text-cyan-400" />
+            <ChartColumn strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0 text-hue-cyan" />
             <span className="text-xs font-medium text-fg shrink-0">Data Profiler</span>
             <span className="text-xs text-fg-muted font-mono truncate">{tableName}</span>
           </div>
@@ -231,7 +231,7 @@ export function DataProfiler({
           )}
 
           {error && (
-            <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 text-xs text-red-400 flex items-center gap-2">
+            <div className="bg-danger-tint/10 border border-danger-tint/20 rounded-lg p-3 text-xs text-danger flex items-center gap-2">
               <CircleAlert strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
               {error}
             </div>
@@ -267,12 +267,12 @@ export function DataProfiler({
                   <div key={col.name} className="bg-surface rounded-lg p-3 border border-hairline">
                     <div className="flex items-center justify-between mb-2">
                       <div className="flex items-center gap-2">
-                        <Hash strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
+                        <Hash strokeWidth={1.5} className="w-3 h-3 text-hue-blue" />
                         <span className="text-xs font-medium text-fg">{col.name}</span>
                         {col.type && <span className="text-xs text-fg-muted font-mono">{col.type}</span>}
                         {sensitiveColumnNames.has(col.name) && (
                           <span title="Sensitive column - values masked">
-                            <Lock strokeWidth={1.5} className="w-3 h-3 text-purple-400" />
+                            <Lock strokeWidth={1.5} className="w-3 h-3 text-hue-purple" />
                           </span>
                         )}
                       </div>
@@ -280,7 +280,7 @@ export function DataProfiler({
                     </div>
 
                     {col.error ? (
-                      <p className="text-xs text-amber-400">{col.error}</p>
+                      <p className="text-xs text-warning">{col.error}</p>
                     ) : (
                       <>
                         {/* Null bar */}
@@ -290,10 +290,10 @@ export function DataProfiler({
                               className={cn(
                                 "h-full rounded-full transition-all",
                                 col.nullPercent > 50
-                                  ? "bg-red-500"
+                                  ? "bg-danger-tint"
                                   : col.nullPercent > 20
-                                    ? "bg-amber-500"
-                                    : "bg-emerald-500",
+                                    ? "bg-warning-tint"
+                                    : "bg-success-tint",
                               )}
                               style={{ width: `${100 - col.nullPercent}%` }}
                             />
@@ -302,10 +302,10 @@ export function DataProfiler({
                             className={cn(
                               "text-xs font-mono w-10 text-right",
                               col.nullPercent > 50
-                                ? "text-red-400"
+                                ? "text-danger"
                                 : col.nullPercent > 20
-                                  ? "text-amber-400"
-                                  : "text-emerald-400",
+                                  ? "text-warning"
+                                  : "text-success",
                             )}
                           >
                             {col.nullPercent}% null
@@ -370,11 +370,11 @@ export function DataProfiler({
 
               {/* AI Summary */}
               {(aiSummary || isAiLoading) && (
-                <div className="bg-cyan-500/5 border border-cyan-500/10 rounded-lg p-4">
+                <div className="bg-hue-cyan-tint/5 border border-hue-cyan-tint/10 rounded-lg p-4">
                   <div className="flex items-center gap-2 mb-2">
-                    <Sparkles strokeWidth={1.5} className="w-3.5 h-3.5 text-cyan-400" />
-                    <span className="text-xs font-medium text-cyan-400">AI Analysis</span>
-                    {isAiLoading && <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin text-cyan-400" />}
+                    <Sparkles strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-cyan" />
+                    <span className="text-xs font-medium text-hue-cyan">AI Analysis</span>
+                    {isAiLoading && <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin text-hue-cyan" />}
                   </div>
                   {aiSummary && (
                     <div className="text-xs text-fg-tertiary leading-relaxed whitespace-pre-wrap">{aiSummary}</div>

--- a/src/components/DatabaseDocs.tsx
+++ b/src/components/DatabaseDocs.tsx
@@ -162,10 +162,10 @@ export function DatabaseDocs({ schema, schemaContext, databaseType }: DatabaseDo
     <div className="h-full flex flex-col bg-sunken">
       <div className="flex items-center justify-between px-4 py-2 border-b border-hairline bg-surface">
         <div className="flex items-center gap-2">
-          <div className="p-1 rounded bg-teal-500/10">
-            <FileText strokeWidth={1.5} className="w-3 h-3 text-teal-400" />
+          <div className="p-1 rounded bg-hue-teal-tint/10">
+            <FileText strokeWidth={1.5} className="w-3 h-3 text-hue-teal" />
           </div>
-          <span className="text-xs font-medium text-teal-400">Database Docs</span>
+          <span className="text-xs font-medium text-hue-teal">Database Docs</span>
           <span className="text-[0.625rem] text-fg-muted font-mono">{schema.length} tables</span>
         </div>
         <div className="flex items-center gap-1.5">
@@ -174,7 +174,9 @@ export function DatabaseDocs({ schema, schemaContext, databaseType }: DatabaseDo
             disabled={isAiLoading}
             className={cn(
               "flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium transition-colors",
-              isAiLoading ? "bg-teal-600/20 text-teal-400 cursor-wait" : "bg-teal-600 hover:bg-teal-500 text-white",
+              isAiLoading
+                ? "bg-hue-teal-solid/20 text-hue-teal cursor-wait"
+                : "bg-hue-teal-solid hover:bg-hue-teal-solid-hover text-white",
             )}
           >
             {isAiLoading && <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />}
@@ -197,22 +199,24 @@ export function DatabaseDocs({ schema, schemaContext, databaseType }: DatabaseDo
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search tables or columns..."
-            className="w-full bg-overlay border border-hairline-strong rounded-lg pl-7 pr-3 py-1.5 text-xs text-fg placeholder:text-fg-subtle outline-none focus:border-teal-500/30"
+            className="w-full bg-overlay border border-hairline-strong rounded-lg pl-7 pr-3 py-1.5 text-xs text-fg placeholder:text-fg-subtle outline-none focus:border-hue-teal-tint/30"
           />
         </div>
       </div>
 
       <div className="flex-1 overflow-auto p-4 space-y-3">
         {error && (
-          <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 text-xs text-red-400">{error}</div>
+          <div className="bg-danger-tint/10 border border-danger-tint/20 rounded-lg p-3 text-xs text-danger">
+            {error}
+          </div>
         )}
 
         {(aiDocs || isAiLoading) && (
-          <div className="bg-teal-500/5 border border-teal-500/10 rounded-lg p-4 mb-4">
+          <div className="bg-hue-teal-tint/5 border border-hue-teal-tint/10 rounded-lg p-4 mb-4">
             <div className="flex items-center gap-2 mb-3">
-              <Sparkles strokeWidth={1.5} className="w-3 h-3 text-teal-400" />
-              <span className="text-xs font-medium text-teal-400">AI-Generated Documentation</span>
-              {isAiLoading && <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin text-teal-400" />}
+              <Sparkles strokeWidth={1.5} className="w-3 h-3 text-hue-teal" />
+              <span className="text-xs font-medium text-hue-teal">AI-Generated Documentation</span>
+              {isAiLoading && <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin text-hue-teal" />}
             </div>
             {aiDocs && <div className="prose prose-invert prose-xs max-w-none">{renderMarkdown(aiDocs)}</div>}
           </div>
@@ -247,7 +251,7 @@ export function DatabaseDocs({ schema, schemaContext, databaseType }: DatabaseDo
                         <td className="px-3 py-1 text-fg-secondary font-mono">{col.name}</td>
                         <td className="px-3 py-1 text-fg-muted font-mono">{col.type}</td>
                         <td className="px-3 py-1">
-                          {col.isPrimary && <span className="text-amber-400 text-[0.625rem] font-medium">PK</span>}
+                          {col.isPrimary && <span className="text-hue-amber text-[0.625rem] font-medium">PK</span>}
                         </td>
                         <td className="px-3 py-1 text-fg-subtle">{col.nullable !== false ? "Yes" : "No"}</td>
                       </tr>

--- a/src/components/MaskingSettings.tsx
+++ b/src/components/MaskingSettings.tsx
@@ -160,7 +160,7 @@ export function MaskingSettings() {
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-xs">
-            <Shield className="h-5 w-5 text-purple-400" />
+            <Shield className="h-5 w-5 text-hue-purple" />
             Data Masking Settings
           </CardTitle>
         </CardHeader>
@@ -288,7 +288,7 @@ export function MaskingSettings() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="h-7 w-7 p-0 text-red-400 hover:text-red-300"
+                          className="h-7 w-7 p-0 text-danger hover:text-danger-bright"
                           onClick={() => deletePattern(pattern.id)}
                         >
                           <Trash2 strokeWidth={1.5} className="w-3 h-3" />
@@ -313,11 +313,11 @@ export function MaskingSettings() {
                   const masked = getPreviewMasked(pattern.maskType, pattern.customMask);
                   return (
                     <div key={pattern.id} className="flex items-center gap-2 text-xs font-mono">
-                      <Lock strokeWidth={1.5} className="w-3 h-3 text-purple-400 shrink-0" />
+                      <Lock strokeWidth={1.5} className="w-3 h-3 text-hue-purple shrink-0" />
                       <span className="text-fg-muted w-24 truncate">{pattern.name}:</span>
                       <span className="text-fg-subtle line-through">{preview.sample}</span>
                       <span className="text-fg-tertiary mx-1">&rarr;</span>
-                      <span className="text-purple-300">{masked}</span>
+                      <span className="text-hue-purple-alt">{masked}</span>
                     </div>
                   );
                 })}
@@ -392,7 +392,7 @@ export function MaskingSettings() {
               </label>
               <textarea
                 id="masking-column-patterns"
-                className="w-full h-32 bg-surface border border-hairline-strong rounded-md px-3 py-2 text-xs font-mono text-fg focus:outline-none focus:ring-1 focus:ring-purple-500/50 resize-none"
+                className="w-full h-32 bg-surface border border-hairline-strong rounded-md px-3 py-2 text-xs font-mono text-fg focus:outline-none focus:ring-1 focus:ring-hue-purple-tint/50 resize-none"
                 value={editColumnPatterns}
                 onChange={(e) => setEditColumnPatterns(e.target.value)}
                 placeholder={"email\ne_mail\nuser_email"}
@@ -404,7 +404,7 @@ export function MaskingSettings() {
             {/* Preview */}
             <div className="rounded-lg border border-hairline bg-surface p-3">
               <p className="text-xs text-fg-muted mb-1">Preview:</p>
-              <p className="text-xs font-mono text-purple-300">
+              <p className="text-xs font-mono text-hue-purple-alt">
                 {getPreviewMasked(editMaskType, editMaskType === "custom" ? editCustomMask : undefined)}
               </p>
             </div>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -36,11 +36,11 @@ export function MobileNav({ activeTab, onTabChange, onOpenAgent }: MobileNavProp
             onClick={() => onTabChange(tab.id)}
             className={cn(
               "flex flex-col items-center gap-1 transition-all duration-200 relative",
-              isActive ? "text-blue-400" : "text-fg-muted",
+              isActive ? "text-brand" : "text-fg-muted",
             )}
           >
             <div
-              className={cn("p-2 rounded-xl transition-all", isActive ? "bg-blue-500/10 scale-110" : "hover:bg-fill")}
+              className={cn("p-2 rounded-xl transition-all", isActive ? "bg-brand-tint/10 scale-110" : "hover:bg-fill")}
             >
               {/* strokeWidth 1.5 matches the shared icon contract; the row's new agent
                   icon would otherwise render visibly thinner than its siblings. */}
@@ -49,7 +49,7 @@ export function MobileNav({ activeTab, onTabChange, onOpenAgent }: MobileNavProp
             {/* `font-mediumr` was a typo Tailwind emitted nothing for; the agent
                 label added below would otherwise render at a different weight. */}
             <span className="text-xs font-medium">{tab.label}</span>
-            {isActive && <div className="absolute -top-1 w-1 h-1 bg-blue-400 rounded-full" />}
+            {isActive && <div className="absolute -top-1 w-1 h-1 bg-brand rounded-full" />}
           </button>
         );
       })}

--- a/src/components/PivotTable.tsx
+++ b/src/components/PivotTable.tsx
@@ -214,7 +214,7 @@ export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProp
               className={cn(
                 "px-1.5 py-0.5 rounded text-xs font-medium transition-colors",
                 aggFunction === fn
-                  ? "bg-blue-500/20 text-blue-400 border border-blue-500/20"
+                  ? "bg-brand-tint/20 text-brand border border-brand-tint/20"
                   : "text-fg-subtle hover:text-fg-tertiary",
               )}
             >
@@ -229,7 +229,7 @@ export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProp
               const sql = generateSQL();
               if (sql) onLoadQuery(sql);
             }}
-            className="ml-auto flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-fg-muted hover:text-blue-400 hover:bg-blue-500/10 transition-colors"
+            className="ml-auto flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-fg-muted hover:text-brand hover:bg-brand-tint/10 transition-colors"
           >
             <ArrowRight strokeWidth={1.5} className="w-3 h-3" /> Generate SQL
           </button>
@@ -256,10 +256,10 @@ export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProp
             </thead>
             <tbody>
               {pivotData.pivotRows.map((row, i) => (
-                <tr key={i} className="hover:bg-blue-500/[0.03] border-b border-hairline">
+                <tr key={i} className="hover:bg-brand-tint/[0.03] border-b border-hairline">
                   <td className="px-3 py-1.5 text-fg-secondary border-r border-hairline font-medium">{row.rowKey}</td>
                   {pivotData.colKeys.map((ck) => (
-                    <td key={ck} className="px-3 py-1.5 text-right text-amber-500/90 border-r border-hairline">
+                    <td key={ck} className="px-3 py-1.5 text-right text-hue-amber/90 border-r border-hairline">
                       {row.values.get(ck) || "0"}
                     </td>
                   ))}

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -605,7 +605,10 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-7 text-xs font-medium text-warning hover:text-warning gap-2"
+                // The base absorbed this button's old hover value when the -500 text
+                // drift collapsed amber-500 onto the token, so the hover has to step
+                // up to keep any feedback of its own (#402).
+                className="h-7 text-xs font-medium text-warning hover:text-warning-bright gap-2"
                 onClick={onExplain}
               >
                 <Zap strokeWidth={1.5} className="w-3 h-3" /> Explain

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -546,7 +546,7 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
               size="sm"
               // `text-white` is the label ON a blue button, not the top of the
               // text ramp: it must stay white in the light theme too.
-              className="h-7 text-xs font-medium text-white bg-blue-600 hover:bg-blue-500 hover:text-white gap-2 shadow-[0_0_10px_rgba(37,99,235,0.3)] animate-in fade-in zoom-in duration-200"
+              className="h-7 text-xs font-medium text-white bg-brand-solid hover:bg-brand-solid-hover hover:text-white gap-2 shadow-[0_0_10px_rgba(37,99,235,0.3)] animate-in fade-in zoom-in duration-200"
               onClick={handleExecute}
             >
               <Play strokeWidth={1.5} className="w-3 h-3 fill-current" /> Run Sel
@@ -577,7 +577,7 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
           <Button
             variant="ghost"
             size="sm"
-            className="h-7 text-xs font-medium text-fg-muted hover:text-red-400 gap-2"
+            className="h-7 text-xs font-medium text-fg-muted hover:text-danger gap-2"
             onClick={handleClear}
           >
             <Trash2 strokeWidth={1.5} className="w-3 h-3" /> Clear
@@ -605,7 +605,7 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-7 text-xs font-medium text-amber-500 hover:text-amber-400 gap-2"
+                className="h-7 text-xs font-medium text-warning hover:text-warning gap-2"
                 onClick={onExplain}
               >
                 <Zap strokeWidth={1.5} className="w-3 h-3" /> Explain

--- a/src/components/QueryHistory.tsx
+++ b/src/components/QueryHistory.tsx
@@ -136,8 +136,8 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
       <div className="p-4 border-b border-hairline bg-surface/50 backdrop-blur-sm sticky top-0 z-10 space-y-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
-              <HistoryIcon strokeWidth={1.5} className="w-3.5 h-3.5 text-emerald-400" />
+            <div className="p-2 rounded-lg bg-hue-emerald-tint/10 border border-hue-emerald-tint/20">
+              <HistoryIcon strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-emerald" />
             </div>
             <div>
               <h3 className="text-xs font-medium text-fg flex items-center gap-2">Query History</h3>
@@ -170,7 +170,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
               variant="ghost"
               size="sm"
               onClick={handleClearHistory}
-              className="h-8 text-xs font-medium text-red-400/70 hover:text-red-400 hover:bg-red-400/10"
+              className="h-8 text-xs font-medium text-danger/70 hover:text-danger hover:bg-danger/10"
             >
               <Trash2 strokeWidth={1.5} className="w-3 h-3 mr-2" /> Clear
             </Button>
@@ -184,7 +184,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
               placeholder="Search by query, connection or tab..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="pl-9 h-9 bg-fill border-hairline-strong text-xs focus:ring-emerald-500/20 rounded-lg"
+              className="pl-9 h-9 bg-fill border-hairline-strong text-xs focus:ring-hue-emerald-tint/20 rounded-lg"
             />
             {search && (
               <button
@@ -202,7 +202,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
               className={cn(
                 "px-3 py-1.5 text-xs font-medium rounded-md transition-all",
                 !isGlobal
-                  ? "bg-emerald-600 text-white shadow-lg shadow-emerald-600/20"
+                  ? "bg-success-solid text-white shadow-lg shadow-emerald-600/20"
                   : "text-fg-muted hover:text-fg-secondary",
               )}
             >
@@ -213,7 +213,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
               className={cn(
                 "px-3 py-1.5 text-xs font-medium rounded-md transition-all",
                 isGlobal
-                  ? "bg-emerald-600 text-white shadow-lg shadow-emerald-600/20"
+                  ? "bg-success-solid text-white shadow-lg shadow-emerald-600/20"
                   : "text-fg-muted hover:text-fg-secondary",
               )}
             >
@@ -262,7 +262,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                         className={cn(
                           "w-3 h-3 transition-opacity",
                           sortField === "executedAt"
-                            ? "opacity-100 text-emerald-500"
+                            ? "opacity-100 text-hue-emerald"
                             : "opacity-0 group-hover:opacity-100",
                         )}
                       />
@@ -280,7 +280,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                         className={cn(
                           "w-3 h-3 transition-opacity",
                           sortField === "executionTime"
-                            ? "opacity-100 text-emerald-500"
+                            ? "opacity-100 text-hue-emerald"
                             : "opacity-0 group-hover:opacity-100",
                         )}
                       />
@@ -296,7 +296,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                         className={cn(
                           "w-3 h-3 transition-opacity",
                           sortField === "rowCount"
-                            ? "opacity-100 text-emerald-500"
+                            ? "opacity-100 text-hue-emerald"
                             : "opacity-0 group-hover:opacity-100",
                         )}
                       />
@@ -313,13 +313,13 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                     <td className="px-4 py-4 text-center">
                       <div className="flex justify-center">
                         {item.status === "success" && (
-                          <div className="w-5 h-5 rounded-full bg-emerald-500/10 flex items-center justify-center border border-emerald-500/20">
-                            <CircleCheck strokeWidth={1.5} className="w-3 h-3 text-emerald-500" />
+                          <div className="w-5 h-5 rounded-full bg-success-tint/10 flex items-center justify-center border border-success-tint/20">
+                            <CircleCheck strokeWidth={1.5} className="w-3 h-3 text-success" />
                           </div>
                         )}
                         {item.status !== "success" && (
-                          <div className="w-5 h-5 rounded-full bg-red-500/10 flex items-center justify-center border border-red-500/20">
-                            <CircleAlert strokeWidth={1.5} className="w-3 h-3 text-red-500" />
+                          <div className="w-5 h-5 rounded-full bg-danger-tint/10 flex items-center justify-center border border-danger-tint/20">
+                            <CircleAlert strokeWidth={1.5} className="w-3 h-3 text-danger" />
                           </div>
                         )}
                       </div>
@@ -339,7 +339,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                     <td className="px-4 py-4 whitespace-nowrap">
                       <div className="flex flex-col gap-1">
                         <div className="flex items-center gap-1.5 text-fg-secondary">
-                          <Database strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
+                          <Database strokeWidth={1.5} className="w-3 h-3 text-brand" />
                           <span className="font-medium">{item.connectionName || "Unknown"}</span>
                         </div>
                         <div className="flex items-center gap-1.5 text-fg-muted text-xs">
@@ -354,7 +354,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                           {item.query}
                         </pre>
                         {item.errorMessage && (
-                          <div className="mt-2 pt-2 border-t border-red-500/10 text-xs text-red-400/80 font-mono italic">
+                          <div className="mt-2 pt-2 border-t border-danger-tint/10 text-xs text-danger/80 font-mono italic">
                             {item.errorMessage}
                           </div>
                         )}
@@ -364,7 +364,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                       <span
                         className={cn(
                           "px-2 py-0.5 rounded text-xs font-mono font-medium",
-                          item.executionTime > 500 ? "text-amber-400 bg-amber-400/10" : "text-fg-tertiary bg-fill",
+                          item.executionTime > 500 ? "text-warning bg-warning/10" : "text-fg-tertiary bg-fill",
                         )}
                       >
                         {item.executionTime}ms
@@ -379,7 +379,7 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
                       <Button
                         variant="ghost"
                         size="sm"
-                        className="h-8 w-8 p-0 hover:bg-emerald-500/10 hover:text-emerald-400"
+                        className="h-8 w-8 p-0 hover:bg-hue-emerald-tint/10 hover:text-hue-emerald"
                         onClick={() => onSelectQuery(item.query)}
                         title="Restore Query"
                       >

--- a/src/components/QuerySafetyDialog.tsx
+++ b/src/components/QuerySafetyDialog.tsx
@@ -51,37 +51,37 @@ function parseSafetyResponse(text: string): SafetyAnalysis | null {
 
 const RISK_CONFIG = {
   safe: {
-    color: "text-emerald-400",
-    bg: "bg-emerald-500/10",
-    border: "border-emerald-500/20",
+    color: "text-hue-emerald",
+    bg: "bg-hue-emerald-tint/10",
+    border: "border-hue-emerald-tint/20",
     icon: ShieldCheck,
     label: "Safe",
   },
   low: {
-    color: "text-blue-400",
-    bg: "bg-blue-500/10",
-    border: "border-blue-500/20",
+    color: "text-hue-blue",
+    bg: "bg-hue-blue-tint/10",
+    border: "border-hue-blue-tint/20",
     icon: ShieldCheck,
     label: "Low Risk",
   },
   medium: {
-    color: "text-amber-400",
-    bg: "bg-amber-500/10",
-    border: "border-amber-500/20",
+    color: "text-hue-amber",
+    bg: "bg-hue-amber-tint/10",
+    border: "border-hue-amber-tint/20",
     icon: TriangleAlert,
     label: "Medium Risk",
   },
   high: {
-    color: "text-orange-400",
-    bg: "bg-orange-500/10",
-    border: "border-orange-500/20",
+    color: "text-hue-orange",
+    bg: "bg-hue-orange-tint/10",
+    border: "border-hue-orange-tint/20",
     icon: ShieldAlert,
     label: "High Risk",
   },
   critical: {
-    color: "text-red-400",
-    bg: "bg-red-500/10",
-    border: "border-red-500/20",
+    color: "text-hue-red",
+    bg: "bg-hue-red-tint/10",
+    border: "border-hue-red-tint/20",
     icon: ShieldAlert,
     label: "Critical Risk",
   },
@@ -210,7 +210,7 @@ export function QuerySafetyDialog({
       <div className="bg-overlay border border-hairline-strong rounded-xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden">
         <div className="flex items-center justify-between px-5 py-3 border-b border-hairline">
           <div className="flex items-center gap-2">
-            <ShieldAlert strokeWidth={1.5} className="w-3.5 h-3.5 text-amber-400" />
+            <ShieldAlert strokeWidth={1.5} className="w-3.5 h-3.5 text-warning" />
             <span className="text-xs font-medium text-fg">Query Safety Check</span>
           </div>
           <button onClick={onClose} className="p-1 rounded hover:bg-fill text-fg-muted">
@@ -231,10 +231,10 @@ export function QuerySafetyDialog({
             whose reading stopped early may not describe what the statement does.
           */}
           {unreadableRun && (
-            <div className="mb-3 flex items-start gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20">
-              <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-400" />
+            <div className="mb-3 flex items-start gap-2 px-3 py-2 rounded-lg bg-warning-tint/10 border border-warning-tint/20">
+              <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 mt-0.5 shrink-0 text-warning" />
               <div>
-                <span className="text-xs font-medium text-amber-400">Part of this statement could not be read</span>
+                <span className="text-xs font-medium text-warning">Part of this statement could not be read</span>
                 <p className="text-xs text-fg-tertiary mt-0.5">
                   A quoted, commented or bracketed run in it never closes (or its closing quote sits behind a backslash,
                   which dialects read differently), so nothing written after that point could be checked. It may hide a
@@ -252,7 +252,9 @@ export function QuerySafetyDialog({
           )}
 
           {error && (
-            <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 text-xs text-red-400">{error}</div>
+            <div className="bg-danger-tint/10 border border-danger-tint/20 rounded-lg p-3 text-xs text-danger">
+              {error}
+            </div>
           )}
 
           {analysis && risk && (
@@ -273,10 +275,10 @@ export function QuerySafetyDialog({
                       className={cn(
                         "px-3 py-2 rounded-lg border text-xs",
                         w.severity === "critical"
-                          ? "bg-red-500/5 border-red-500/20"
+                          ? "bg-danger-tint/5 border-danger-tint/20"
                           : w.severity === "warning"
-                            ? "bg-amber-500/5 border-amber-500/20"
-                            : "bg-blue-500/5 border-blue-500/20",
+                            ? "bg-warning-tint/5 border-warning-tint/20"
+                            : "bg-brand-tint/5 border-brand-tint/20",
                       )}
                     >
                       <p className="font-medium text-fg-secondary">{w.message}</p>
@@ -327,8 +329,8 @@ export function QuerySafetyDialog({
             className={cn(
               "px-4 py-2 rounded-lg text-white text-xs font-medium transition-colors flex items-center gap-1.5",
               analysis?.riskLevel === "critical" || analysis?.riskLevel === "high"
-                ? "bg-red-600 hover:bg-red-500"
-                : "bg-blue-600 hover:bg-blue-500",
+                ? "bg-danger-solid hover:bg-danger-solid-hover"
+                : "bg-brand-solid hover:bg-brand-solid-hover",
               isAnalyzing && "opacity-50 cursor-not-allowed",
             )}
           >

--- a/src/components/ResultsGrid.tsx
+++ b/src/components/ResultsGrid.tsx
@@ -257,7 +257,7 @@ export function ResultsGrid({
               )}
               {isSensitive && (
                 <span title="Masked column">
-                  <Lock strokeWidth={1.5} className="w-3 h-3 text-purple-400 shrink-0" />
+                  <Lock strokeWidth={1.5} className="w-3 h-3 text-hue-purple shrink-0" />
                 </span>
               )}
               <div className="flex-shrink-0 opacity-0 group-hover/header:opacity-100 transition-opacity">
@@ -270,7 +270,7 @@ export function ResultsGrid({
               className={cn(
                 "shrink-0 p-0.5 rounded transition-colors",
                 hasFilter
-                  ? "text-blue-400"
+                  ? "text-brand"
                   : "opacity-0 group-hover/header:opacity-100 text-fg-muted hover:text-fg-secondary",
               )}
               onClick={(e) => {
@@ -300,11 +300,11 @@ export function ResultsGrid({
                   onKeyDown={(e) => {
                     if (e.key === "Escape" || e.key === "Enter") setActiveFilterCol(null);
                   }}
-                  className="w-full bg-canvas border border-hairline-strong rounded px-2 py-1 text-xs text-fg outline-none focus:border-blue-500/30"
+                  className="w-full bg-canvas border border-hairline-strong rounded px-2 py-1 text-xs text-fg outline-none focus:border-brand-tint/30"
                 />
                 {hasFilter && (
                   <button
-                    className="mt-1 text-xs text-red-400 hover:text-red-300"
+                    className="mt-1 text-xs text-danger hover:text-danger-bright"
                     onClick={() => {
                       const next = new Map(columnFilters);
                       next.delete(field);
@@ -330,7 +330,7 @@ export function ResultsGrid({
             <div role="presentation" className="flex items-center gap-1 w-full" onClick={(e) => e.stopPropagation()}>
               <input
                 autoFocus
-                className="w-full bg-overlay border border-blue-500 rounded px-1 py-0.5 text-fg outline-none"
+                className="w-full bg-overlay border border-brand-tint rounded px-1 py-0.5 text-fg outline-none"
                 value={editValue}
                 onChange={(e) => setEditValue(e.target.value)}
                 onKeyDown={(e) => {
@@ -375,14 +375,14 @@ export function ResultsGrid({
               <span className="text-fg-muted italic">{masked}</span>
               {userCanReveal && (
                 <button
-                  className="opacity-0 group-hover/cell:opacity-100 transition-opacity p-0.5 rounded hover:bg-purple-500/10"
+                  className="opacity-0 group-hover/cell:opacity-100 transition-opacity p-0.5 rounded hover:bg-hue-purple-tint/10"
                   onClick={(e) => {
                     e.stopPropagation();
                     revealCell(cellKey);
                   }}
                   title="Reveal value (10s)"
                 >
-                  <Eye className="w-3 h-3 text-purple-400" />
+                  <Eye className="w-3 h-3 text-hue-purple" />
                 </button>
               )}
             </div>
@@ -395,7 +395,7 @@ export function ResultsGrid({
           return (
             <div className="truncate w-full h-full flex items-center gap-1">
               <span className={className}>{display}</span>
-              <Lock strokeWidth={1.5} className="w-2.5 h-2.5 text-purple-400/50 shrink-0" />
+              <Lock strokeWidth={1.5} className="w-2.5 h-2.5 text-hue-purple/50 shrink-0" />
             </div>
           );
         }
@@ -410,21 +410,21 @@ export function ResultsGrid({
         // editing at all (issue #269).
         if (!editingEnabled) {
           return (
-            <div className={cn("truncate w-full h-full", pendingChange && "bg-amber-500/10 rounded px-0.5")}>
-              <span className={cn(className, pendingChange && "text-amber-400")}>{display}</span>
+            <div className={cn("truncate w-full h-full", pendingChange && "bg-warning-tint/10 rounded px-0.5")}>
+              <span className={cn(className, pendingChange && "text-warning")}>{display}</span>
             </div>
           );
         }
 
         return (
           <div
-            className={cn("truncate w-full h-full cursor-text", pendingChange && "bg-amber-500/10 rounded px-0.5")}
+            className={cn("truncate w-full h-full cursor-text", pendingChange && "bg-warning-tint/10 rounded px-0.5")}
             onDoubleClick={() => {
               setEditingCell({ rowIndex: row.index, columnId: column.id });
               setEditValue(pendingChange ? pendingChange.newValue : String(val ?? ""));
             }}
           >
-            <span className={cn(className, pendingChange && "text-amber-400")}>{display}</span>
+            <span className={cn(className, pendingChange && "text-warning")}>{display}</span>
           </div>
         );
       },
@@ -505,7 +505,7 @@ export function ResultsGrid({
         </div>
         <p className="text-xs font-medium text-fg-tertiary">Query returned no data</p>
         {emptyWarnings.length > 0 && (
-          <div className="mt-3 max-w-[280px] text-xs text-amber-400 leading-relaxed">
+          <div className="mt-3 max-w-[280px] text-xs text-warning leading-relaxed">
             <p className="font-medium">{ENGINE_WARNINGS_LABEL}</p>
             <ul className="mt-1 space-y-1">
               {emptyWarnings.map((warning, idx) => (
@@ -596,7 +596,7 @@ export function ResultsGrid({
                       unreliable for assistive tech, so the type also ships as
                       screen-reader text - same treatment as the warnings badge. */}
                   {declaredType && <span className="sr-only">, {declaredType}</span>}
-                  {isSensitive && <Lock strokeWidth={1.5} className="w-2.5 h-2.5 text-purple-400" />}
+                  {isSensitive && <Lock strokeWidth={1.5} className="w-2.5 h-2.5 text-hue-purple" />}
                 </div>
               );
             })}
@@ -622,7 +622,7 @@ export function ResultsGrid({
                     height: `${virtualRow.size}px`,
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
-                  className="flex hover:bg-blue-500/[0.03] transition-colors border-b border-hairline cursor-pointer text-left"
+                  className="flex hover:bg-brand-tint/[0.03] transition-colors border-b border-hairline cursor-pointer text-left"
                   onClick={() => setSelectedRow({ row, index: virtualRow.index })}
                 >
                   {result.fields.map((field, idx) => {
@@ -671,8 +671,8 @@ export function ResultsGrid({
                     onMouseDown={header.getResizeHandler()}
                     onTouchStart={header.getResizeHandler()}
                     className={cn(
-                      "absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-blue-500/50 transition-colors",
-                      header.column.getIsResizing() ? "bg-blue-500 w-1" : "bg-transparent",
+                      "absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-brand-tint/50 transition-colors",
+                      header.column.getIsResizing() ? "bg-brand-tint w-1" : "bg-transparent",
                     )}
                   />
                 </div>
@@ -694,7 +694,7 @@ export function ResultsGrid({
                     top: 0,
                     left: 0,
                   }}
-                  className="flex group hover:bg-blue-500/[0.03] transition-colors border-b border-hairline"
+                  className="flex group hover:bg-brand-tint/[0.03] transition-colors border-b border-hairline"
                 >
                   {row.getVisibleCells().map((cell) => (
                     <div

--- a/src/components/SaveQueryModal.tsx
+++ b/src/components/SaveQueryModal.tsx
@@ -38,7 +38,7 @@ export function SaveQueryModal({ isOpen, onClose, onSave, defaultQuery }: SaveQu
       <DialogContent className="bg-raised border-hairline-strong text-fg-secondary sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle className="text-fg flex items-center gap-2">
-            <Bookmark strokeWidth={1.5} className="w-5 h-5 text-blue-500" /> Save Query
+            <Bookmark strokeWidth={1.5} className="w-5 h-5 text-brand" /> Save Query
           </DialogTitle>
           <DialogDescription className="text-fg-muted">
             Give your query a name and description to find it easily later.
@@ -55,7 +55,7 @@ export function SaveQueryModal({ isOpen, onClose, onSave, defaultQuery }: SaveQu
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Monthly Active Users"
-              className="bg-fill border-hairline-strong focus:ring-blue-500/20"
+              className="bg-fill border-hairline-strong focus:ring-brand-tint/20"
             />
           </div>
           <div className="grid gap-2">
@@ -67,7 +67,7 @@ export function SaveQueryModal({ isOpen, onClose, onSave, defaultQuery }: SaveQu
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What does this query do?"
-              className="bg-fill border-hairline-strong focus:ring-blue-500/20 min-h-[80px]"
+              className="bg-fill border-hairline-strong focus:ring-brand-tint/20 min-h-[80px]"
             />
           </div>
           <div className="grid gap-2">
@@ -79,7 +79,7 @@ export function SaveQueryModal({ isOpen, onClose, onSave, defaultQuery }: SaveQu
               value={tagsInput}
               onChange={(e) => setTagsInput(e.target.value)}
               placeholder="reports, analytics, users"
-              className="bg-fill border-hairline-strong focus:ring-blue-500/20"
+              className="bg-fill border-hairline-strong focus:ring-brand-tint/20"
             />
           </div>
           <div className="mt-2">
@@ -99,7 +99,7 @@ export function SaveQueryModal({ isOpen, onClose, onSave, defaultQuery }: SaveQu
           <Button
             onClick={handleSave}
             disabled={!name}
-            className="bg-blue-600 hover:bg-blue-500 text-white font-medium"
+            className="bg-brand-solid hover:bg-brand-solid-hover text-white font-medium"
           >
             Save Query
           </Button>

--- a/src/components/SavedQueries.tsx
+++ b/src/components/SavedQueries.tsx
@@ -55,7 +55,7 @@ export function SavedQueries({ onSelectQuery, connectionType, refreshTrigger }: 
             placeholder="Search saved queries..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="pl-8 h-8 bg-fill border-hairline-strong text-xs focus:ring-blue-500/20"
+            className="pl-8 h-8 bg-fill border-hairline-strong text-xs focus:ring-brand-tint/20"
           />
         </div>
       </div>
@@ -81,7 +81,7 @@ export function SavedQueries({ onSelectQuery, connectionType, refreshTrigger }: 
                           whole card clickable while nested action buttons stay above it */}
                       <button
                         type="button"
-                        className="text-blue-400 group-hover:text-blue-300 transition-colors cursor-pointer text-left after:absolute after:inset-0"
+                        className="text-brand group-hover:text-brand-bright transition-colors cursor-pointer text-left after:absolute after:inset-0"
                         onClick={() => onSelectQuery(q.query)}
                       >
                         {q.name}
@@ -103,7 +103,7 @@ export function SavedQueries({ onSelectQuery, connectionType, refreshTrigger }: 
                       variant="ghost"
                       size="icon"
                       aria-label={`Delete ${q.name}`}
-                      className="h-6 w-6 text-fg-muted hover:text-red-400"
+                      className="h-6 w-6 text-fg-muted hover:text-danger"
                       onClick={(e) => handleDelete(q.id, e)}
                     >
                       <Trash2 strokeWidth={1.5} className="w-3 h-3" />
@@ -117,7 +117,7 @@ export function SavedQueries({ onSelectQuery, connectionType, refreshTrigger }: 
 
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <span className="px-1.5 py-0.5 rounded bg-blue-500/10 border border-blue-500/20 text-[0.625rem] font-medium text-blue-400">
+                    <span className="px-1.5 py-0.5 rounded bg-brand-tint/10 border border-brand-tint/20 text-[0.625rem] font-medium text-brand">
                       {q.connectionType}
                     </span>
                     {q.tags?.map((tag) => (

--- a/src/components/SchemaDiagram.tsx
+++ b/src/components/SchemaDiagram.tsx
@@ -353,7 +353,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
   if (schema.length === 0) {
     return (
       <div className="absolute inset-0 z-50 bg-canvas flex flex-col items-center justify-center">
-        <LoaderCircle strokeWidth={1.5} className="w-8 h-8 text-blue-500 animate-spin mb-4" />
+        <LoaderCircle strokeWidth={1.5} className="w-8 h-8 text-brand animate-spin mb-4" />
         <p className="text-fg-muted text-xs">Generating ERD Diagram...</p>
       </div>
     );
@@ -435,7 +435,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
                 <Button
                   variant="outline"
                   size="sm"
-                  className={`bg-raised border-hairline-strong hover:bg-fill text-xs ${compactMode ? "text-blue-400" : ""}`}
+                  className={`bg-raised border-hairline-strong hover:bg-fill text-xs ${compactMode ? "text-brand" : ""}`}
                   onClick={() => setCompactMode(!compactMode)}
                 >
                   {compactMode ? "Detail" : "Compact"}
@@ -455,7 +455,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
             <Panel position="top-left" className="p-4">
               <div className="bg-raised/80 backdrop-blur-md border border-hairline-strong p-3 rounded-xl shadow-2xl space-y-2">
                 <h3 className="text-xs font-medium text-fg mb-1 flex items-center gap-2">
-                  <div className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                  <div className="w-2 h-2 rounded-full bg-brand-tint animate-pulse" />
                   ERD Visualizer
                 </h3>
                 <div className="flex items-center gap-3 text-xs text-fg-muted">
@@ -480,13 +480,13 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
                     placeholder="Filter tables..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="w-full pl-7 pr-2 py-1.5 bg-fill border border-hairline-strong rounded text-xs text-fg-secondary placeholder:text-fg-subtle focus:outline-none focus:border-blue-500/50"
+                    className="w-full pl-7 pr-2 py-1.5 bg-fill border border-hairline-strong rounded text-xs text-fg-secondary placeholder:text-fg-subtle focus:outline-none focus:border-brand-tint/50"
                   />
                 </div>
 
                 {/* No FK warning */}
                 {showHeuristicWarning && (
-                  <div className="flex items-start gap-1.5 text-[0.625rem] text-amber-500/80">
+                  <div className="flex items-start gap-1.5 text-[0.625rem] text-warning/80">
                     <Info strokeWidth={1.5} className="w-3 h-3 mt-0.5 shrink-0" />
                     <span>{heuristicWarningText}</span>
                   </div>
@@ -494,7 +494,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
 
                 {/* Selected node info */}
                 {selectedNode && (
-                  <div className="text-xs text-blue-400 border-t border-hairline pt-2">
+                  <div className="text-xs text-brand border-t border-hairline pt-2">
                     Selected: <span className="font-mono font-medium">{selectedNode}</span>
                     <button onClick={() => selectTable(null)} className="ml-2 text-fg-subtle hover:text-fg-tertiary">
                       clear
@@ -509,7 +509,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
               transform is temporarily swapped for the fit-all capture. */}
           {exporting && (
             <div className="absolute inset-0 z-50 bg-canvas/85 flex flex-col items-center justify-center gap-2">
-              <LoaderCircle strokeWidth={1.5} className="w-6 h-6 text-blue-500 animate-spin" />
+              <LoaderCircle strokeWidth={1.5} className="w-6 h-6 text-brand animate-spin" />
               <p className="text-fg-muted text-xs">Exporting {exporting.toUpperCase()}...</p>
             </div>
           )}

--- a/src/components/SchemaDiff.tsx
+++ b/src/components/SchemaDiff.tsx
@@ -141,21 +141,21 @@ export function SchemaDiff({ schema, connection }: SchemaDiffProps) {
     switch (action) {
       case "added":
         return (
-          <Badge className="bg-green-500/20 text-green-400 border-green-500/30 text-xs">
+          <Badge className="bg-hue-green-tint/20 text-hue-green border-hue-green-tint/30 text-xs">
             <Plus strokeWidth={1.5} className="w-2.5 h-2.5 mr-0.5" />
             {"Added"}
           </Badge>
         );
       case "removed":
         return (
-          <Badge className="bg-red-500/20 text-red-400 border-red-500/30 text-xs">
+          <Badge className="bg-hue-red-tint/20 text-hue-red border-hue-red-tint/30 text-xs">
             <Minus className="w-2.5 h-2.5 mr-0.5" />
             {"Removed"}
           </Badge>
         );
       case "modified":
         return (
-          <Badge className="bg-yellow-500/20 text-yellow-400 border-yellow-500/30 text-xs">
+          <Badge className="bg-hue-yellow-tint/20 text-hue-yellow border-hue-yellow-tint/30 text-xs">
             <PenLine strokeWidth={1.5} className="w-2.5 h-2.5 mr-0.5" />
             {"Modified"}
           </Badge>
@@ -174,7 +174,7 @@ export function SchemaDiff({ schema, connection }: SchemaDiffProps) {
     <div className="h-full flex flex-col bg-sunken">
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2 border-b border-hairline bg-surface flex-wrap">
-        <GitCompare strokeWidth={1.5} className="w-3.5 h-3.5 text-rose-400" />
+        <GitCompare strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-rose" />
         <span className="text-xs font-medium text-fg-tertiary">Schema Diff</span>
 
         <div className="h-4 w-px bg-fill-strong" />
@@ -244,9 +244,9 @@ export function SchemaDiff({ schema, connection }: SchemaDiffProps) {
                     .map((c) => (
                       <SelectItem key={`conn:${c.id}`} value={`conn:${c.id}`} className="text-xs">
                         <div className="flex items-center gap-1">
-                          <Database strokeWidth={1.5} className="w-3 h-3 text-blue-400" /> {c.name}
+                          <Database strokeWidth={1.5} className="w-3 h-3 text-hue-blue" /> {c.name}
                           {c.environment === "production" && (
-                            <TriangleAlert strokeWidth={1.5} className="w-3 h-3 text-red-400" />
+                            <TriangleAlert strokeWidth={1.5} className="w-3 h-3 text-danger" />
                           )}
                         </div>
                       </SelectItem>
@@ -269,10 +269,10 @@ export function SchemaDiff({ schema, connection }: SchemaDiffProps) {
               value={snapshotLabel}
               onChange={(e) => setSnapshotLabel(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && takeSnapshot()}
-              className="h-7 px-2 text-xs bg-fill border border-hairline-strong rounded text-fg-secondary focus:outline-none focus:border-blue-500 w-32"
+              className="h-7 px-2 text-xs bg-fill border border-hairline-strong rounded text-fg-secondary focus:outline-none focus:border-brand-tint w-32"
               autoFocus
             />
-            <Button variant="ghost" size="sm" className="h-7 text-xs text-blue-400" onClick={takeSnapshot}>
+            <Button variant="ghost" size="sm" className="h-7 text-xs text-brand" onClick={takeSnapshot}>
               {"Save"}
             </Button>
             <Button
@@ -400,9 +400,9 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
         <Badge
           className={cn(
             "text-xs",
-            diff.action === "added" && "bg-green-500/20 text-green-400",
-            diff.action === "removed" && "bg-red-500/20 text-red-400",
-            diff.action === "modified" && "bg-yellow-500/20 text-yellow-400",
+            diff.action === "added" && "bg-hue-green-tint/20 text-hue-green",
+            diff.action === "removed" && "bg-hue-red-tint/20 text-hue-red",
+            diff.action === "modified" && "bg-hue-yellow-tint/20 text-hue-yellow",
           )}
         >
           {diff.action}
@@ -425,9 +425,9 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
                 key={col.columnName}
                 className={cn(
                   "px-3 py-2 rounded text-xs flex items-center gap-2",
-                  col.action === "added" && "bg-green-500/5 border border-green-500/10",
-                  col.action === "removed" && "bg-red-500/5 border border-red-500/10",
-                  col.action === "modified" && "bg-yellow-500/5 border border-yellow-500/10",
+                  col.action === "added" && "bg-hue-green-tint/5 border border-hue-green-tint/10",
+                  col.action === "removed" && "bg-hue-red-tint/5 border border-hue-red-tint/10",
+                  col.action === "modified" && "bg-hue-yellow-tint/5 border border-hue-yellow-tint/10",
                 )}
               >
                 <span className="font-mono text-fg-secondary min-w-[120px]">{col.columnName}</span>
@@ -440,8 +440,8 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
                     ))}
                   </div>
                 )}
-                {col.action === "added" && <span className="text-xs text-green-400 font-mono">{col.targetType}</span>}
-                {col.action === "removed" && <span className="text-xs text-red-400 font-mono">{col.sourceType}</span>}
+                {col.action === "added" && <span className="text-xs text-hue-green font-mono">{col.targetType}</span>}
+                {col.action === "removed" && <span className="text-xs text-hue-red font-mono">{col.sourceType}</span>}
                 <span className="ml-auto">{getActionIcon(col.action)}</span>
               </div>
             ))}
@@ -459,9 +459,9 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
                 key={idx.indexName}
                 className={cn(
                   "px-3 py-2 rounded text-xs flex items-center gap-2",
-                  idx.action === "added" && "bg-green-500/5 border border-green-500/10",
-                  idx.action === "removed" && "bg-red-500/5 border border-red-500/10",
-                  idx.action === "modified" && "bg-yellow-500/5 border border-yellow-500/10",
+                  idx.action === "added" && "bg-hue-green-tint/5 border border-hue-green-tint/10",
+                  idx.action === "removed" && "bg-hue-red-tint/5 border border-hue-red-tint/10",
+                  idx.action === "modified" && "bg-hue-yellow-tint/5 border border-hue-yellow-tint/10",
                 )}
               >
                 <span className="font-mono text-fg-secondary">{idx.indexName}</span>
@@ -492,8 +492,8 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
                 key={`${fk.action}:${fk.columnName}`}
                 className={cn(
                   "px-3 py-2 rounded text-xs flex items-center gap-2",
-                  fk.action === "added" && "bg-green-500/5 border border-green-500/10",
-                  fk.action === "removed" && "bg-red-500/5 border border-red-500/10",
+                  fk.action === "added" && "bg-hue-green-tint/5 border border-hue-green-tint/10",
+                  fk.action === "removed" && "bg-hue-red-tint/5 border border-hue-red-tint/10",
                 )}
               >
                 <span className="font-mono text-fg-secondary">{fk.columnName}</span>
@@ -515,11 +515,11 @@ function TableDiffDetail({ diff }: { diff: TableDiff }) {
 function getActionIcon(action: string) {
   switch (action) {
     case "added":
-      return <Plus strokeWidth={1.5} className="w-3 h-3 text-green-400" />;
+      return <Plus strokeWidth={1.5} className="w-3 h-3 text-hue-green" />;
     case "removed":
-      return <Minus className="w-3 h-3 text-red-400" />;
+      return <Minus className="w-3 h-3 text-hue-red" />;
     case "modified":
-      return <PenLine strokeWidth={1.5} className="w-3 h-3 text-yellow-400" />;
+      return <PenLine strokeWidth={1.5} className="w-3 h-3 text-hue-yellow" />;
     default:
       return null;
   }

--- a/src/components/SnapshotTimeline.tsx
+++ b/src/components/SnapshotTimeline.tsx
@@ -19,7 +19,7 @@ const NODE_CLASS = "relative flex flex-col items-center min-w-[100px] cursor-poi
 // w-6 h-6 keeps a 24x24 minimum hit target: the control sits on top of the
 // stretched selection overlay, so a near miss must not select the snapshot.
 const DELETE_BUTTON_CLASS =
-  "absolute -top-3 -right-2 z-20 w-6 h-6 flex items-center justify-center text-fg-subtle hover:text-red-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity";
+  "absolute -top-3 -right-2 z-20 w-6 h-6 flex items-center justify-center text-fg-subtle hover:text-danger opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity";
 
 export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTimelineProps) {
   const [selected, setSelected] = useState<string[]>([]);
@@ -54,7 +54,7 @@ export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTim
     <div className="space-y-2">
       <div className="flex items-center justify-between px-2">
         <span className="text-xs text-fg-muted font-medium">Timeline</span>
-        {canCompare && <span className="text-xs text-blue-400">Comparing 2 snapshots</span>}
+        {canCompare && <span className="text-xs text-brand">Comparing 2 snapshots</span>}
       </div>
 
       <div className="relative flex items-center overflow-x-auto pb-2 px-2 gap-0">
@@ -65,7 +65,7 @@ export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTim
           const date = new Date(snapshot.createdAt);
           const labelClass = cn(
             "mt-2 text-center transition-colors",
-            isSelected ? "text-blue-400" : "text-fg-muted group-hover:text-fg-secondary",
+            isSelected ? "text-brand" : "text-fg-muted group-hover:text-fg-secondary",
           );
           const handleDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();
@@ -78,7 +78,7 @@ export function SnapshotTimeline({ snapshots, onCompare, onDelete }: SnapshotTim
                 className={cn(
                   "w-3.5 h-3.5 rounded-full border-2 z-10 transition-all",
                   isSelected
-                    ? "bg-blue-500 border-blue-400 scale-125"
+                    ? "bg-brand-tint border-brand scale-125"
                     : "bg-raised border-edge group-hover:border-edge-hover",
                 )}
               />

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -494,7 +494,7 @@ export default function Studio() {
                 onGenerateTestData={(name) => setTestDataTable(name)}
               />
             </ResizablePanel>
-            <ResizableHandle className="w-1 bg-transparent hover:bg-blue-500/30 transition-colors" />
+            <ResizableHandle className="w-1 bg-transparent hover:bg-brand-tint/30 transition-colors" />
           </>
         )}
         <ResizablePanel id="studio-body" defaultSize={agentEnabled ? "54" : "78"}>
@@ -672,7 +672,7 @@ export default function Studio() {
                         </div>
                       </div>
                     </ResizablePanel>
-                    <ResizableHandle className="h-1 bg-fill hover:bg-blue-500/20" />
+                    <ResizableHandle className="h-1 bg-fill hover:bg-brand-tint/20" />
                     <ResizablePanel id="studio-editor-bottom" defaultSize="60" minSize="20">
                       <BottomPanel
                         mode={queryExec.bottomPanelMode}
@@ -742,7 +742,7 @@ export default function Studio() {
         */}
         {agentEnabled && !isMobile && (
           <>
-            <ResizableHandle className="w-1 bg-transparent hover:bg-blue-500/30 transition-colors" />
+            <ResizableHandle className="w-1 bg-transparent hover:bg-brand-tint/30 transition-colors" />
             <ResizablePanel id="studio-agent" defaultSize="24" minSize="18" maxSize="45">
               {agentRail}{" "}
             </ResizablePanel>
@@ -837,7 +837,7 @@ export default function Studio() {
           <div className="px-6 pt-6 pb-4">
             <div className="flex items-start gap-3">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-amber-500/20 to-red-500/10 flex items-center justify-center shrink-0">
-                <TriangleAlert strokeWidth={1.5} className="w-5 h-5 text-amber-400" />
+                <TriangleAlert strokeWidth={1.5} className="w-5 h-5 text-warning" />
               </div>
               <div className="flex-1 min-w-0">
                 <AlertDialogTitle className="text-[0.8125rem] font-medium text-fg mb-1">
@@ -856,7 +856,7 @@ export default function Studio() {
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={queryExec.handleUnlimitedQuery}
-              className="flex-1 h-9 bg-amber-600 border-0 text-white text-xs font-medium hover:bg-amber-500"
+              className="flex-1 h-9 bg-warning-solid border-0 text-white text-xs font-medium hover:bg-warning-solid-hover"
             >
               Load All
             </AlertDialogAction>

--- a/src/components/TestDataGenerator.tsx
+++ b/src/components/TestDataGenerator.tsx
@@ -241,7 +241,7 @@ export function TestDataGenerator({
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-3 border-b border-hairline">
           <div className="flex items-center gap-2">
-            <WandSparkles strokeWidth={1.5} className="w-3.5 h-3.5 text-amber-400" />
+            <WandSparkles strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-amber" />
             <span className="text-xs font-medium text-fg">Test Data Generator</span>
             <span className="text-xs text-fg-muted font-mono">{tableName}</span>
           </div>
@@ -262,7 +262,7 @@ export function TestDataGenerator({
                   className={cn(
                     "px-2 py-0.5 rounded text-xs font-medium transition-colors",
                     rowCount === n
-                      ? "bg-amber-500/20 text-amber-400 border border-amber-500/20"
+                      ? "bg-hue-amber-tint/20 text-hue-amber border border-hue-amber-tint/20"
                       : "text-fg-muted hover:text-fg-secondary hover:bg-fill",
                   )}
                 >
@@ -290,7 +290,7 @@ export function TestDataGenerator({
                   "text-xs px-1.5 py-0.5 rounded font-mono",
                   col.faker.generator === "autoIncrement"
                     ? "bg-overlay text-fg-subtle line-through"
-                    : "bg-amber-500/10 text-amber-400/80",
+                    : "bg-hue-amber-tint/10 text-hue-amber/80",
                 )}
                 title={`${col.name} → ${col.faker.generator} (e.g., ${col.faker.example})`}
               >
@@ -302,7 +302,7 @@ export function TestDataGenerator({
 
         {/* Preview */}
         <div className="flex-1 overflow-auto relative">
-          <pre className="p-5 text-xs font-mono text-blue-300 whitespace-pre-wrap leading-relaxed">
+          <pre className="p-5 text-xs font-mono text-hue-blue-alt whitespace-pre-wrap leading-relaxed">
             {generatedQuery}
           </pre>
         </div>
@@ -329,7 +329,7 @@ export function TestDataGenerator({
                 onExecuteQuery(generatedQuery);
                 onClose();
               }}
-              className="flex items-center gap-1.5 px-4 py-1.5 rounded-lg bg-amber-600 hover:bg-amber-500 text-white text-xs font-medium transition-colors"
+              className="flex items-center gap-1.5 px-4 py-1.5 rounded-lg bg-warning-solid hover:bg-warning-solid-hover text-white text-xs font-medium transition-colors"
             >
               <Play strokeWidth={1.5} className="w-3 h-3 fill-current" /> Execute
             </button>

--- a/src/components/VisualExplain.tsx
+++ b/src/components/VisualExplain.tsx
@@ -199,16 +199,16 @@ function analyzePlan(plan: ExplainPlanResult[]): PlanAnalysis {
 // ============================================================================
 
 const NodeIcon = ({ type }: { type: string }) => {
-  if (type.includes("Seq Scan")) return <Search strokeWidth={1.5} className="w-3.5 h-3.5 text-amber-400" />;
+  if (type.includes("Seq Scan")) return <Search strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-amber" />;
   if (type.includes("Index Scan") || type.includes("Index Only"))
-    return <Target strokeWidth={1.5} className="w-3.5 h-3.5 text-emerald-400" />;
-  if (type.includes("Scan")) return <Search strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />;
-  if (type.includes("Join")) return <Layers strokeWidth={1.5} className="w-3.5 h-3.5 text-purple-400" />;
-  if (type.includes("Sort")) return <ArrowDown strokeWidth={1.5} className="w-3.5 h-3.5 text-amber-400" />;
+    return <Target strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-emerald" />;
+  if (type.includes("Scan")) return <Search strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-blue" />;
+  if (type.includes("Join")) return <Layers strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-purple" />;
+  if (type.includes("Sort")) return <ArrowDown strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-amber" />;
   if (type.includes("Limit")) return <LayoutGrid strokeWidth={1.5} className="w-3.5 h-3.5 text-fg-tertiary" />;
   if (type.includes("Aggregate") || type.includes("Group"))
-    return <Zap strokeWidth={1.5} className="w-3.5 h-3.5 text-pink-400" />;
-  if (type.includes("Hash")) return <HardDrive strokeWidth={1.5} className="w-3.5 h-3.5 text-cyan-400" />;
+    return <Zap strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-pink" />;
+  if (type.includes("Hash")) return <HardDrive strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-cyan" />;
   return <Database strokeWidth={1.5} className="w-3.5 h-3.5 text-fg-muted" />;
 };
 
@@ -217,7 +217,7 @@ const StatusBadge = ({ status }: { status: "good" | "warning" | "critical" }) =>
     <div
       className={cn(
         "w-2 h-2 rounded-full",
-        status === "good" ? "bg-emerald-500" : status === "warning" ? "bg-amber-500" : "bg-red-500",
+        status === "good" ? "bg-success-tint" : status === "warning" ? "bg-warning-tint" : "bg-danger-tint",
       )}
     />
   );
@@ -259,7 +259,10 @@ const PlanNode = ({ node, depth = 0, maxTime }: { node: ExplainPlanNode; depth?:
 
         {/* Icon */}
         <div
-          className={cn("p-1 rounded", isSeqScan ? "bg-amber-500/10" : isIndexScan ? "bg-emerald-500/10" : "bg-fill")}
+          className={cn(
+            "p-1 rounded",
+            isSeqScan ? "bg-hue-amber-tint/10" : isIndexScan ? "bg-hue-emerald-tint/10" : "bg-fill",
+          )}
         >
           <NodeIcon type={nodeType} />
         </div>
@@ -280,7 +283,7 @@ const PlanNode = ({ node, depth = 0, maxTime }: { node: ExplainPlanNode; depth?:
           <span
             className={cn(
               "w-16 text-right",
-              timePercent > 50 ? "text-red-400" : timePercent > 20 ? "text-amber-400" : "text-fg-tertiary",
+              timePercent > 50 ? "text-danger" : timePercent > 20 ? "text-warning" : "text-fg-tertiary",
             )}
           >
             {formatTime(actualTime)}
@@ -290,7 +293,7 @@ const PlanNode = ({ node, depth = 0, maxTime }: { node: ExplainPlanNode; depth?:
             <div
               className={cn(
                 "h-full rounded-full transition-all",
-                timePercent > 50 ? "bg-red-500" : timePercent > 20 ? "bg-amber-500" : "bg-blue-500",
+                timePercent > 50 ? "bg-danger-tint" : timePercent > 20 ? "bg-warning-tint" : "bg-brand-tint",
               )}
               style={{ width: `${Math.min(timePercent, 100)}%` }}
             />
@@ -304,15 +307,15 @@ const PlanNode = ({ node, depth = 0, maxTime }: { node: ExplainPlanNode; depth?:
           {/* Filter info */}
           {node["Filter"] && (
             <div className="flex items-start gap-2 py-1 text-xs">
-              <span className="text-amber-500/70 font-medium shrink-0">Filter:</span>
+              <span className="text-hue-amber/70 font-medium shrink-0">Filter:</span>
               <span className="text-fg-muted font-mono break-all">{node["Filter"]}</span>
             </div>
           )}
           {/* Index info */}
           {node["Index Name"] && (
             <div className="flex items-center gap-2 py-1 text-xs">
-              <span className="text-emerald-500/70 font-medium">Index:</span>
-              <span className="text-emerald-400 font-mono">{node["Index Name"]}</span>
+              <span className="text-hue-emerald/70 font-medium">Index:</span>
+              <span className="text-hue-emerald font-mono">{node["Index Name"]}</span>
             </div>
           )}
           {/* Buffer stats */}
@@ -545,7 +548,7 @@ function AIExplainTab({
                 className={cn(
                   "text-xs font-mono p-3 rounded-lg overflow-x-auto border",
                   isSql
-                    ? "bg-blue-500/5 border-blue-500/10 text-blue-300"
+                    ? "bg-brand-tint/5 border-brand-tint/10 text-brand-bright"
                     : "bg-fill-subtle border-hairline text-fg-tertiary",
                 )}
               >
@@ -554,7 +557,7 @@ function AIExplainTab({
               {isSql && onLoadQuery && (
                 <button
                   onClick={() => onLoadQuery(content)}
-                  className="absolute top-2 right-2 opacity-0 group-hover/code:opacity-100 transition-opacity px-2 py-1 rounded bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium flex items-center gap-1"
+                  className="absolute top-2 right-2 opacity-0 group-hover/code:opacity-100 transition-opacity px-2 py-1 rounded bg-brand-solid hover:bg-brand-solid-hover text-white text-xs font-medium flex items-center gap-1"
                 >
                   <Play strokeWidth={1.5} className="w-3 h-3" /> Try This
                 </button>
@@ -601,7 +604,7 @@ function AIExplainTab({
         const num = line.match(/^(\d+)\./)?.[1];
         elements.push(
           <div key={idx} className="flex items-start gap-2 text-xs text-fg-tertiary leading-relaxed ml-2 my-0.5">
-            <span className="text-blue-400 font-medium mt-0 shrink-0 w-4">{num}.</span>
+            <span className="text-brand font-medium mt-0 shrink-0 w-4">{num}.</span>
             <span>{renderInlineFormatting(line.replace(/^\d+\.\s*/, ""))}</span>
           </div>,
         );
@@ -632,7 +635,7 @@ function AIExplainTab({
       }
       if (part.startsWith("`") && part.endsWith("`")) {
         return (
-          <code key={i} className="text-blue-400 bg-blue-500/10 px-1 rounded text-xs font-mono">
+          <code key={i} className="text-brand bg-brand-tint/10 px-1 rounded text-xs font-mono">
             {part.slice(1, -1)}
           </code>
         );
@@ -646,7 +649,7 @@ function AIExplainTab({
     return (
       <div className="h-full flex flex-col items-center justify-center p-8 text-center">
         <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-purple-500/20 to-blue-500/10 flex items-center justify-center mb-4">
-          <Sparkles strokeWidth={1.5} className="w-7 h-7 text-purple-400" />
+          <Sparkles strokeWidth={1.5} className="w-7 h-7 text-hue-purple" />
         </div>
         <h3 className="text-xs font-medium text-fg mb-1">AI Query Analysis</h3>
         <p className="text-xs text-fg-muted max-w-[280px] leading-relaxed mb-4">
@@ -658,7 +661,7 @@ function AIExplainTab({
           className={cn(
             "flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-medium transition-all",
             query
-              ? "bg-purple-600 hover:bg-purple-500 text-white shadow-lg shadow-purple-900/20"
+              ? "bg-hue-purple-solid hover:bg-hue-purple-solid-hover text-white shadow-lg shadow-purple-900/20"
               : "bg-fill text-fg-subtle cursor-not-allowed",
           )}
         >
@@ -675,8 +678,8 @@ function AIExplainTab({
       {/* Re-analyze button */}
       <div className="flex items-center justify-between px-4 py-2 border-b border-hairline bg-surface">
         <div className="flex items-center gap-2">
-          <Sparkles strokeWidth={1.5} className="w-3 h-3 text-purple-400" />
-          <span className="text-xs font-medium text-purple-400">AI Analysis</span>
+          <Sparkles strokeWidth={1.5} className="w-3 h-3 text-hue-purple" />
+          <span className="text-xs font-medium text-hue-purple">AI Analysis</span>
         </div>
         <button
           onClick={analyzeWithAI}
@@ -695,7 +698,7 @@ function AIExplainTab({
       {/* Content */}
       <div className="flex-1 overflow-auto p-4">
         {error && (
-          <div className="flex items-center gap-2 p-3 rounded-lg bg-red-500/5 border border-red-500/10 text-red-400 text-xs mb-4">
+          <div className="flex items-center gap-2 p-3 rounded-lg bg-danger-tint/5 border border-danger-tint/10 text-danger text-xs mb-4">
             <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 shrink-0" />
             {error}
           </div>
@@ -705,7 +708,7 @@ function AIExplainTab({
 
         {isLoading && !aiResponse && (
           <div className="flex items-center gap-3 text-fg-muted text-xs">
-            <LoaderCircle strokeWidth={1.5} className="w-3.5 h-3.5 animate-spin text-purple-400" />
+            <LoaderCircle strokeWidth={1.5} className="w-3.5 h-3.5 animate-spin text-hue-purple" />
             <span>Analyzing execution plan...</span>
           </div>
         )}
@@ -834,7 +837,7 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
           ) : (
             <div className="flex items-center gap-6">
               <div className="flex items-center gap-2">
-                <Clock strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
+                <Clock strokeWidth={1.5} className="w-3 h-3 text-brand" />
                 <span className="text-xs font-medium text-fg">{formatTime(analysis?.executionTime || 0)}</span>
                 <span className="text-xs text-fg-subtle">execution</span>
               </div>
@@ -861,7 +864,7 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
                   "px-3 py-1 text-xs font-medium rounded-md transition-all",
                   activeTab === tab
                     ? tab === "ai"
-                      ? "bg-purple-500/20 text-purple-300"
+                      ? "bg-hue-purple-tint/20 text-hue-purple-alt"
                       : "bg-fill-strong text-fg"
                     : "text-fg-muted hover:text-fg-secondary",
                 )}
@@ -902,28 +905,28 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
                     className={cn(
                       "flex items-start gap-3 p-3 rounded-lg border",
                       warning.type === "critical"
-                        ? "bg-red-500/5 border-red-500/10"
+                        ? "bg-danger-tint/5 border-danger-tint/10"
                         : warning.type === "warning"
-                          ? "bg-amber-500/5 border-amber-500/10"
-                          : "bg-blue-500/5 border-blue-500/10",
+                          ? "bg-warning-tint/5 border-warning-tint/10"
+                          : "bg-brand-tint/5 border-brand-tint/10",
                     )}
                   >
                     <div
                       className={cn(
                         "p-1 rounded",
                         warning.type === "critical"
-                          ? "bg-red-500/10"
+                          ? "bg-danger-tint/10"
                           : warning.type === "warning"
-                            ? "bg-amber-500/10"
-                            : "bg-blue-500/10",
+                            ? "bg-warning-tint/10"
+                            : "bg-brand-tint/10",
                       )}
                     >
                       {warning.type === "critical" ? (
-                        <TriangleAlert strokeWidth={1.5} className="w-3 h-3 text-red-400" />
+                        <TriangleAlert strokeWidth={1.5} className="w-3 h-3 text-danger" />
                       ) : warning.type === "warning" ? (
-                        <TriangleAlert strokeWidth={1.5} className="w-3 h-3 text-amber-400" />
+                        <TriangleAlert strokeWidth={1.5} className="w-3 h-3 text-warning" />
                       ) : (
-                        <Info strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
+                        <Info strokeWidth={1.5} className="w-3 h-3 text-brand" />
                       )}
                     </div>
                     <div className="flex-1 min-w-0">
@@ -931,10 +934,10 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
                         className={cn(
                           "text-xs font-medium",
                           warning.type === "critical"
-                            ? "text-red-300"
+                            ? "text-danger-bright"
                             : warning.type === "warning"
-                              ? "text-amber-300"
-                              : "text-blue-300",
+                              ? "text-warning-bright"
+                              : "text-brand-bright",
                         )}
                       >
                         {warning.title}
@@ -948,12 +951,12 @@ export function VisualExplain({ plan, query, schemaContext, databaseType, onLoad
 
             {/* No warnings */}
             {analysis && analysis.warnings.length === 0 && (
-              <div className="flex items-center gap-3 p-3 rounded-lg bg-emerald-500/5 border border-emerald-500/10">
-                <div className="p-1 rounded bg-emerald-500/10">
-                  <CircleCheck strokeWidth={1.5} className="w-3 h-3 text-emerald-400" />
+              <div className="flex items-center gap-3 p-3 rounded-lg bg-success-tint/5 border border-success-tint/10">
+                <div className="p-1 rounded bg-success-tint/10">
+                  <CircleCheck strokeWidth={1.5} className="w-3 h-3 text-success" />
                 </div>
                 <div>
-                  <h4 className="text-xs font-medium text-emerald-300">Query looks good</h4>
+                  <h4 className="text-xs font-medium text-success-bright">Query looks good</h4>
                   <p className="text-xs text-fg-muted">No obvious performance issues detected.</p>
                 </div>
               </div>

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -54,7 +54,7 @@ export default function AdminDashboard({ children }: AdminDashboardProps) {
             <Button
               variant="outline"
               size="sm"
-              className="border-red-500/20 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+              className="border-danger-tint/20 text-danger hover:bg-danger-tint/10 hover:text-danger-bright"
               onClick={handleLogout}
             >
               <LogOut className="mr-2 h-3.5 w-3.5" />
@@ -82,10 +82,8 @@ export default function AdminDashboard({ children }: AdminDashboardProps) {
                     // whitespace-nowrap keeps the longest labels on one line inside the
                     // h-11 row; the nav's overflow-x-auto then scrolls instead of wrapping.
                     "flex flex-1 items-center justify-center gap-2 px-3 sm:px-4 h-11 border-b-2 text-xs sm:text-sm whitespace-nowrap transition-colors",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-400/60",
-                    isActive
-                      ? "border-blue-400 text-blue-400"
-                      : "border-transparent text-fg-muted hover:text-fg-secondary",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand/60",
+                    isActive ? "border-brand text-brand" : "border-transparent text-fg-muted hover:text-fg-secondary",
                   )}
                 >
                   <Icon className="h-4 w-4" strokeWidth={1.5} />

--- a/src/components/admin/tabs/AuditTab.tsx
+++ b/src/components/admin/tabs/AuditTab.tsx
@@ -34,21 +34,21 @@ export function AuditTab() {
         <TabsList className="bg-transparent border-b border-hairline rounded-none p-0 h-10 w-full justify-start">
           <TabsTrigger
             value="operations"
-            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-blue-400 data-[state=active]:bg-transparent data-[state=active]:text-blue-400 text-fg-muted text-xs px-4"
+            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-brand data-[state=active]:bg-transparent data-[state=active]:text-brand text-fg-muted text-xs px-4"
           >
             <Wrench className="h-3.5 w-3.5" />
             Operations
           </TabsTrigger>
           <TabsTrigger
             value="queries"
-            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-blue-400 data-[state=active]:bg-transparent data-[state=active]:text-blue-400 text-fg-muted text-xs px-4"
+            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-brand data-[state=active]:bg-transparent data-[state=active]:text-brand text-fg-muted text-xs px-4"
           >
             <SearchIcon className="h-3.5 w-3.5" />
             Queries
           </TabsTrigger>
           <TabsTrigger
             value="stats"
-            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-blue-400 data-[state=active]:bg-transparent data-[state=active]:text-blue-400 text-fg-muted text-xs px-4"
+            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-brand data-[state=active]:bg-transparent data-[state=active]:text-brand text-fg-muted text-xs px-4"
           >
             <ChartColumn className="h-3.5 w-3.5" />
             Stats
@@ -191,7 +191,7 @@ function OperationsAudit() {
           Total: <span className="font-bold text-fg-secondary">{events.length}</span> ops
         </span>
         <span>
-          Success: <span className="font-bold text-emerald-400">{successRate}%</span>
+          Success: <span className="font-bold text-success">{successRate}%</span>
         </span>
       </div>
 
@@ -229,9 +229,9 @@ function OperationsAudit() {
                 <TableRow key={event.id} className="border-hairline hover:bg-fill">
                   <TableCell className="py-2">
                     {event.result === "success" ? (
-                      <CircleCheck className="w-3.5 h-3.5 text-emerald-500" />
+                      <CircleCheck className="w-3.5 h-3.5 text-success" />
                     ) : (
-                      <CircleX className="w-3.5 h-3.5 text-red-500" />
+                      <CircleX className="w-3.5 h-3.5 text-danger" />
                     )}
                   </TableCell>
                   <TableCell className="py-2 font-mono text-xs text-fg-muted">
@@ -314,7 +314,7 @@ function QueryAudit() {
         <div className="text-xs text-fg-muted ml-auto">
           <span className="font-bold text-fg-secondary">{history.length}</span> queries
           <span className="mx-2">&middot;</span>
-          <span className="text-emerald-400 font-bold">{successRate}%</span> success
+          <span className="text-success font-bold">{successRate}%</span> success
         </div>
       </div>
 
@@ -346,9 +346,9 @@ function QueryAudit() {
                 <TableRow key={idx} className="border-hairline hover:bg-fill">
                   <TableCell className="py-2">
                     {item.status === "success" ? (
-                      <CircleCheck className="w-3.5 h-3.5 text-emerald-500" />
+                      <CircleCheck className="w-3.5 h-3.5 text-success" />
                     ) : (
-                      <CircleX className="w-3.5 h-3.5 text-red-500" />
+                      <CircleX className="w-3.5 h-3.5 text-danger" />
                     )}
                   </TableCell>
                   <TableCell className="py-2 font-mono text-xs text-fg-muted whitespace-nowrap">
@@ -432,7 +432,7 @@ function AuditStats() {
         </div>
         <div className="rounded-xl border border-hairline bg-panel p-4">
           <div className="text-xs text-fg-muted mb-1">Success Rate</div>
-          <div className="text-2xl font-bold text-emerald-400 tabular-nums">{stats.successRate}%</div>
+          <div className="text-2xl font-bold text-success tabular-nums">{stats.successRate}%</div>
           <Progress value={stats.successRate} className="h-1 mt-2" />
         </div>
         <div className="rounded-xl border border-hairline bg-panel p-4">
@@ -444,7 +444,7 @@ function AuditStats() {
         </div>
         <div className="rounded-xl border border-hairline bg-panel p-4">
           <div className="text-xs text-fg-muted mb-1">Failed</div>
-          <div className="text-2xl font-bold text-red-400 tabular-nums">{stats.total - stats.successful}</div>
+          <div className="text-2xl font-bold text-danger tabular-nums">{stats.total - stats.successful}</div>
         </div>
       </div>
 
@@ -452,7 +452,7 @@ function AuditStats() {
       <div className="grid gap-6 md:grid-cols-2">
         <div className="rounded-xl border border-hairline bg-panel p-5">
           <h3 className="text-sm font-bold text-fg-secondary mb-4 flex items-center gap-2">
-            <Activity className="h-4 w-4 text-blue-400" />
+            <Activity className="h-4 w-4 text-brand" />
             Query Activity (7 days)
           </h3>
           {stats.total === 0 ? (
@@ -480,7 +480,7 @@ function AuditStats() {
         {/* Most Active Connections */}
         <div className="rounded-xl border border-hairline bg-panel p-5">
           <h3 className="text-sm font-bold text-fg-secondary mb-4 flex items-center gap-2">
-            <Clock className="h-4 w-4 text-blue-400" />
+            <Clock className="h-4 w-4 text-brand" />
             Most Active Connections
           </h3>
           {stats.topConnections.length === 0 ? (

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -54,11 +54,11 @@ import { useProviderMetadata } from "@/hooks/use-provider-metadata";
  * `DBCC CHECKDB`, SQLite's `VACUUM`) - see `maintenanceControl` (#496).
  */
 const TABLE_ACTIONS: { type: MaintenanceType; label: string; Icon: LucideIcon; hover: string }[] = [
-  { type: "analyze", label: "Analyze", Icon: Search, hover: "hover:text-yellow-500" },
-  { type: "vacuum", label: "Vacuum", Icon: HardDrive, hover: "hover:text-blue-500" },
-  { type: "optimize", label: "Optimize", Icon: Wrench, hover: "hover:text-blue-500" },
-  { type: "reindex", label: "Reindex", Icon: RefreshCw, hover: "hover:text-purple-500" },
-  { type: "check", label: "Check", Icon: ShieldCheck, hover: "hover:text-green-500" },
+  { type: "analyze", label: "Analyze", Icon: Search, hover: "hover:text-hue-yellow" },
+  { type: "vacuum", label: "Vacuum", Icon: HardDrive, hover: "hover:text-hue-blue" },
+  { type: "optimize", label: "Optimize", Icon: Wrench, hover: "hover:text-hue-blue" },
+  { type: "reindex", label: "Reindex", Icon: RefreshCw, hover: "hover:text-hue-purple" },
+  { type: "check", label: "Check", Icon: ShieldCheck, hover: "hover:text-hue-green" },
 ];
 
 /**
@@ -290,7 +290,9 @@ export function OperationsTab() {
     switch (state) {
       case "active":
         return (
-          <Badge className="bg-green-500/10 text-green-400 border border-green-500/20 text-[0.625rem]">Active</Badge>
+          <Badge className="bg-hue-green-tint/10 text-hue-green border border-hue-green-tint/20 text-[0.625rem]">
+            Active
+          </Badge>
         );
       case "idle":
         return (
@@ -300,12 +302,14 @@ export function OperationsTab() {
         );
       case "idle in transaction":
         return (
-          <Badge className="bg-yellow-500/10 text-yellow-400 border border-yellow-500/20 text-[0.625rem]">
+          <Badge className="bg-hue-yellow-tint/10 text-hue-yellow border border-hue-yellow-tint/20 text-[0.625rem]">
             Idle TX
           </Badge>
         );
       case "idle in transaction (aborted)":
-        return <Badge className="bg-red-500/10 text-red-400 border border-red-500/20 text-[0.625rem]">Abort</Badge>;
+        return (
+          <Badge className="bg-hue-red-tint/10 text-hue-red border border-hue-red-tint/20 text-[0.625rem]">Abort</Badge>
+        );
       default:
         return (
           <Badge variant="outline" className="text-[0.625rem]">
@@ -368,7 +372,7 @@ export function OperationsTab() {
       </div>
 
       {error && !data && (
-        <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-4 text-red-400 text-sm">{error}</div>
+        <div className="rounded-xl border border-danger-tint/20 bg-danger-tint/5 p-4 text-danger text-sm">{error}</div>
       )}
 
       {/* Global Operations — hidden entirely where not one operation has a
@@ -378,7 +382,7 @@ export function OperationsTab() {
       {anyMaintenance && (
         <div>
           <div className="flex items-center gap-2 mb-3">
-            <ShieldAlert className="h-4 w-4 text-blue-400" />
+            <ShieldAlert className="h-4 w-4 text-brand" />
             <h3 className="text-sm font-bold text-fg-secondary">Global Operations</h3>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -386,13 +390,13 @@ export function OperationsTab() {
             {globalAnalyze && (
               <div className="p-4 rounded-xl border border-hairline bg-fill-subtle hover:bg-fill transition-colors">
                 <div className="flex items-start justify-between mb-3">
-                  <div className="w-8 h-8 rounded-lg bg-yellow-500/10 border border-yellow-500/20 flex items-center justify-center">
-                    <Zap className="w-4 h-4 text-yellow-500" />
+                  <div className="w-8 h-8 rounded-lg bg-hue-yellow-tint/10 border border-hue-yellow-tint/20 flex items-center justify-center">
+                    <Zap className="w-4 h-4 text-hue-yellow" />
                   </div>
                   <Button
                     size="sm"
                     variant="outline"
-                    className="h-7 text-xs border-hairline-strong hover:bg-yellow-500/10 hover:text-yellow-500"
+                    className="h-7 text-xs border-hairline-strong hover:bg-hue-yellow-tint/10 hover:text-hue-yellow"
                     onClick={() => handleRunMaintenance("analyze")}
                     disabled={!!actionLoading || !selectedConnection}
                   >
@@ -411,13 +415,13 @@ export function OperationsTab() {
             {globalVacuum && (
               <div className="p-4 rounded-xl border border-hairline bg-fill-subtle hover:bg-fill transition-colors">
                 <div className="flex items-start justify-between mb-3">
-                  <div className="w-8 h-8 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-center">
-                    <HardDrive className="w-4 h-4 text-blue-500" />
+                  <div className="w-8 h-8 rounded-lg bg-hue-blue-tint/10 border border-hue-blue-tint/20 flex items-center justify-center">
+                    <HardDrive className="w-4 h-4 text-hue-blue" />
                   </div>
                   <Button
                     size="sm"
                     variant="outline"
-                    className="h-7 text-xs border-hairline-strong hover:bg-blue-500/10 hover:text-blue-500"
+                    className="h-7 text-xs border-hairline-strong hover:bg-hue-blue-tint/10 hover:text-hue-blue"
                     onClick={() => handleRunMaintenance(vacuumOperation)}
                     disabled={!!actionLoading || !selectedConnection}
                   >
@@ -442,13 +446,13 @@ export function OperationsTab() {
             {globalReindex && (
               <div className="p-4 rounded-xl border border-hairline bg-fill-subtle hover:bg-fill transition-colors">
                 <div className="flex items-start justify-between mb-3">
-                  <div className="w-8 h-8 rounded-lg bg-purple-500/10 border border-purple-500/20 flex items-center justify-center">
-                    <RefreshCw className="w-4 h-4 text-purple-500" />
+                  <div className="w-8 h-8 rounded-lg bg-hue-purple-tint/10 border border-hue-purple-tint/20 flex items-center justify-center">
+                    <RefreshCw className="w-4 h-4 text-hue-purple" />
                   </div>
                   <Button
                     size="sm"
                     variant="outline"
-                    className="h-7 text-xs border-hairline-strong hover:bg-purple-500/10 hover:text-purple-500"
+                    className="h-7 text-xs border-hairline-strong hover:bg-hue-purple-tint/10 hover:text-hue-purple"
                     onClick={() => handleRunMaintenance("reindex")}
                     disabled={!!actionLoading || !selectedConnection}
                   >
@@ -464,12 +468,12 @@ export function OperationsTab() {
             )}
 
             {/* Warning Card */}
-            <div className="p-4 rounded-xl border border-red-500/10 bg-red-500/5 flex flex-col justify-center">
-              <div className="flex items-center gap-2 text-red-400 mb-2">
+            <div className="p-4 rounded-xl border border-danger-tint/10 bg-danger-tint/5 flex flex-col justify-center">
+              <div className="flex items-center gap-2 text-danger mb-2">
                 <ShieldAlert className="w-4 h-4" />
                 <span className="text-xs font-bold uppercase tracking-wider">Warning</span>
               </div>
-              <p className="text-xs text-red-400/70 leading-relaxed italic">
+              <p className="text-xs text-danger/70 leading-relaxed italic">
                 These operations can be resource-intensive. Avoid running them during peak traffic hours.
               </p>
             </div>
@@ -484,7 +488,7 @@ export function OperationsTab() {
           <div className="rounded-xl border border-hairline bg-panel">
             <div className="p-4 border-b border-hairline flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <Table2 className="w-4 h-4 text-blue-400" />
+                <Table2 className="w-4 h-4 text-brand" />
                 <span className="text-xs font-bold text-fg-secondary">
                   {tablesUnavailable ? "Tables" : `Tables (${tables.length})`}
                 </span>
@@ -528,7 +532,7 @@ export function OperationsTab() {
                           {(table.bloatRatio ?? 0) > 10 && (
                             <Badge
                               variant="outline"
-                              className="text-[0.625rem] text-yellow-400 border-yellow-500/20 h-4"
+                              className="text-[0.625rem] text-hue-yellow border-hue-yellow-tint/20 h-4"
                             >
                               {(table.bloatRatio ?? 0).toFixed(0)}% bloat
                             </Badge>
@@ -572,7 +576,7 @@ export function OperationsTab() {
         <div className="rounded-xl border border-hairline bg-panel">
           <div className="p-4 border-b border-hairline">
             <div className="flex items-center gap-2 mb-3">
-              <Users className="w-4 h-4 text-green-400" />
+              <Users className="w-4 h-4 text-hue-green" />
               <span className="text-xs font-bold text-fg-secondary">
                 {sessionsUnavailable ? "Sessions" : `Sessions (${sessions.length})`}
               </span>
@@ -587,13 +591,13 @@ export function OperationsTab() {
                 <div className="text-[0.625rem] text-fg-muted uppercase font-bold">Idle</div>
               </div>
               <div className="rounded-lg bg-fill p-2 text-center">
-                <div className={`text-lg font-bold tabular-nums ${idleInTxCount > 0 ? "text-yellow-400" : "text-fg"}`}>
+                <div className={`text-lg font-bold tabular-nums ${idleInTxCount > 0 ? "text-hue-yellow" : "text-fg"}`}>
                   {idleInTxCount}
                 </div>
                 <div className="text-[0.625rem] text-fg-muted uppercase font-bold">In TX</div>
               </div>
               <div className="rounded-lg bg-fill p-2 text-center">
-                <div className={`text-lg font-bold tabular-nums ${waitingCount > 0 ? "text-orange-400" : "text-fg"}`}>
+                <div className={`text-lg font-bold tabular-nums ${waitingCount > 0 ? "text-hue-orange" : "text-fg"}`}>
                   {waitingCount}
                 </div>
                 <div className="text-[0.625rem] text-fg-muted uppercase font-bold">Wait</div>
@@ -666,7 +670,7 @@ export function OperationsTab() {
                         <Button
                           variant="ghost"
                           size="icon"
-                          className="h-6 w-6 text-fg-subtle hover:text-red-500 hover:bg-red-500/10 opacity-0 group-hover:opacity-100 transition-all"
+                          className="h-6 w-6 text-fg-subtle hover:text-danger hover:bg-danger-tint/10 opacity-0 group-hover:opacity-100 transition-all"
                           onClick={() => handleKillClick(session)}
                           disabled={killingPid === session.pid}
                         >
@@ -711,9 +715,9 @@ export function OperationsTab() {
                 <span className="text-fg-tertiary font-mono truncate">{entry.target}</span>
                 <div className="ml-auto flex items-center gap-2 shrink-0">
                   {entry.result === "success" ? (
-                    <CircleCheck className="w-3 h-3 text-emerald-500" />
+                    <CircleCheck className="w-3 h-3 text-success" />
                   ) : (
-                    <CircleX className="w-3 h-3 text-red-500" />
+                    <CircleX className="w-3 h-3 text-danger" />
                   )}
                   <span className="text-fg-subtle font-mono text-xs">{entry.duration}ms</span>
                 </div>
@@ -745,7 +749,10 @@ export function OperationsTab() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel className="border-hairline-strong text-fg-tertiary">Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmKill} className="bg-red-600 text-white hover:bg-red-500">
+            <AlertDialogAction
+              onClick={handleConfirmKill}
+              className="bg-danger-solid text-white hover:bg-danger-solid-hover"
+            >
               Terminate
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/components/admin/tabs/OverviewTab.tsx
+++ b/src/components/admin/tabs/OverviewTab.tsx
@@ -446,7 +446,7 @@ function HeroStatusBanner({
   const statusText =
     errorCount > 0 ? "Attention Required" : degradedCount > 0 ? "Degraded Performance" : "All Systems Operational";
 
-  const statusColor = errorCount > 0 ? "text-red-400" : degradedCount > 0 ? "text-amber-400" : "text-emerald-400";
+  const statusColor = errorCount > 0 ? "text-danger" : degradedCount > 0 ? "text-warning" : "text-success";
 
   const statusGlow =
     errorCount > 0
@@ -463,8 +463,8 @@ function HeroStatusBanner({
         className={`relative overflow-hidden rounded-2xl border border-hairline bg-gradient-to-br from-panel via-surface to-panel p-6 ${statusGlow}`}
       >
         {/* Decorative blur orbs */}
-        <div className="absolute top-0 left-1/4 w-64 h-64 bg-blue-500/5 rounded-full blur-3xl pointer-events-none" />
-        <div className="absolute bottom-0 right-1/4 w-48 h-48 bg-emerald-500/5 rounded-full blur-3xl pointer-events-none" />
+        <div className="absolute top-0 left-1/4 w-64 h-64 bg-brand-tint/5 rounded-full blur-3xl pointer-events-none" />
+        <div className="absolute bottom-0 right-1/4 w-48 h-48 bg-success-tint/5 rounded-full blur-3xl pointer-events-none" />
 
         <div className="relative flex flex-col md:flex-row gap-6 items-center">
           {/*
@@ -502,11 +502,11 @@ function HeroStatusBanner({
             {/* LIVE badge — in the padding below the ring, clear of the stroke. */}
             <div className="absolute bottom-0 left-1/2 -translate-x-1/2 flex items-center gap-1.5">
               <motion.div
-                className="w-2 h-2 rounded-full bg-emerald-500"
+                className="w-2 h-2 rounded-full bg-success-tint"
                 animate={{ scale: [1, 1.05, 1], opacity: [0.7, 1, 0.7] }}
                 transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
               />
-              <span className="text-[0.625rem] font-bold text-emerald-400 uppercase tracking-widest">Live</span>
+              <span className="text-[0.625rem] font-bold text-success uppercase tracking-widest">Live</span>
             </div>
           </div>
 
@@ -518,17 +518,17 @@ function HeroStatusBanner({
                 <span className={`text-sm font-bold ${statusColor}`}>{statusText}</span>
                 <div className="flex gap-1.5 text-xs">
                   {healthyCount > 0 && (
-                    <Badge variant="outline" className="border-emerald-500/30 text-emerald-400 h-5 text-[0.625rem]">
+                    <Badge variant="outline" className="border-success-tint/30 text-success h-5 text-[0.625rem]">
                       {healthyCount} healthy
                     </Badge>
                   )}
                   {degradedCount > 0 && (
-                    <Badge variant="outline" className="border-amber-500/30 text-amber-400 h-5 text-[0.625rem]">
+                    <Badge variant="outline" className="border-warning-tint/30 text-warning h-5 text-[0.625rem]">
                       {degradedCount} degraded
                     </Badge>
                   )}
                   {errorCount > 0 && (
-                    <Badge variant="outline" className="border-red-500/30 text-red-400 h-5 text-[0.625rem]">
+                    <Badge variant="outline" className="border-danger-tint/30 text-danger h-5 text-[0.625rem]">
                       {errorCount} error
                     </Badge>
                   )}
@@ -555,13 +555,13 @@ function HeroStatusBanner({
 
             {/* Counter Cards */}
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-              <CounterCard icon={Link2} label="Connections" value={animatedConns} suffix="" color="text-blue-400" />
+              <CounterCard icon={Link2} label="Connections" value={animatedConns} suffix="" color="text-hue-blue" />
               <CounterCard
                 icon={Zap}
                 label="Total Queries"
                 value={animatedQueries}
                 suffix=""
-                color="text-purple-400"
+                color="text-hue-purple"
                 formatValue={formatNumber}
               />
               <CounterCard
@@ -569,7 +569,7 @@ function HeroStatusBanner({
                 label="DB Size"
                 value={totalDBSize}
                 suffix={dbSizeExcluded > 0 ? `(${dbSizeExcluded} excluded)` : ""}
-                color="text-emerald-400"
+                color="text-hue-emerald"
                 isString
               />
               <CounterCard
@@ -577,7 +577,7 @@ function HeroStatusBanner({
                 label="Today"
                 value={animatedToday}
                 suffix=""
-                color="text-amber-400"
+                color="text-hue-amber"
                 trend={queryTrend}
               />
             </div>
@@ -620,7 +620,7 @@ function CounterCard({
         {suffix && <span className="text-xs text-fg-muted">{suffix}</span>}
       </div>
       {trend !== undefined && trend !== 0 && (
-        <div className={`flex items-center gap-0.5 mt-1 text-xs ${trend > 0 ? "text-emerald-400" : "text-red-400"}`}>
+        <div className={`flex items-center gap-0.5 mt-1 text-xs ${trend > 0 ? "text-success" : "text-danger"}`}>
           {trend > 0 ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
           <span>
             {trend > 0 ? "+" : ""}
@@ -649,24 +649,24 @@ function FleetHealthSection({
     switch (status) {
       case "healthy":
         return {
-          dot: "bg-emerald-500",
-          border: "border-emerald-500/20 hover:border-emerald-500/40",
+          dot: "bg-success-tint",
+          border: "border-success-tint/20 hover:border-success-tint/40",
           glow: "hover:shadow-[0_0_30px_rgba(16,185,129,0.08)]",
           gradient: "from-emerald-500/60 via-emerald-400/40",
           latencyColor: "#10b981",
         };
       case "degraded":
         return {
-          dot: "bg-amber-500",
-          border: "border-amber-500/20 hover:border-amber-500/40",
+          dot: "bg-warning-tint",
+          border: "border-warning-tint/20 hover:border-warning-tint/40",
           glow: "hover:shadow-[0_0_30px_rgba(245,158,11,0.08)]",
           gradient: "from-amber-500/60 via-amber-400/40",
           latencyColor: "#f59e0b",
         };
       default:
         return {
-          dot: "bg-red-500",
-          border: "border-red-500/20 hover:border-red-500/40",
+          dot: "bg-danger-tint",
+          border: "border-danger-tint/20 hover:border-danger-tint/40",
           glow: "hover:shadow-[0_0_30px_rgba(239,68,68,0.08)]",
           gradient: "from-red-500/60 via-red-400/40",
           latencyColor: "#ef4444",
@@ -677,7 +677,7 @@ function FleetHealthSection({
   return (
     <motion.div variants={itemVariants}>
       <div className="flex items-center gap-2 mb-3">
-        <Radio className="h-4 w-4 text-blue-400" />
+        <Radio className="h-4 w-4 text-brand" />
         <h2 className="text-sm font-bold text-fg-secondary">Fleet Status</h2>
         <span className="text-xs text-fg-subtle">
           {fleetHealth.length} endpoint{fleetHealth.length !== 1 ? "s" : ""}
@@ -777,7 +777,7 @@ function FleetHealthSection({
                   )}
                 </div>
 
-                {item.error && <div className="text-red-400 text-xs truncate mt-1.5">{item.error}</div>}
+                {item.error && <div className="text-danger text-xs truncate mt-1.5">{item.error}</div>}
               </motion.a>
             );
           })}
@@ -805,7 +805,7 @@ function KeyMetricsSection({
   return (
     <motion.div variants={itemVariants}>
       <div className="flex items-center gap-2 mb-3">
-        <Gauge className="h-4 w-4 text-blue-400" />
+        <Gauge className="h-4 w-4 text-brand" />
         <h2 className="text-sm font-bold text-fg-secondary">Key Metrics</h2>
       </div>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
@@ -896,13 +896,13 @@ function MetricBigNumber({
 
   return (
     <div className="rounded-xl border border-hairline bg-fill-subtle p-4 flex flex-col items-center justify-center">
-      <div className="p-2 rounded-lg bg-purple-500/10 mb-2">
-        <Icon className="w-5 h-5 text-purple-400" />
+      <div className="p-2 rounded-lg bg-hue-purple-tint/10 mb-2">
+        <Icon className="w-5 h-5 text-hue-purple" />
       </div>
       <span className="text-3xl font-bold text-fg tabular-nums">{formatNumber(animatedValue)}</span>
       <span className="text-xs text-fg-muted mt-1 uppercase tracking-wider">{label}</span>
       {trend !== 0 && (
-        <div className={`flex items-center gap-0.5 mt-1.5 text-xs ${trend > 0 ? "text-emerald-400" : "text-red-400"}`}>
+        <div className={`flex items-center gap-0.5 mt-1.5 text-xs ${trend > 0 ? "text-success" : "text-danger"}`}>
           {trend > 0 ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
           <span>
             {trend > 0 ? "+" : ""}
@@ -931,7 +931,7 @@ function AnalyticsSection({
         {/* Gradient AreaChart */}
         <div className="rounded-xl border border-hairline bg-panel p-5">
           <h3 className="text-sm font-bold text-fg-secondary mb-4 flex items-center gap-2">
-            <Activity className="h-4 w-4 text-blue-400" />
+            <Activity className="h-4 w-4 text-brand" />
             Query Volume (7 days)
           </h3>
           {queryStats.total === 0 ? (
@@ -988,7 +988,7 @@ function AnalyticsSection({
         {/* Recent Activity Feed */}
         <div className="rounded-xl border border-hairline bg-panel p-5">
           <h3 className="text-sm font-bold text-fg-secondary mb-4 flex items-center gap-2">
-            <Clock className="h-4 w-4 text-blue-400" />
+            <Clock className="h-4 w-4 text-brand" />
             Recent Activity
           </h3>
           {activityFeed.length === 0 ? (
@@ -1018,9 +1018,9 @@ function AnalyticsSection({
                     </div>
                     <div className="flex items-center gap-1.5 flex-shrink-0">
                       {item.status === "success" ? (
-                        <CircleCheck className="w-3 h-3 text-emerald-500" />
+                        <CircleCheck className="w-3 h-3 text-success" />
                       ) : (
-                        <CircleX className="w-3 h-3 text-red-500" />
+                        <CircleX className="w-3 h-3 text-danger" />
                       )}
                       <span className="text-xs text-fg-subtle whitespace-nowrap">{formatRelativeTime(item.time)}</span>
                     </div>
@@ -1045,8 +1045,8 @@ function QuickActionsSection() {
       icon: Wrench,
       href: "/admin/operations",
       gradient: "from-blue-500/20 to-cyan-500/20",
-      iconColor: "text-blue-400",
-      borderColor: "hover:border-blue-500/30",
+      iconColor: "text-hue-blue",
+      borderColor: "hover:border-hue-blue-tint/30",
     },
     {
       label: "Security & Masking",
@@ -1054,8 +1054,8 @@ function QuickActionsSection() {
       icon: Shield,
       href: "/admin/security",
       gradient: "from-emerald-500/20 to-teal-500/20",
-      iconColor: "text-emerald-400",
-      borderColor: "hover:border-emerald-500/30",
+      iconColor: "text-hue-emerald",
+      borderColor: "hover:border-hue-emerald-tint/30",
     },
     {
       label: "Real-time Monitoring",
@@ -1063,15 +1063,15 @@ function QuickActionsSection() {
       icon: Activity,
       href: "/admin/monitoring",
       gradient: "from-purple-500/20 to-pink-500/20",
-      iconColor: "text-purple-400",
-      borderColor: "hover:border-purple-500/30",
+      iconColor: "text-hue-purple",
+      borderColor: "hover:border-hue-purple-tint/30",
     },
   ];
 
   return (
     <motion.div variants={itemVariants}>
       <div className="flex items-center gap-2 mb-3">
-        <Sparkles className="h-4 w-4 text-blue-400" />
+        <Sparkles className="h-4 w-4 text-brand" />
         <h2 className="text-sm font-bold text-fg-secondary">Quick Actions</h2>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -1130,12 +1130,12 @@ function EmptyState() {
     <div className="relative min-h-[70vh] flex flex-col items-center justify-center px-4">
       {/* Animated breathing orbs */}
       <motion.div
-        className="absolute top-1/4 left-1/3 w-72 h-72 bg-blue-500/5 rounded-full blur-3xl pointer-events-none"
+        className="absolute top-1/4 left-1/3 w-72 h-72 bg-brand-tint/5 rounded-full blur-3xl pointer-events-none"
         animate={{ scale: [1, 1.2, 1], opacity: [0.3, 0.5, 0.3] }}
         transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
       />
       <motion.div
-        className="absolute bottom-1/4 right-1/3 w-56 h-56 bg-emerald-500/5 rounded-full blur-3xl pointer-events-none"
+        className="absolute bottom-1/4 right-1/3 w-56 h-56 bg-success-tint/5 rounded-full blur-3xl pointer-events-none"
         animate={{ scale: [1.2, 1, 1.2], opacity: [0.3, 0.5, 0.3] }}
         transition={{ duration: 8, repeat: Infinity, ease: "easeInOut", delay: 2 }}
       />
@@ -1148,7 +1148,7 @@ function EmptyState() {
       >
         {/* Database icon with pulse glow */}
         <motion.div variants={itemVariants} className="relative mb-6">
-          <div className="absolute inset-0 w-20 h-20 bg-blue-500/20 rounded-full blur-xl" />
+          <div className="absolute inset-0 w-20 h-20 bg-brand-tint/20 rounded-full blur-xl" />
           <motion.div
             className="relative p-5 rounded-2xl border border-hairline-strong bg-panel"
             animate={{
@@ -1160,7 +1160,7 @@ function EmptyState() {
             }}
             transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
           >
-            <Database className="w-10 h-10 text-blue-400" />
+            <Database className="w-10 h-10 text-brand" />
           </motion.div>
         </motion.div>
 
@@ -1182,8 +1182,8 @@ function EmptyState() {
               variants={itemVariants}
               className="rounded-xl border border-hairline bg-fill-subtle p-4 text-center"
             >
-              <div className="p-2 rounded-lg bg-blue-500/10 w-fit mx-auto mb-2">
-                <f.icon className="w-5 h-5 text-blue-400" />
+              <div className="p-2 rounded-lg bg-brand-tint/10 w-fit mx-auto mb-2">
+                <f.icon className="w-5 h-5 text-brand" />
               </div>
               <div className="text-sm font-bold text-fg mb-1">{f.label}</div>
               <div className="text-xs text-fg-muted">{f.description}</div>
@@ -1195,7 +1195,7 @@ function EmptyState() {
         <motion.div variants={itemVariants}>
           <Button
             asChild
-            className="bg-blue-600 hover:bg-blue-500 text-white px-6 py-2.5 shadow-[0_0_30px_rgba(59,130,246,0.3)] hover:shadow-[0_0_40px_rgba(59,130,246,0.4)] transition-all"
+            className="bg-brand-solid hover:bg-brand-solid-hover text-white px-6 py-2.5 shadow-[0_0_30px_rgba(59,130,246,0.3)] hover:shadow-[0_0_40px_rgba(59,130,246,0.4)] transition-all"
           >
             <Link href="/">Connect Your First Database</Link>
           </Button>

--- a/src/components/admin/tabs/SecurityTab.tsx
+++ b/src/components/admin/tabs/SecurityTab.tsx
@@ -31,21 +31,21 @@ export function SecurityTab() {
         <TabsList className="bg-transparent border-b border-hairline rounded-none p-0 h-10 w-full justify-start">
           <TabsTrigger
             value="masking"
-            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-blue-400 data-[state=active]:bg-transparent data-[state=active]:text-blue-400 text-fg-muted text-xs px-4"
+            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-brand data-[state=active]:bg-transparent data-[state=active]:text-brand text-fg-muted text-xs px-4"
           >
             <EyeOff className="h-3.5 w-3.5" />
             {MASKING_TAB_LABEL}
           </TabsTrigger>
           <TabsTrigger
             value="access"
-            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-blue-400 data-[state=active]:bg-transparent data-[state=active]:text-blue-400 text-fg-muted text-xs px-4"
+            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-brand data-[state=active]:bg-transparent data-[state=active]:text-brand text-fg-muted text-xs px-4"
           >
             <Lock className="h-3.5 w-3.5" />
             {ACCESS_TAB_LABEL}
           </TabsTrigger>
           <TabsTrigger
             value="thresholds"
-            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-blue-400 data-[state=active]:bg-transparent data-[state=active]:text-blue-400 text-fg-muted text-xs px-4"
+            className="gap-2 rounded-none border-b-2 border-transparent data-[state=active]:border-brand data-[state=active]:bg-transparent data-[state=active]:text-brand text-fg-muted text-xs px-4"
           >
             <Activity className="h-3.5 w-3.5" />
             {THRESHOLDS_TAB_LABEL}
@@ -73,7 +73,7 @@ function AccessSummary() {
     <div className="grid gap-6 md:grid-cols-2">
       <div className="rounded-xl border border-hairline bg-panel p-5 space-y-3">
         <h3 className="text-sm font-bold text-fg-secondary flex items-center gap-2">
-          <Lock className="h-4 w-4 text-blue-400" />
+          <Lock className="h-4 w-4 text-brand" />
           {ACCESS_CARD_TITLE}
         </h3>
         <div className="space-y-3 text-sm">
@@ -92,11 +92,11 @@ function AccessSummary() {
           <Separator className="bg-fill" />
           <div className="flex items-center justify-between">
             <span className="text-fg-muted">Admin Access</span>
-            <Badge className="bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 text-xs">ENABLED</Badge>
+            <Badge className="bg-success-tint/10 text-success border border-success-tint/20 text-xs">ENABLED</Badge>
           </div>
           <div className="flex items-center justify-between">
             <span className="text-fg-muted">User Access</span>
-            <Badge className="bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 text-xs">ENABLED</Badge>
+            <Badge className="bg-success-tint/10 text-success border border-success-tint/20 text-xs">ENABLED</Badge>
           </div>
         </div>
       </div>
@@ -160,16 +160,16 @@ function ThresholdSettings() {
 
   const getSliderColors = (threshold: ThresholdConfig) => {
     if (threshold.direction === "above") {
-      return { warn: "text-amber-400", crit: "text-red-400" };
+      return { warn: "text-warning", crit: "text-danger" };
     }
-    return { warn: "text-amber-400", crit: "text-red-400" };
+    return { warn: "text-warning", crit: "text-danger" };
   };
 
   return (
     <div className="space-y-6">
       <div className="rounded-xl border border-hairline bg-panel p-5">
         <h3 className="text-sm font-bold text-fg-secondary mb-4 flex items-center gap-2">
-          <Activity className="h-4 w-4 text-blue-400" />
+          <Activity className="h-4 w-4 text-brand" />
           {THRESHOLDS_CARD_TITLE}
         </h3>
         <p className="text-xs text-fg-muted mb-6">{THRESHOLDS_DESCRIPTION}</p>
@@ -203,7 +203,7 @@ function ThresholdSettings() {
                       onValueChange={(v) => updateThreshold(index, "warning", v[0])}
                       max={max}
                       step={1}
-                      className="[&_[role=slider]]:bg-amber-500 [&_[role=slider]]:border-amber-500"
+                      className="[&_[role=slider]]:bg-warning-tint [&_[role=slider]]:border-warning-tint"
                     />
                   </div>
 
@@ -220,7 +220,7 @@ function ThresholdSettings() {
                       onValueChange={(v) => updateThreshold(index, "critical", v[0])}
                       max={max}
                       step={1}
-                      className="[&_[role=slider]]:bg-red-500 [&_[role=slider]]:border-red-500"
+                      className="[&_[role=slider]]:bg-danger-tint [&_[role=slider]]:border-danger-tint"
                     />
                   </div>
                 </div>
@@ -238,7 +238,7 @@ function ThresholdSettings() {
           </Button>
           <Button
             size="sm"
-            className="bg-blue-600 hover:bg-blue-500 text-white"
+            className="bg-brand-solid hover:bg-brand-solid-hover text-white"
             onClick={handleSave}
             disabled={!hasChanges}
           >

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -164,9 +164,9 @@ export interface AgentRailProps {
 
 const TONE_CLASSES: Readonly<Record<AgentTimelineTone, string>> = {
   neutral: "bg-fg-subtle",
-  progress: "bg-blue-400",
-  refused: "bg-amber-400",
-  done: "bg-emerald-400",
+  progress: "bg-brand",
+  refused: "bg-warning",
+  done: "bg-success",
 };
 
 const MODE_LABELS: Readonly<Record<AgentRunMode, string>> = {
@@ -540,7 +540,7 @@ function PlanStatementCard({ draft }: { readonly draft: AgentPlanStatementView }
       data-read-only={!draft.guardApplicable ? "unexamined" : draft.readOnly ? "true" : "false"}
       className={cn(
         "mt-1 ml-3.5 rounded border p-1.5",
-        draft.readOnly ? "border-hairline-strong" : "border-amber-400/50 bg-amber-500/5",
+        draft.readOnly ? "border-hairline-strong" : "border-warning/50 bg-warning-tint/5",
       )}
     >
       {/*
@@ -550,7 +550,7 @@ function PlanStatementCard({ draft }: { readonly draft: AgentPlanStatementView }
       */}
       <p
         data-testid="agent-plan-statement-summary"
-        className={cn("text-[0.625rem]", guardReading(draft) === "checked" ? "text-fg-muted" : "text-amber-300")}
+        className={cn("text-[0.625rem]", guardReading(draft) === "checked" ? "text-fg-muted" : "text-warning-bright")}
       >
         {guardSummaryLine(draft)} The statement, what the name check found and what applying it would and would not
         establish are in the answer at the top of this rail.
@@ -666,7 +666,7 @@ function TimelineEntryBody({
         (item.planRefusal === true ? (
           <section
             data-testid="agent-plan-refusal"
-            className="mt-1 ml-3.5 rounded border border-amber-400/40 bg-amber-500/5 p-1.5"
+            className="mt-1 ml-3.5 rounded border border-warning/40 bg-warning-tint/5 p-1.5"
           >
             {/*
               Says only that the run could not draft, never WHY — the two reasons
@@ -678,7 +678,7 @@ function TimelineEntryBody({
               because there was no inventory at all. The earlier wording named "the schema it read",
               which on the second path is a reading that never happened.
             */}
-            <p className="text-[0.625rem] text-amber-300">
+            <p className="text-[0.625rem] text-warning-bright">
               This run drafted no statement. What it says is missing, and what it needs from you, are in its own words
               below.
             </p>
@@ -716,11 +716,7 @@ function TimelineEntryBody({
       {declinedHandovers
         .filter((declined) => declined.id === item.id)
         .map((declined) => (
-          <p
-            key={declined.id}
-            data-testid="agent-handover-declined"
-            className="mt-0.5 pl-3.5 text-xs text-amber-400/80"
-          >
+          <p key={declined.id} data-testid="agent-handover-declined" className="mt-0.5 pl-3.5 text-xs text-warning/80">
             It was not run: this run was opened on {declined.openedOn ?? "another connection"} and your editor has moved
             to a different one since. The answer would have arrived in a tab that is connected somewhere else, so
             nothing was executed. The statement is below — take it yourself if you want it on the connection you are on
@@ -1963,7 +1959,7 @@ export function AgentRail({
     <div className="flex flex-col h-full min-h-0 bg-surface text-fg">
       <div className="flex items-center justify-between gap-2 px-3 h-9 border-b border-hairline shrink-0">
         <div className="flex items-center gap-2 min-w-0">
-          <Bot strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />
+          <Bot strokeWidth={1.5} className="w-3.5 h-3.5 text-brand" />
           <span className="text-xs font-medium text-fg-secondary">Agent</span>
           {connectionName !== null && <span className="text-xs text-fg-subtle truncate">on {connectionName}</span>}
         </div>
@@ -1986,7 +1982,7 @@ export function AgentRail({
               onClick={() => setMode(candidate)}
               className={cn(
                 "px-2 py-0.5 rounded text-xs font-normal transition-colors disabled:opacity-40 disabled:hover:bg-transparent",
-                mode === candidate ? "bg-blue-500/15 text-blue-300" : "text-fg-muted hover:bg-fill",
+                mode === candidate ? "bg-brand-tint/15 text-brand-bright" : "text-fg-muted hover:bg-fill",
               )}
             >
               {MODE_LABELS[candidate]}
@@ -2048,7 +2044,7 @@ export function AgentRail({
               onChange={(e) => setObjective(e.target.value)}
               maxLength={AGENT_MAX_OBJECTIVE_LENGTH}
               rows={3}
-              className="mt-1 w-full resize-none rounded bg-sunken border border-hairline-strong px-2 py-1.5 text-xs text-fg placeholder:text-fg-subtle focus:outline-none focus:border-blue-500/40"
+              className="mt-1 w-full resize-none rounded bg-sunken border border-hairline-strong px-2 py-1.5 text-xs text-fg placeholder:text-fg-subtle focus:outline-none focus:border-brand-tint/40"
               placeholder="Why is checkout slow?"
             />
           </>
@@ -2124,7 +2120,7 @@ export function AgentRail({
                 prefilledObjective.current = offeredObjective;
                 setOfferedObjective(null);
               }}
-              className="ml-1 px-1 py-0.5 rounded text-[0.625rem] text-blue-300 hover:bg-fill transition-colors"
+              className="ml-1 px-1 py-0.5 rounded text-[0.625rem] text-brand-bright hover:bg-fill transition-colors"
             >
               Replace
             </button>
@@ -2189,7 +2185,9 @@ export function AgentRail({
                       onClick={() => setWorkflowChoice(candidate)}
                       className={cn(
                         "px-2 py-0.5 rounded text-xs font-normal transition-colors disabled:opacity-40 disabled:hover:bg-transparent",
-                        workflowChoice === candidate ? "bg-blue-500/15 text-blue-300" : "text-fg-muted hover:bg-fill",
+                        workflowChoice === candidate
+                          ? "bg-brand-tint/15 text-brand-bright"
+                          : "text-fg-muted hover:bg-fill",
                       )}
                     >
                       {candidate === "automatic" ? "Automatic" : WORKFLOW_LABELS[candidate]}
@@ -2216,16 +2214,12 @@ export function AgentRail({
         */}
         {connectionId === null &&
           (connection?.reason === "seed-config-unreadable" ? (
-            <p
-              data-testid="agent-seed-config-unreadable"
-              data-tone="warning"
-              className="mt-2 text-xs text-amber-400/80"
-            >
+            <p data-testid="agent-seed-config-unreadable" data-tone="warning" className="mt-2 text-xs text-warning/80">
               The server could not read its own connection configuration, so it cannot resolve a connection for a run.
               This is not a problem with {connectionName ?? "this connection"} — the server log says what failed.
             </p>
           ) : (
-            <p data-testid="agent-unresolvable-connection" className="mt-2 text-xs text-amber-400/80">
+            <p data-testid="agent-unresolvable-connection" className="mt-2 text-xs text-warning/80">
               {connectionName ?? "This connection"} cannot be rebuilt on the server: its settings live in this browser.
               A run re-resolves its connection there after a restart, so it can only investigate a connection the server
               holds too.
@@ -2239,7 +2233,7 @@ export function AgentRail({
           uses, so the two can never disagree.
         */}
         {run.timeline.failureReason !== null && (
-          <p data-testid="agent-failure-reason" className="mt-2 text-[0.625rem] text-rose-300">
+          <p data-testid="agent-failure-reason" className="mt-2 text-[0.625rem] text-hue-rose-alt">
             {describeFailureReason(run.timeline.failureReason)}
           </p>
         )}
@@ -2336,7 +2330,7 @@ export function AgentRail({
               evicted, so an offer this rail cannot keep would be worse than the notice.
             */}
             {interruptedThread !== null && (
-              <p data-testid="agent-thread-ended" className="text-amber-400/80">
+              <p data-testid="agent-thread-ended" className="text-warning/80">
                 {`The conversation this browser was in (${interruptedThread.steps} question${
                   interruptedThread.steps === 1 ? "" : "s"
                 }, ${interruptedThread.threadId}) ended when the page reloaded. Your next question starts a new one.`}
@@ -2350,7 +2344,7 @@ export function AgentRail({
                     type="button"
                     data-testid="agent-thread-new"
                     onClick={() => setStartFresh(true)}
-                    className="ml-1 px-1 py-0.5 rounded text-[0.625rem] text-blue-300 hover:bg-fill transition-colors"
+                    className="ml-1 px-1 py-0.5 rounded text-[0.625rem] text-brand-bright hover:bg-fill transition-colors"
                   >
                     new conversation
                   </button>
@@ -2367,19 +2361,19 @@ export function AgentRail({
               </>
             )}
             {startFresh && (
-              <p data-testid="agent-thread-fresh-pending" className="mt-1 text-blue-300/90">
+              <p data-testid="agent-thread-fresh-pending" className="mt-1 text-brand-bright/90">
                 Your next question will start a new conversation.
                 <button
                   type="button"
                   onClick={() => setStartFresh(false)}
-                  className="ml-1 px-1 py-0.5 rounded text-[0.625rem] text-blue-300 hover:bg-fill transition-colors"
+                  className="ml-1 px-1 py-0.5 rounded text-[0.625rem] text-brand-bright hover:bg-fill transition-colors"
                 >
                   keep it
                 </button>
               </p>
             )}
             {declineNotice !== null && (
-              <p data-testid="agent-thread-notice" className="mt-1 text-amber-400/80">
+              <p data-testid="agent-thread-notice" className="mt-1 text-warning/80">
                 {declineNotice}
               </p>
             )}
@@ -2396,7 +2390,7 @@ export function AgentRail({
                   aria-expanded={changeOpen}
                   aria-controls="agent-change-workflow"
                   onClick={() => setChangeOpen((open) => !open)}
-                  className="ml-1 px-1 py-0.5 rounded text-[0.625rem] text-blue-300 hover:bg-fill transition-colors"
+                  className="ml-1 px-1 py-0.5 rounded text-[0.625rem] text-brand-bright hover:bg-fill transition-colors"
                 >
                   change
                 </button>
@@ -2434,7 +2428,7 @@ export function AgentRail({
               nothing, and why that is the safe answer.
             */}
             {replaceFailed && (
-              <p role="alert" data-testid="agent-change-failed" className="mt-1 text-amber-400/80">
+              <p role="alert" data-testid="agent-change-failed" className="mt-1 text-warning/80">
                 This run was not stopped, so nothing new was opened: it is still going and still spending its budget.
                 The line above is what the server answered. Ask again, or use Stop and start a new run once it has
                 ended.
@@ -2462,16 +2456,16 @@ export function AgentRail({
         {engineUnsupported && (
           <div
             data-testid="agent-engine-unsupported-notice"
-            className="mt-2 rounded border border-amber-400/40 bg-amber-500/5 p-2 space-y-1"
+            className="mt-2 rounded border border-warning/40 bg-warning-tint/5 p-2 space-y-1"
           >
-            <p className="flex items-start gap-1 text-xs text-amber-300">
+            <p className="flex items-start gap-1 text-xs text-warning-bright">
               <TriangleAlert strokeWidth={1.5} className="mt-px w-3 h-3 shrink-0" aria-hidden="true" />
               {selectionPosture.title}
             </p>
             <p
               id={ENGINE_UNSUPPORTED_REASON_ID}
               data-testid="agent-engine-unsupported-reason"
-              className="text-[0.625rem] text-amber-300/90"
+              className="text-[0.625rem] text-warning-bright/90"
             >
               {selectionPosture.body}
             </p>
@@ -2479,7 +2473,7 @@ export function AgentRail({
               type="button"
               data-testid="agent-engine-unsupported-plan"
               onClick={() => setMode("planning")}
-              className="px-1.5 py-0.5 rounded text-[0.625rem] text-blue-300 hover:bg-fill transition-colors"
+              className="px-1.5 py-0.5 rounded text-[0.625rem] text-brand-bright hover:bg-fill transition-colors"
             >
               Switch to Plan
             </button>
@@ -2502,7 +2496,7 @@ export function AgentRail({
                 type="button"
                 data-testid="agent-stop"
                 onClick={() => void run.cancel()}
-                className="flex items-center gap-1 px-2 py-1 rounded text-xs bg-amber-500/15 text-amber-300 hover:bg-amber-500/25 transition-colors"
+                className="flex items-center gap-1 px-2 py-1 rounded text-xs bg-warning-tint/15 text-warning-bright hover:bg-warning-tint/25 transition-colors"
               >
                 <Square strokeWidth={1.5} className="w-3 h-3" />
                 Stop
@@ -2514,7 +2508,7 @@ export function AgentRail({
               data-testid="agent-start"
               disabled={!canStart}
               onClick={() => void handleStart()}
-              className="flex items-center gap-1 px-2 py-1 rounded text-xs bg-blue-500/15 text-blue-300 hover:bg-blue-500/25 disabled:opacity-40 disabled:hover:bg-blue-500/15 transition-colors"
+              className="flex items-center gap-1 px-2 py-1 rounded text-xs bg-brand-tint/15 text-brand-bright hover:bg-brand-tint/25 disabled:opacity-40 disabled:hover:bg-brand-tint/15 transition-colors"
             >
               {run.isBusy || classifying ? (
                 <LoaderCircle strokeWidth={1.5} className="w-3 h-3 animate-spin" />
@@ -2587,14 +2581,17 @@ export function AgentRail({
           <div
             role="alert"
             data-testid="agent-model-refusal"
-            className="mt-2 p-2 rounded border border-red-500/30 bg-red-500/5 space-y-1"
+            className="mt-2 p-2 rounded border border-danger-tint/30 bg-danger-tint/5 space-y-1"
           >
-            <p className="text-xs text-red-300">This model cannot drive an agent run.</p>
+            <p className="text-xs text-danger-bright">This model cannot drive an agent run.</p>
             {modelRefusal.missing.length > 0 && (
               <div data-testid="agent-model-refusal-missing" className="flex flex-wrap items-center gap-1">
                 <span className="text-[0.625rem] text-fg-tertiary">The probe could not establish:</span>
                 {modelRefusal.missing.map((capability) => (
-                  <span key={capability} className="px-1 py-0.5 rounded bg-red-500/10 text-[0.625rem] text-red-200/90">
+                  <span
+                    key={capability}
+                    className="px-1 py-0.5 rounded bg-danger-tint/10 text-[0.625rem] text-danger-bright/90"
+                  >
                     {describeAgentCapability(capability)}
                   </span>
                 ))}
@@ -2616,7 +2613,7 @@ export function AgentRail({
                 type="button"
                 data-testid="agent-model-refusal-use-planning"
                 onClick={() => setMode("planning")}
-                className="px-1.5 py-0.5 rounded text-[0.625rem] text-blue-300 hover:bg-fill transition-colors"
+                className="px-1.5 py-0.5 rounded text-[0.625rem] text-brand-bright hover:bg-fill transition-colors"
               >
                 Switch to Plan mode
               </button>
@@ -2628,7 +2625,7 @@ export function AgentRail({
           <p
             role="alert"
             data-testid="agent-error"
-            className="mt-2 text-xs text-red-400"
+            className="mt-2 text-xs text-danger"
             /*
               "The notice above" is a positional claim, and a positional claim is false for
               a reader who is not looking at the panel. Set on exactly the branch where the
@@ -2701,7 +2698,7 @@ export function AgentRail({
                 <div className="mt-1 h-0.5 rounded-full bg-fill">
                   <div
                     data-testid={`agent-budget-${gauge.id}-bar`}
-                    className="h-full rounded-full bg-blue-400/60"
+                    className="h-full rounded-full bg-brand/60"
                     style={{ width: `${gaugeFraction(gauge)}%` }}
                   />
                 </div>

--- a/src/components/agent/AnswerCard.tsx
+++ b/src/components/agent/AnswerCard.tsx
@@ -96,11 +96,11 @@ const EYEBROWS: Readonly<Record<AnswerState, string>> = Object.freeze({
  * with a union that lives on the server.
  */
 const STATUS_TONES: Readonly<Record<AgentRunStatus, string>> = Object.freeze({
-  queued: "bg-blue-500/10 text-blue-300",
-  running: "bg-blue-500/10 text-blue-300",
-  succeeded: "bg-emerald-500/10 text-emerald-300",
-  failed: "bg-rose-500/10 text-rose-300",
-  cancelled: "bg-amber-500/10 text-amber-300",
+  queued: "bg-brand-tint/10 text-brand-bright",
+  running: "bg-brand-tint/10 text-brand-bright",
+  succeeded: "bg-success-tint/10 text-success-bright",
+  failed: "bg-hue-rose-tint/10 text-hue-rose-alt",
+  cancelled: "bg-warning-tint/10 text-warning-bright",
 });
 
 /**
@@ -117,10 +117,10 @@ type StatementLanguage = "sql" | "json" | "libredb" | "redis" | "unknown";
  * takes the hairline, which says nothing, because nothing is what is known.
  */
 const LANGUAGE_ACCENTS: Readonly<Record<StatementLanguage, string>> = Object.freeze({
-  sql: "border-blue-400/40",
-  json: "border-cyan-400/40",
-  redis: "border-fuchsia-400/40",
-  libredb: "border-violet-400/40",
+  sql: "border-hue-blue/40",
+  json: "border-hue-cyan/40",
+  redis: "border-hue-fuchsia/40",
+  libredb: "border-hue-violet/40",
   unknown: "border-hairline-strong",
 });
 
@@ -154,10 +154,10 @@ function statementLanguage(
  */
 const GUARD_CHIPS: Readonly<Record<GuardReading, { readonly label: string; readonly className: string }>> =
   Object.freeze({
-    checked: { label: "Read-only", className: "text-emerald-300" },
+    checked: { label: "Read-only", className: "text-success-bright" },
     // The timeline's own headline for this state, in its own words.
-    objected: { label: "not classified as a read", className: "text-amber-300" },
-    unexamined: { label: "not checked", className: "text-amber-300" },
+    objected: { label: "not classified as a read", className: "text-warning-bright" },
+    unexamined: { label: "not checked", className: "text-warning-bright" },
   });
 
 /*
@@ -336,7 +336,7 @@ function GuardLine({ draft }: { readonly draft: AgentPlanStatementView }) {
     <p
       className={cn(
         "mt-1 flex items-start gap-1 text-[0.625rem]",
-        reading === "checked" ? "text-fg-muted" : "text-amber-300",
+        reading === "checked" ? "text-fg-muted" : "text-warning-bright",
       )}
     >
       {reading !== "checked" && (
@@ -399,7 +399,7 @@ function PlanChips({
         >
           {unknown.map((name) => (
             <li key={name}>
-              <Chip testId="agent-answer-chip-name" className="font-mono text-amber-200">
+              <Chip testId="agent-answer-chip-name" className="font-mono text-warning-bright">
                 {name}
               </Chip>
             </li>
@@ -528,8 +528,11 @@ function FailureNote({
   readonly onRetry: (() => void) | undefined;
 }) {
   return (
-    <div data-testid="agent-answer-failed" className="mt-1.5 rounded border border-rose-500/40 bg-rose-500/5 p-2">
-      <p className="flex items-center gap-1 text-xs text-rose-300">
+    <div
+      data-testid="agent-answer-failed"
+      className="mt-1.5 rounded border border-hue-rose-tint/40 bg-hue-rose-tint/5 p-2"
+    >
+      <p className="flex items-center gap-1 text-xs text-hue-rose-alt">
         <TriangleAlert strokeWidth={1.5} className="w-3 h-3 shrink-0" aria-hidden="true" />
         Run failed
       </p>
@@ -542,7 +545,7 @@ function FailureNote({
           type="button"
           data-testid="agent-answer-retry"
           onClick={onRetry}
-          className="mt-1 flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] text-blue-300 hover:bg-fill transition-colors"
+          className="mt-1 flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] text-brand-bright hover:bg-fill transition-colors"
         >
           <RotateCcw strokeWidth={1.5} className="w-3 h-3" />
           Retry
@@ -593,7 +596,7 @@ function PlanAnswer({
             onClick={() => onApplyStatement(draft.sql)}
             className={cn(
               "flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] transition-colors hover:bg-fill",
-              draft.readOnly ? "bg-blue-500/15 text-blue-300" : "bg-amber-500/15 text-amber-300",
+              draft.readOnly ? "bg-brand-tint/15 text-brand-bright" : "bg-warning-tint/15 text-warning-bright",
             )}
           >
             <PencilLine strokeWidth={1.5} className="w-3 h-3" />
@@ -679,7 +682,7 @@ function ReportAnswer({
                     takes the panel sideways instead — which is the failure the statement
                     blocks in this same card were changed to avoid.
                   */
-                  className={cn("font-mono whitespace-normal", citation.resolved ? undefined : "text-amber-300")}
+                  className={cn("font-mono whitespace-normal", citation.resolved ? undefined : "text-warning-bright")}
                 >
                   {/*
                     The identifier at chip length, never the whole one: a correlation id
@@ -745,7 +748,7 @@ function ReportAnswer({
         <div className="mt-1 space-y-1.5">
           {citations.map((citation) => (
             <div key={citation.id} data-testid="agent-answer-evidence-citation" className="text-[0.625rem]">
-              <span className={citation.resolved ? "text-fg-tertiary" : "text-amber-300"}>{citation.label}</span>
+              <span className={citation.resolved ? "text-fg-tertiary" : "text-warning-bright"}>{citation.label}</span>
               <span className="ml-1 text-fg-subtle">{citation.detail}</span>
               {citation.quoted !== undefined && (
                 <QuotedBlock text={citation.quoted} testId="agent-answer-citation-quoted-copy" className="mt-0.5" />
@@ -769,12 +772,12 @@ function ReportAnswer({
  */
 function RefusedAnswer({ prose }: { readonly prose: string }) {
   return (
-    <div data-testid="agent-answer-refused" className="mt-1.5 rounded border border-amber-400/40 bg-amber-500/5 p-2">
-      <p className="flex items-center gap-1 text-xs text-amber-300">
+    <div data-testid="agent-answer-refused" className="mt-1.5 rounded border border-warning/40 bg-warning-tint/5 p-2">
+      <p className="flex items-center gap-1 text-xs text-warning-bright">
         <TriangleAlert strokeWidth={1.5} className="w-3 h-3 shrink-0" aria-hidden="true" />
         No statement drafted
       </p>
-      <p data-testid="agent-answer-refusal-note" className="mt-1 text-[0.625rem] text-amber-300/90">
+      <p data-testid="agent-answer-refusal-note" className="mt-1 text-[0.625rem] text-warning-bright/90">
         {REFUSAL_NOTE}
       </p>
       {/* The marker it was read by is already stripped: it is a protocol token the model
@@ -821,7 +824,7 @@ function RunningAnswer({
       <div className="mt-1 h-0.5 rounded-full bg-fill">
         <div
           data-testid="agent-answer-progress"
-          className="h-full rounded-full bg-blue-400/60"
+          className="h-full rounded-full bg-brand/60"
           style={{ width: `${budgetFraction(timeline.budget)}%` }}
         />
       </div>
@@ -840,7 +843,7 @@ function RunningAnswer({
             type="button"
             data-testid="agent-answer-stop"
             onClick={onStop}
-            className="flex items-center gap-1 rounded bg-amber-500/15 px-1.5 py-0.5 text-[0.625rem] text-amber-300 hover:bg-amber-500/25 transition-colors"
+            className="flex items-center gap-1 rounded bg-warning-tint/15 px-1.5 py-0.5 text-[0.625rem] text-warning-bright hover:bg-warning-tint/25 transition-colors"
           >
             <Square strokeWidth={1.5} className="w-3 h-3" />
             Stop

--- a/src/components/agent/ConsentCard.tsx
+++ b/src/components/agent/ConsentCard.tsx
@@ -129,7 +129,7 @@ export function ConsentCard({
       aria-labelledby="agent-consent-workflow"
       aria-describedby="agent-consent-terms"
       data-testid="agent-consent"
-      className="mt-2 rounded border border-blue-400/30 bg-blue-500/5 p-2 space-y-1 focus:outline-none focus:ring-1 focus:ring-blue-400/50"
+      className="mt-2 rounded border border-brand/30 bg-brand-tint/5 p-2 space-y-1 focus:outline-none focus:ring-1 focus:ring-brand/50"
     >
       {/*
         The default, first. The pill says what the run is with the box untouched, which is
@@ -143,7 +143,7 @@ export function ConsentCard({
         Start this run
         <span
           data-testid="agent-consent-pill"
-          className="rounded px-1 py-px text-[0.625rem] normal-case tracking-normal bg-emerald-500/10 text-emerald-400/90"
+          className="rounded px-1 py-px text-[0.625rem] normal-case tracking-normal bg-success-tint/10 text-success/90"
         >
           read-only
         </span>
@@ -228,7 +228,7 @@ export function ConsentCard({
                 key={chip.text}
                 className={cn(
                   "rounded px-1 py-px text-[0.625rem] bg-fill",
-                  chip.tone === "warn" ? "text-amber-400/90" : "text-fg-tertiary",
+                  chip.tone === "warn" ? "text-warning/90" : "text-fg-tertiary",
                 )}
               >
                 {chip.text}
@@ -245,7 +245,7 @@ export function ConsentCard({
           decides whether a second, unbounded read joins the run's own.
         */}
         {isSqlite && (
-          <p data-testid="agent-auto-execute-sqlite" className="ml-5 text-[0.625rem] text-amber-400/70">
+          <p data-testid="agent-auto-execute-sqlite" className="ml-5 text-[0.625rem] text-warning/70">
             {SQLITE_COST}
           </p>
         )}
@@ -255,7 +255,7 @@ export function ConsentCard({
           type="button"
           data-testid="agent-consent-open"
           onClick={onOpen}
-          className="flex items-center gap-1 px-2 py-1 rounded text-xs bg-blue-500/15 text-blue-300 hover:bg-blue-500/25 transition-colors"
+          className="flex items-center gap-1 px-2 py-1 rounded text-xs bg-brand-tint/15 text-brand-bright hover:bg-brand-tint/25 transition-colors"
         >
           <Play strokeWidth={1.5} className="w-3 h-3" aria-hidden="true" />
           Start run

--- a/src/components/agent/SafetyStrip.tsx
+++ b/src/components/agent/SafetyStrip.tsx
@@ -68,9 +68,9 @@ export interface SafetyStripProps {
  * scans every rendered `class` attribute to keep it that way.
  */
 const TONE_PILL: Readonly<Record<AgentPostureTone, string>> = Object.freeze({
-  safe: "text-emerald-400/90 bg-emerald-500/10",
-  reads: "text-blue-300 bg-blue-500/10",
-  widened: "text-amber-400 bg-amber-500/10",
+  safe: "text-success/90 bg-success-tint/10",
+  reads: "text-brand-bright bg-brand-tint/10",
+  widened: "text-warning bg-warning-tint/10",
   blocked: "text-fg-muted bg-fill",
 } satisfies Record<AgentPostureTone, string>);
 

--- a/src/components/community-section.tsx
+++ b/src/components/community-section.tsx
@@ -27,9 +27,9 @@ interface CommunitySectionProps {
  */
 const SOCIAL_ANCHOR_CLASSES = {
   desktop:
-    "flex h-8 w-8 items-center justify-center rounded-lg bg-fill border border-hairline text-fg-tertiary hover:bg-fill-strong hover:border-hairline-strong hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 transition-all duration-200",
+    "flex h-8 w-8 items-center justify-center rounded-lg bg-fill border border-hairline text-fg-tertiary hover:bg-fill-strong hover:border-hairline-strong hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-tint/50 transition-all duration-200",
   mobile:
-    "flex h-8 w-8 items-center justify-center rounded-full bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 transition-colors",
+    "flex h-8 w-8 items-center justify-center rounded-full bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-tint/50 transition-colors",
 } as const;
 
 /**
@@ -79,7 +79,7 @@ function DesktopCommunity() {
             href={REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 rounded-sm transition-colors duration-200"
+            className="hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-tint/50 rounded-sm transition-colors duration-200"
           >
             github.com/libredb/libredb-studio
           </a>
@@ -105,7 +105,7 @@ function MobileCommunity() {
           href={REPO_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 rounded-sm transition-colors"
+          className="hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-tint/50 rounded-sm transition-colors"
         >
           github.com/libredb/libredb-studio
         </a>

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -153,7 +153,7 @@ export function CopyButton({ text, testId, label = "Copy", className }: CopyButt
       }}
       className={cn(
         "flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.625rem] transition-colors",
-        outcome === "failed" ? "text-amber-400/80 hover:bg-fill" : "text-fg-tertiary hover:bg-fill hover:text-fg",
+        outcome === "failed" ? "text-warning/80 hover:bg-fill" : "text-fg-tertiary hover:bg-fill hover:text-fg",
         className,
       )}
     >

--- a/src/components/login/connection-signature.tsx
+++ b/src/components/login/connection-signature.tsx
@@ -65,7 +65,7 @@ export function ConnectionSignature() {
         aria-hidden="true"
         className="font-mono text-xl xl:text-2xl tracking-tight text-fg-tertiary select-none"
       >
-        <span key={current.type} className="text-blue-400 animate-in fade-in duration-500">
+        <span key={current.type} className="text-brand animate-in fade-in duration-500">
           {current.scheme}
         </span>
         {current.rest}

--- a/src/components/monitoring/MonitoringDashboard.tsx
+++ b/src/components/monitoring/MonitoringDashboard.tsx
@@ -128,7 +128,7 @@ export function MonitoringDashboard({ isEmbedded = false }: MonitoringDashboardP
           {/* Refresh Controls */}
           <div className="flex items-center gap-1 sm:gap-2">
             <div className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground mr-2">
-              <div className={`h-2 w-2 rounded-full ${autoRefresh ? "bg-green-500 animate-pulse" : "bg-muted"}`} />
+              <div className={`h-2 w-2 rounded-full ${autoRefresh ? "bg-hue-green-tint animate-pulse" : "bg-muted"}`} />
               <span className="hidden md:inline">{autoRefresh ? "Auto" : "Manual"}</span>
               <span className="hidden lg:inline text-xs">Last: {formatLastUpdated(lastUpdated)}</span>
             </div>

--- a/src/components/monitoring/tabs/OverviewTab.tsx
+++ b/src/components/monitoring/tabs/OverviewTab.tsx
@@ -114,7 +114,7 @@ export function OverviewTab({ data, loading, history = [] }: OverviewTabProps) {
         <Card className={`p-0 border-2 transition-colors ${getThresholdColor(connThreshold)}`}>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Connections</CardTitle>
-            <Zap strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-yellow-500" />
+            <Zap strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-yellow" />
           </CardHeader>
           <CardContent className="p-3 sm:p-4 pt-0">
             <div
@@ -142,7 +142,7 @@ export function OverviewTab({ data, loading, history = [] }: OverviewTabProps) {
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">DB Size</CardTitle>
-            <Database strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-blue-500" />
+            <Database strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-blue" />
           </CardHeader>
           <CardContent className="p-3 sm:p-4 pt-0">
             <div className="text-lg sm:text-2xl font-medium">{overview?.databaseSize || "N/A"}</div>
@@ -154,7 +154,7 @@ export function OverviewTab({ data, loading, history = [] }: OverviewTabProps) {
         <Card className={`p-0 border-2 transition-colors ${getThresholdColor(cacheThreshold)}`}>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Cache Hit</CardTitle>
-            <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-green-500" />
+            <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-green" />
           </CardHeader>
           <CardContent className="p-3 sm:p-4 pt-0">
             {cacheHitRatio === undefined ? (
@@ -180,7 +180,7 @@ export function OverviewTab({ data, loading, history = [] }: OverviewTabProps) {
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Tables</CardTitle>
-            <Table2 strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-purple-500" />
+            <Table2 strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-purple" />
           </CardHeader>
           <CardContent className="p-3 sm:p-4 pt-0">
             <div className="text-lg sm:text-2xl font-medium">{overview?.tableCount ?? 0}</div>

--- a/src/components/monitoring/tabs/PerformanceTab.tsx
+++ b/src/components/monitoring/tabs/PerformanceTab.tsx
@@ -313,7 +313,10 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
                 nothing to advise about a cache nobody measured. */}
             {cacheHitRatio !== undefined && cacheHitRatio < 90 && (
               <div className="flex items-start gap-2 p-2 bg-hue-yellow-tint/10 rounded-md">
-                <TriangleAlert strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-yellow mt-0.5 flex-shrink-0" />
+                <TriangleAlert
+                  strokeWidth={1.5}
+                  className="h-3 w-3 sm:h-4 sm:w-4 text-hue-yellow mt-0.5 flex-shrink-0"
+                />
                 <div>
                   <p className="text-xs sm:text-xs font-medium">Low Cache Hit</p>
                   <p className="text-xs sm:text-xs text-muted-foreground hidden sm:block">Increase shared_buffers</p>

--- a/src/components/monitoring/tabs/PerformanceTab.tsx
+++ b/src/components/monitoring/tabs/PerformanceTab.tsx
@@ -46,8 +46,8 @@ function metricSeries(
  */
 function deadlockIconClass(deadlocks: number | undefined): string {
   if (deadlocks === undefined) return "text-muted-foreground";
-  if (deadlocks > 0) return "text-red-500";
-  return "text-green-500";
+  if (deadlocks > 0) return "text-danger";
+  return "text-hue-green";
 }
 
 /**
@@ -113,10 +113,10 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
   }
 
   const getHealthStatus = (ratio: number) => {
-    if (ratio >= 95) return { label: "Excellent", color: "text-green-500", bg: "bg-green-500" };
-    if (ratio >= 90) return { label: "Good", color: "text-blue-500", bg: "bg-blue-500" };
-    if (ratio >= 80) return { label: "Fair", color: "text-yellow-500", bg: "bg-yellow-500" };
-    return { label: "Poor", color: "text-red-500", bg: "bg-red-500" };
+    if (ratio >= 95) return { label: "Excellent", color: "text-hue-green", bg: "bg-hue-green-tint" };
+    if (ratio >= 90) return { label: "Good", color: "text-brand", bg: "bg-brand-tint" };
+    if (ratio >= 80) return { label: "Fair", color: "text-hue-yellow", bg: "bg-hue-yellow-tint" };
+    return { label: "Poor", color: "text-danger", bg: "bg-danger-tint" };
   };
 
   // Optional on purpose: an engine that cannot measure its cache (Druid) reports
@@ -312,11 +312,8 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
             {/* Guarded on the ratio existing, not on a stand-in value: there is
                 nothing to advise about a cache nobody measured. */}
             {cacheHitRatio !== undefined && cacheHitRatio < 90 && (
-              <div className="flex items-start gap-2 p-2 bg-yellow-500/10 rounded-md">
-                <TriangleAlert
-                  strokeWidth={1.5}
-                  className="h-3 w-3 sm:h-4 sm:w-4 text-yellow-500 mt-0.5 flex-shrink-0"
-                />
+              <div className="flex items-start gap-2 p-2 bg-hue-yellow-tint/10 rounded-md">
+                <TriangleAlert strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-yellow mt-0.5 flex-shrink-0" />
                 <div>
                   <p className="text-xs sm:text-xs font-medium">Low Cache Hit</p>
                   <p className="text-xs sm:text-xs text-muted-foreground hidden sm:block">Increase shared_buffers</p>
@@ -324,8 +321,8 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
               </div>
             )}
             {(performance?.deadlocks ?? 0) > 0 && (
-              <div className="flex items-start gap-2 p-2 bg-red-500/10 rounded-md">
-                <TriangleAlert strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-red-500 mt-0.5 flex-shrink-0" />
+              <div className="flex items-start gap-2 p-2 bg-danger-tint/10 rounded-md">
+                <TriangleAlert strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-danger mt-0.5 flex-shrink-0" />
                 <div>
                   <p className="text-xs sm:text-xs font-medium">Deadlocks</p>
                   <p className="text-xs sm:text-xs text-muted-foreground hidden sm:block">Review lock ordering</p>
@@ -333,8 +330,8 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
               </div>
             )}
             {cacheHitRatio !== undefined && cacheHitRatio >= 90 && !performance?.deadlocks && (
-              <div className="flex items-center gap-2 p-2 bg-green-500/10 rounded-md">
-                <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-green-500 flex-shrink-0" />
+              <div className="flex items-center gap-2 p-2 bg-hue-green-tint/10 rounded-md">
+                <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-green flex-shrink-0" />
                 <p className="text-xs sm:text-xs">Performing well!</p>
               </div>
             )}

--- a/src/components/monitoring/tabs/PoolTab.tsx
+++ b/src/components/monitoring/tabs/PoolTab.tsx
@@ -149,7 +149,7 @@ function PoolStatsGrid({ measured, usagePercent }: Readonly<{ measured: PoolStat
       <Card className="p-0">
         <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
           <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Total</CardTitle>
-          <Server strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-blue-500" />
+          <Server strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-blue" />
         </CardHeader>
         <CardContent className="p-3 sm:p-4 pt-0">
           <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.total : "N/A"}</div>
@@ -160,7 +160,7 @@ function PoolStatsGrid({ measured, usagePercent }: Readonly<{ measured: PoolStat
       <Card className="p-0">
         <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
           <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Active</CardTitle>
-          <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-green-500" />
+          <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-green" />
         </CardHeader>
         <CardContent className="p-3 sm:p-4 pt-0">
           <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.active : "N/A"}</div>
@@ -176,7 +176,7 @@ function PoolStatsGrid({ measured, usagePercent }: Readonly<{ measured: PoolStat
       <Card className="p-0">
         <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 sm:p-4 pb-1 sm:pb-2">
           <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Idle</CardTitle>
-          <Clock strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-yellow-500" />
+          <Clock strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-yellow" />
         </CardHeader>
         <CardContent className="p-3 sm:p-4 pt-0">
           <div className="text-lg sm:text-2xl font-medium">{measured !== null ? measured.idle : "N/A"}</div>

--- a/src/components/monitoring/tabs/QueriesTab.tsx
+++ b/src/components/monitoring/tabs/QueriesTab.tsx
@@ -63,7 +63,7 @@ const STAT_CARDS: readonly StatCard[] = [
     title: "Listed queries over 1s",
     icon: ({ overOneSecond }) => (
       <TriangleAlert
-        className={`h-3 w-3 sm:h-4 sm:w-4 ${overOneSecond > 0 ? "text-yellow-500" : "text-muted-foreground"}`}
+        className={`h-3 w-3 sm:h-4 sm:w-4 ${overOneSecond > 0 ? "text-hue-yellow" : "text-muted-foreground"}`}
       />
     ),
     value: ({ statsKnown, overOneSecond }) => (statsKnown ? String(overOneSecond) : "N/A"),

--- a/src/components/monitoring/tabs/SessionsTab.tsx
+++ b/src/components/monitoring/tabs/SessionsTab.tsx
@@ -79,11 +79,11 @@ export function SessionsTab({ data, loading, onKillSession, isAdmin = true, labe
   const getStateBadge = (state: string) => {
     switch (state) {
       case "active":
-        return <Badge className="bg-green-500">Active</Badge>;
+        return <Badge className="bg-hue-green-tint">Active</Badge>;
       case "idle":
         return <Badge variant="secondary">Idle</Badge>;
       case "idle in transaction":
-        return <Badge className="bg-yellow-500">Idle in TX</Badge>;
+        return <Badge className="bg-hue-yellow-tint">Idle in TX</Badge>;
       case "idle in transaction (aborted)":
         return <Badge variant="destructive">Aborted TX</Badge>;
       default:
@@ -98,7 +98,7 @@ export function SessionsTab({ data, loading, onKillSession, isAdmin = true, labe
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Active</CardTitle>
-            <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-green-500" />
+            <Activity strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-green" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
             <div className="text-lg sm:text-2xl font-medium" data-testid="session-stat-active">
@@ -123,7 +123,7 @@ export function SessionsTab({ data, loading, onKillSession, isAdmin = true, labe
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">In TX</CardTitle>
             <Clock
-              className={`h-3 w-3 sm:h-4 sm:w-4 ${idleInTxCount !== "0" && !sessionsUnavailable ? "text-yellow-500" : "text-muted-foreground"}`}
+              className={`h-3 w-3 sm:h-4 sm:w-4 ${idleInTxCount !== "0" && !sessionsUnavailable ? "text-hue-yellow" : "text-muted-foreground"}`}
             />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
@@ -137,7 +137,7 @@ export function SessionsTab({ data, loading, onKillSession, isAdmin = true, labe
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Wait</CardTitle>
             <Users
-              className={`h-3 w-3 sm:h-4 sm:w-4 ${waitingCount !== "0" && !sessionsUnavailable ? "text-orange-500" : "text-muted-foreground"}`}
+              className={`h-3 w-3 sm:h-4 sm:w-4 ${waitingCount !== "0" && !sessionsUnavailable ? "text-hue-orange" : "text-muted-foreground"}`}
             />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">

--- a/src/components/monitoring/tabs/StorageTab.tsx
+++ b/src/components/monitoring/tabs/StorageTab.tsx
@@ -126,7 +126,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">DB Size</CardTitle>
-            <Database strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-blue-500" />
+            <Database strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-blue" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
             <div className="text-lg sm:text-2xl font-medium truncate">{overview?.databaseSize || "N/A"}</div>
@@ -136,7 +136,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Tables</CardTitle>
-            <HardDrive strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-green-500" />
+            <HardDrive strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-green" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
             {/*
@@ -159,7 +159,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">Indexes</CardTitle>
-            <Archive strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-purple-500" />
+            <Archive strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-purple" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
             <div className="text-lg sm:text-2xl font-medium truncate" data-testid="storage-stat-indexes">
@@ -174,7 +174,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
         <Card className="p-0">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 p-2 sm:p-4 pb-1 sm:pb-2">
             <CardTitle className="text-xs sm:text-xs font-medium text-muted-foreground">WAL</CardTitle>
-            <FolderOpen strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-orange-500" />
+            <FolderOpen strokeWidth={1.5} className="h-3 w-3 sm:h-4 sm:w-4 text-hue-orange" />
           </CardHeader>
           <CardContent className="p-2 sm:p-4 pt-0">
             <div className="text-lg sm:text-2xl font-medium truncate">
@@ -200,7 +200,7 @@ export function StorageTab({ data, loading }: StorageTabProps) {
               <div>
                 <div className="flex items-center justify-between text-xs sm:text-xs mb-1">
                   <span className="flex items-center gap-1 sm:gap-2">
-                    <div className="w-2 h-2 sm:w-3 sm:h-3 rounded-sm bg-green-500" />
+                    <div className="w-2 h-2 sm:w-3 sm:h-3 rounded-sm bg-hue-green-tint" />
                     Tables
                   </span>
                   <span className="font-medium" data-testid="storage-breakdown-tables">
@@ -213,14 +213,14 @@ export function StorageTab({ data, loading }: StorageTabProps) {
               <div>
                 <div className="flex items-center justify-between text-xs sm:text-xs mb-1">
                   <span className="flex items-center gap-1 sm:gap-2">
-                    <div className="w-2 h-2 sm:w-3 sm:h-3 rounded-sm bg-purple-500" />
+                    <div className="w-2 h-2 sm:w-3 sm:h-3 rounded-sm bg-hue-purple-tint" />
                     Indexes
                   </span>
                   <span className="font-medium" data-testid="storage-breakdown-indexes">
                     {indexSizeKnown ? formatBytes(totalIndexSize) : "N/A"}
                   </span>
                 </div>
-                <Progress value={indexPercent} className="h-1.5 sm:h-2 [&>div]:bg-purple-500" />
+                <Progress value={indexPercent} className="h-1.5 sm:h-2 [&>div]:bg-hue-purple-tint" />
               </div>
 
               <div>

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -88,8 +88,8 @@ function formatVacuumDate(date: Date | undefined, vacuumSupported: boolean): str
  */
 function vacuumIconClass(stateKnown: boolean, needingVacuum: number): string {
   if (!stateKnown) return "text-muted-foreground";
-  if (needingVacuum > 0) return "text-yellow-500";
-  return "text-green-500";
+  if (needingVacuum > 0) return "text-hue-yellow";
+  return "text-hue-green";
 }
 
 /** The same three states, as the note under the figure. `null` is the unknown case. */

--- a/src/components/results-grid/ResultCard.tsx
+++ b/src/components/results-grid/ResultCard.tsx
@@ -49,8 +49,8 @@ export function ResultCard({
     >
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2 flex-1 min-w-0">
-          <div className="w-8 h-8 rounded-lg bg-blue-500/10 flex items-center justify-center shrink-0">
-            <Hash strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />
+          <div className="w-8 h-8 rounded-lg bg-brand-tint/10 flex items-center justify-center shrink-0">
+            <Hash strokeWidth={1.5} className="w-3.5 h-3.5 text-brand" />
           </div>
           <div className="min-w-0 flex-1">
             <p
@@ -78,7 +78,7 @@ export function ResultCard({
             <div key={field} className="flex items-center justify-between text-xs">
               <span className="text-fg-muted truncate mr-2">
                 {field}
-                {isMasked && <Lock strokeWidth={1.5} className="w-2.5 h-2.5 inline ml-1 text-purple-400" />}
+                {isMasked && <Lock strokeWidth={1.5} className="w-2.5 h-2.5 inline ml-1 text-hue-purple" />}
               </span>
               <span className={cn("truncate max-w-[60%] text-right font-mono", className)}>{displayValue}</span>
             </div>

--- a/src/components/results-grid/RowDetailSheet.tsx
+++ b/src/components/results-grid/RowDetailSheet.tsx
@@ -108,8 +108,8 @@ export function RowDetailSheet({
         <SheetHeader className="pb-4 border-b border-hairline">
           <div className="flex items-center justify-between">
             <SheetTitle className="text-fg flex items-center gap-2">
-              <div className="w-8 h-8 rounded-lg bg-blue-500/10 flex items-center justify-center">
-                <FileBraces strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />
+              <div className="w-8 h-8 rounded-lg bg-brand-tint/10 flex items-center justify-center">
+                <FileBraces strokeWidth={1.5} className="w-3.5 h-3.5 text-brand" />
               </div>
               Row #{rowIndex + 1}
             </SheetTitle>
@@ -121,12 +121,12 @@ export function RowDetailSheet({
             >
               {copyOutcome?.key === "__all__" && copyOutcome.copied && (
                 <>
-                  <Check strokeWidth={1.5} className="w-3 h-3 mr-1 text-emerald-400" /> Copied
+                  <Check strokeWidth={1.5} className="w-3 h-3 mr-1 text-success" /> Copied
                 </>
               )}
               {copyOutcome?.key === "__all__" && !copyOutcome.copied && (
                 <>
-                  <TriangleAlert strokeWidth={1.5} className="w-3 h-3 mr-1 text-amber-400" /> Copy failed
+                  <TriangleAlert strokeWidth={1.5} className="w-3 h-3 mr-1 text-warning" /> Copy failed
                 </>
               )}
               {copyOutcome?.key !== "__all__" && (
@@ -150,7 +150,7 @@ export function RowDetailSheet({
                     <div className="flex-1 min-w-0">
                       <p className="text-xs text-fg-muted mb-1 font-mono flex items-center gap-1">
                         {field}
-                        {isMasked && <Lock strokeWidth={1.5} className="w-2.5 h-2.5 text-purple-400" />}
+                        {isMasked && <Lock strokeWidth={1.5} className="w-2.5 h-2.5 text-hue-purple" />}
                       </p>
                       <p
                         className={cn(
@@ -172,7 +172,7 @@ export function RowDetailSheet({
                           onClick={() => revealField(field)}
                           title="Reveal value (10s)"
                         >
-                          <Eye className="w-3.5 h-3.5 text-purple-400" />
+                          <Eye className="w-3.5 h-3.5 text-hue-purple" />
                         </Button>
                       )}
                       <Button
@@ -182,10 +182,10 @@ export function RowDetailSheet({
                         onClick={() => copyValue(field, row[field])}
                       >
                         {copyOutcome?.key === field && copyOutcome.copied && (
-                          <Check strokeWidth={1.5} className="w-3.5 h-3.5 text-emerald-400" />
+                          <Check strokeWidth={1.5} className="w-3.5 h-3.5 text-success" />
                         )}
                         {copyOutcome?.key === field && !copyOutcome.copied && (
-                          <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 text-amber-400" />
+                          <TriangleAlert strokeWidth={1.5} className="w-3.5 h-3.5 text-warning" />
                         )}
                         {copyOutcome?.key !== field && <Copy strokeWidth={1.5} className="w-3.5 h-3.5 text-fg-muted" />}
                       </Button>

--- a/src/components/results-grid/StatsBar.tsx
+++ b/src/components/results-grid/StatsBar.tsx
@@ -57,14 +57,14 @@ export function StatsBar({
     <div className="flex items-center justify-between px-4 py-2 border-b border-hairline bg-surface text-xs text-fg-muted font-mono">
       <div className="flex items-center gap-4">
         <span className="flex items-center gap-1.5">
-          <span className="w-1.5 h-1.5 rounded-full bg-emerald-500/50" />
+          <span className="w-1.5 h-1.5 rounded-full bg-success-tint/50" />
           {result.rows.length} rows
-          {result.pagination?.hasMore && <span className="text-amber-400 ml-1">(more available)</span>}
+          {result.pagination?.hasMore && <span className="text-warning ml-1">(more available)</span>}
         </span>
         <span className="hidden sm:inline">{result.fields.length} columns</span>
         {activeFilterCount > 0 && (
           <button
-            className="flex items-center gap-1 text-blue-400 text-xs bg-blue-500/10 px-2 py-0.5 rounded hover:bg-blue-500/20 transition-colors"
+            className="flex items-center gap-1 text-brand text-xs bg-brand-tint/10 px-2 py-0.5 rounded hover:bg-brand-tint/20 transition-colors"
             onClick={onClearFilters}
             title="Clear all filters"
           >
@@ -74,10 +74,10 @@ export function StatsBar({
           </button>
         )}
         {result.pagination?.wasLimited && (
-          <span className="text-blue-400 text-xs bg-blue-500/10 px-2 py-0.5 rounded">AUTO-LIMITED</span>
+          <span className="text-brand text-xs bg-brand-tint/10 px-2 py-0.5 rounded">AUTO-LIMITED</span>
         )}
         {warnings.length > 0 && (
-          <span className="text-amber-400 text-xs bg-amber-500/10 px-2 py-0.5 rounded" title={warningDetail}>
+          <span className="text-warning text-xs bg-warning-tint/10 px-2 py-0.5 rounded" title={warningDetail}>
             {warnings.length} WARNING{warnings.length > 1 ? "S" : ""}
             <span className="sr-only">: {warningDetail}</span>
           </span>
@@ -92,7 +92,7 @@ export function StatsBar({
               size="sm"
               className={cn(
                 "h-6 px-2 text-xs font-medium gap-1",
-                effectiveMaskingEnabled ? "text-purple-400 bg-purple-500/10" : "text-fg-muted",
+                effectiveMaskingEnabled ? "text-hue-purple bg-hue-purple-tint/10" : "text-fg-muted",
               )}
               onClick={onToggleMasking}
               title={effectiveMaskingEnabled ? "Show sensitive data" : "Mask sensitive data"}
@@ -101,7 +101,7 @@ export function StatsBar({
               {effectiveMaskingEnabled ? "MASKED" : "MASK"}
             </Button>
           ) : effectiveMaskingEnabled ? (
-            <span className="h-6 px-2 text-xs font-medium text-purple-400 bg-purple-500/10 rounded flex items-center gap-1">
+            <span className="h-6 px-2 text-xs font-medium text-hue-purple bg-hue-purple-tint/10 rounded flex items-center gap-1">
               <Lock strokeWidth={1.5} className="w-3 h-3" />
               {MASKED_LABEL}
             </span>
@@ -109,13 +109,13 @@ export function StatsBar({
 
         {editingEnabled && pendingChanges && pendingChanges.length > 0 && (
           <div className="flex items-center gap-1">
-            <span className="text-xs text-amber-400 bg-amber-500/10 px-1.5 py-0.5 rounded">
+            <span className="text-xs text-warning bg-warning-tint/10 px-1.5 py-0.5 rounded">
               {pendingChanges.length} change{pendingChanges.length > 1 ? "s" : ""}
             </span>
             <Button
               variant="ghost"
               size="sm"
-              className="h-6 px-1.5 text-xs text-emerald-400 hover:bg-emerald-500/10"
+              className="h-6 px-1.5 text-xs text-success hover:bg-success-tint/10"
               onClick={onApplyChanges}
             >
               <Save strokeWidth={1.5} className="w-3 h-3" />
@@ -123,7 +123,7 @@ export function StatsBar({
             <Button
               variant="ghost"
               size="sm"
-              className="h-6 px-1.5 text-xs text-red-400 hover:bg-red-500/10"
+              className="h-6 px-1.5 text-xs text-danger hover:bg-danger-tint/10"
               onClick={onDiscardChanges}
             >
               <X strokeWidth={1.5} className="w-3 h-3" />
@@ -140,7 +140,7 @@ export function StatsBar({
             onClick={() => onSetViewMode("card")}
             className={cn(
               "p-1.5 rounded transition-all",
-              viewMode === "card" ? "bg-blue-600 text-white" : "text-fg-muted",
+              viewMode === "card" ? "bg-brand-solid text-white" : "text-fg-muted",
             )}
           >
             <LayoutGrid strokeWidth={1.5} className="w-3.5 h-3.5" />
@@ -149,7 +149,7 @@ export function StatsBar({
             onClick={() => onSetViewMode("table")}
             className={cn(
               "p-1.5 rounded transition-all",
-              viewMode === "table" ? "bg-blue-600 text-white" : "text-fg-muted",
+              viewMode === "table" ? "bg-brand-solid text-white" : "text-fg-muted",
             )}
           >
             <Table2 strokeWidth={1.5} className="w-3.5 h-3.5" />

--- a/src/components/results-grid/renderers/binary.ts
+++ b/src/components/results-grid/renderers/binary.ts
@@ -3,7 +3,7 @@ import type { ValueRenderer } from "./types";
 
 // Monospaced, because hex is read by position: a reader comparing two values, or
 // counting to an offset, needs the digits to line up.
-const BINARY_CLASS = "text-cyan-400/80 font-mono";
+const BINARY_CLASS = "text-hue-cyan/80 font-mono";
 
 // `classifyValue` selects this renderer with the same `asBytes` check, so a
 // non-binary value cannot arrive here; the fallback exists so the narrowing is

--- a/src/components/results-grid/renderers/json.ts
+++ b/src/components/results-grid/renderers/json.ts
@@ -35,7 +35,7 @@ export const jsonRenderer: ValueRenderer = {
     if (typeof value === "string") {
       return { display: value, className: "text-fg-secondary" };
     }
-    return { display: JSON.stringify(value), className: "text-blue-400/80 italic font-light" };
+    return { display: JSON.stringify(value), className: "text-hue-blue/80 italic font-light" };
   },
   renderDetail(value) {
     // classifyValue only routes parseable container strings here, so the parse

--- a/src/components/results-grid/renderers/scalar.ts
+++ b/src/components/results-grid/renderers/scalar.ts
@@ -4,18 +4,18 @@ export const scalarRenderer: ValueRenderer = {
   kind: "scalar",
   renderCompact(value) {
     if (typeof value === "number") {
-      return { display: String(value), className: "text-amber-500/90 font-medium" };
+      return { display: String(value), className: "text-hue-amber/90 font-medium" };
     }
     if (typeof value === "boolean") {
-      return { display: String(value), className: value ? "text-emerald-500/90" : "text-rose-500/90" };
+      return { display: String(value), className: value ? "text-hue-emerald/90" : "text-hue-rose/90" };
     }
     const display = String(value);
     const strVal = display.toLowerCase();
     if (strVal === "true" || strVal === "active" || strVal === "enabled") {
-      return { display, className: "text-emerald-500/90" };
+      return { display, className: "text-hue-emerald/90" };
     }
     if (strVal === "false" || strVal === "inactive" || strVal === "disabled") {
-      return { display, className: "text-rose-500/90" };
+      return { display, className: "text-hue-rose/90" };
     }
     return { display, className: "text-fg-secondary" };
   },

--- a/src/components/schema-diagram/TableNode.tsx
+++ b/src/components/schema-diagram/TableNode.tsx
@@ -52,9 +52,9 @@ const ColumnRow = memo(function ColumnRow({ column, isFk, hasSourceHandle, hasTa
 
       <div className="flex items-center gap-2">
         {column.isPrimary ? (
-          <Key strokeWidth={1.5} className="w-2.5 h-2.5 text-yellow-500" />
+          <Key strokeWidth={1.5} className="w-2.5 h-2.5 text-hue-yellow" />
         ) : isFk ? (
-          <Link2 strokeWidth={1.5} className="w-2.5 h-2.5 text-blue-400" />
+          <Link2 strokeWidth={1.5} className="w-2.5 h-2.5 text-hue-blue" />
         ) : column.type.toLowerCase().includes("int") ? (
           <Hash strokeWidth={1.5} className="w-2.5 h-2.5 text-fg-muted" />
         ) : (
@@ -62,14 +62,14 @@ const ColumnRow = memo(function ColumnRow({ column, isFk, hasSourceHandle, hasTa
         )}
         <span
           className={
-            column.isPrimary ? "text-yellow-500/90 font-medium" : isFk ? "text-blue-400/80" : "text-fg-tertiary"
+            column.isPrimary ? "text-hue-yellow/90 font-medium" : isFk ? "text-hue-blue/80" : "text-fg-tertiary"
           }
         >
           {column.name}
         </span>
       </div>
       <div className="flex items-center gap-1">
-        {column.nullable === false && <span className="text-[0.5rem] text-red-500/60">NN</span>}
+        {column.nullable === false && <span className="text-[0.5rem] text-hue-red/60">NN</span>}
         <span className="text-[0.625rem] text-fg-subtle font-mono uppercase">{column.type}</span>
       </div>
     </div>
@@ -103,10 +103,10 @@ export const TableNode = memo(function TableNode({ id, data }: NodeProps<TableFl
   return (
     <div
       className={`bg-raised border rounded-lg overflow-hidden min-w-[200px] shadow-2xl transition-all ${
-        highlighted ? "border-blue-500/60 ring-1 ring-blue-500/30" : "border-hairline-strong"
+        highlighted ? "border-brand-tint/60 ring-1 ring-brand-tint/30" : "border-hairline-strong"
       }`}
     >
-      <div className="relative bg-blue-600/10 px-3 py-2 border-b border-hairline flex items-center gap-2">
+      <div className="relative bg-brand-solid/10 px-3 py-2 border-b border-hairline flex items-center gap-2">
         <Handle
           type="target"
           position={Position.Left}
@@ -121,7 +121,7 @@ export const TableNode = memo(function TableNode({ id, data }: NodeProps<TableFl
           isConnectable={false}
           style={{ opacity: 0, right: -5 }}
         />
-        <Database strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />
+        <Database strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-blue" />
         <span className="text-xs font-medium text-fg">{table.name}</span>
         <span className="text-[0.625rem] text-fg-subtle ml-auto">{table.columns?.length || 0} cols</span>
       </div>

--- a/src/components/schema-explorer/ColumnList.tsx
+++ b/src/components/schema-explorer/ColumnList.tsx
@@ -23,7 +23,7 @@ export const ColumnList = React.memo(function ColumnList({ columns, indexes }: C
           key={column.name}
           className="flex items-center gap-2 py-1 px-2 rounded-sm group/col hover:bg-accent/20 cursor-default"
         >
-          {column.isPrimary ? <Key strokeWidth={1.5} className="w-2.5 h-2.5 text-yellow-500/70" /> : nonPrimaryDot}
+          {column.isPrimary ? <Key strokeWidth={1.5} className="w-2.5 h-2.5 text-hue-yellow/70" /> : nonPrimaryDot}
 
           <span className="text-xs text-muted-foreground flex-1 truncate group-hover/col:text-foreground">
             {column.name}
@@ -37,7 +37,7 @@ export const ColumnList = React.memo(function ColumnList({ columns, indexes }: C
       {indexes.length > 0 && (
         <div className="pt-2 pb-1">
           <div className="flex items-center gap-1.5 px-2 mb-1">
-            <Hash strokeWidth={1.5} className="w-2.5 h-2.5 text-purple-500/40" />
+            <Hash strokeWidth={1.5} className="w-2.5 h-2.5 text-hue-purple/40" />
             <span className="text-[0.625rem] font-medium text-muted-foreground">Indexes</span>
           </div>
           {indexes.map((idx) => (

--- a/src/components/schema-explorer/SchemaExplorer.tsx
+++ b/src/components/schema-explorer/SchemaExplorer.tsx
@@ -76,8 +76,8 @@ export function SchemaExplorer({
     return (
       <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
         <div className="relative mb-4">
-          <LoaderCircle strokeWidth={1.5} className="w-8 h-8 animate-spin text-blue-500/20" />
-          <Database strokeWidth={1.5} className="w-3.5 h-3.5 absolute inset-0 m-auto text-blue-500 animate-pulse" />
+          <LoaderCircle strokeWidth={1.5} className="w-8 h-8 animate-spin text-brand/20" />
+          <Database strokeWidth={1.5} className="w-3.5 h-3.5 absolute inset-0 m-auto text-brand animate-pulse" />
         </div>
         <span className="text-xs font-medium animate-pulse">Scanning Schema...</span>
       </div>
@@ -95,7 +95,7 @@ export function SchemaExplorer({
         className="flex flex-col items-center justify-center py-12 px-6 text-center"
       >
         <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4 border border-border">
-          <CircleAlert strokeWidth={1.5} className="w-6 h-6 text-amber-400" />
+          <CircleAlert strokeWidth={1.5} className="w-6 h-6 text-warning" />
         </div>
         <h3 className="text-foreground text-xs font-medium mb-1">Schema could not be read</h3>
         <p className="text-xs text-muted-foreground leading-relaxed break-words">{schemaError}</p>
@@ -122,13 +122,13 @@ export function SchemaExplorer({
       <div className="sticky top-0 z-10 px-3 pb-3 pt-1 space-y-3 bg-background">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Database strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-500/50" />
+            <Database strokeWidth={1.5} className="w-3.5 h-3.5 text-brand/50" />
             <span className="text-xs font-medium text-muted-foreground">Explorer</span>
           </div>
           <div className="flex items-center gap-1.5">
             {isAdmin && (
               <button
-                className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-amber-400 transition-colors"
+                className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-warning transition-colors"
                 onClick={() => onOpenMaintenance?.("global")}
                 title="Database Maintenance"
               >
@@ -137,14 +137,14 @@ export function SchemaExplorer({
             )}
             {capabilities?.supportsCreateTable !== false && (
               <button
-                className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-blue-400 transition-colors"
+                className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-brand transition-colors"
                 onClick={onCreateTableClick}
                 title={`Create ${labels?.entityName || "Table"}`}
               >
                 <Plus strokeWidth={1.5} className="w-3.5 h-3.5" />
               </button>
             )}
-            <span className="text-[0.625rem] bg-blue-500/10 text-blue-400 px-1.5 py-0.5 rounded-full font-mono border border-blue-500/10">
+            <span className="text-[0.625rem] bg-brand-tint/10 text-brand px-1.5 py-0.5 rounded-full font-mono border border-brand-tint/10">
               {schema.length}
             </span>
           </div>
@@ -153,13 +153,13 @@ export function SchemaExplorer({
         <div className="relative group">
           <Search
             strokeWidth={1.5}
-            className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground group-focus-within:text-blue-500 transition-colors"
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground group-focus-within:text-brand transition-colors"
           />
           <Input
             placeholder={labels?.searchPlaceholder || "Search tables or columns..."}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="h-8 pl-8 pr-8 text-xs bg-muted/50 border-border focus-visible:ring-1 focus-visible:ring-blue-500/50 placeholder:text-muted-foreground/50"
+            className="h-8 pl-8 pr-8 text-xs bg-muted/50 border-border focus-visible:ring-1 focus-visible:ring-brand-tint/50 placeholder:text-muted-foreground/50"
           />
           {searchQuery && (
             <button

--- a/src/components/schema-explorer/TableItem.tsx
+++ b/src/components/schema-explorer/TableItem.tsx
@@ -108,11 +108,11 @@ function renderMenuItems({
   return (
     <>
       <Item onClick={() => callbacks.onTableClick?.(table.name)}>
-        <Play strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-green-500" />
+        <Play strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-hue-green" />
         {labels?.selectAction || "Select Top 50"}
       </Item>
       <Item onClick={() => callbacks.onGenerateSelect?.(table.name)}>
-        <Funnel strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-blue-500" />
+        <Funnel strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-hue-blue" />
         {labels?.generateAction || "Generate Query"}
       </Item>
       <Item onClick={() => copyToClipboard(table.name, `${labels?.entityName || "Table"} name`)}>
@@ -124,17 +124,17 @@ function renderMenuItems({
       <Separator />
       {rowsAreAddressable && (
         <Item onClick={() => callbacks.onProfileTable?.(table.name)}>
-          <ChartColumn strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-cyan-500" />
+          <ChartColumn strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-hue-cyan" />
           {"Profile Table"}
         </Item>
       )}
       <Item onClick={() => callbacks.onGenerateCode?.(table.name)}>
-        <Code strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-purple-500" />
+        <Code strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-hue-purple" />
         {"Generate Code"}
       </Item>
       {rowsAreAddressable && (
         <Item onClick={() => callbacks.onGenerateTestData?.(table.name)}>
-          <WandSparkles strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-amber-500" />
+          <WandSparkles strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-hue-amber" />
           {"Generate Test Data"}
         </Item>
       )}
@@ -173,13 +173,13 @@ function renderMenuItems({
           <Separator />
           {analyzeControl.offered && (
             <Item onClick={() => callbacks.onOpenMaintenance?.("tables", table.name)}>
-              <Search strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-amber-500" />
+              <Search strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-hue-amber" />
               {analyzeControl.label ?? labels?.analyzeAction ?? "Analyze Table"}
             </Item>
           )}
           {vacuumControl.offered && (
             <Item onClick={() => callbacks.onOpenMaintenance?.("tables", table.name)}>
-              <Trash2 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-blue-400" />
+              <Trash2 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2 text-hue-blue" />
               {vacuumControl.label ?? labels?.vacuumAction ?? "Vacuum Table"}
             </Item>
           )}
@@ -246,7 +246,7 @@ export const TableItem = React.memo(function TableItem({
               <TableIcon
                 className={cn(
                   "w-3.5 h-3.5 shrink-0 transition-colors",
-                  isExpanded ? "text-blue-400" : "text-muted-foreground group-hover:text-foreground",
+                  isExpanded ? "text-brand" : "text-muted-foreground group-hover:text-foreground",
                 )}
               />
 

--- a/src/components/sidebar/ConnectionItem.tsx
+++ b/src/components/sidebar/ConnectionItem.tsx
@@ -26,7 +26,7 @@ export const ConnectionItem = React.memo(function ConnectionItem({
       initial={false}
       className={cn(
         "group flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer transition-all duration-200 text-xs relative overflow-hidden",
-        isActive ? "bg-blue-600/10 text-blue-400" : "hover:bg-accent/50 text-muted-foreground hover:text-foreground",
+        isActive ? "bg-brand-solid/10 text-brand" : "hover:bg-accent/50 text-muted-foreground hover:text-foreground",
       )}
       onClick={() => onSelect(conn)}
     >
@@ -38,7 +38,10 @@ export const ConnectionItem = React.memo(function ConnectionItem({
         />
       )}
       <div
-        className={cn("p-1 rounded transition-colors", isActive ? "bg-blue-500/20" : "bg-muted group-hover:bg-accent")}
+        className={cn(
+          "p-1 rounded transition-colors",
+          isActive ? "bg-brand-tint/20" : "bg-muted group-hover:bg-accent",
+        )}
       >
         {React.createElement(getDBIcon(conn.type), { className: "w-3 h-3" })}
       </div>
@@ -62,7 +65,7 @@ export const ConnectionItem = React.memo(function ConnectionItem({
         {conn.managed && (
           <div
             data-testid={`managed-lock-${conn.seedId || conn.id}`}
-            className="flex items-center justify-center text-amber-500/60"
+            className="flex items-center justify-center text-warning/60"
             title="Managed by administrator"
           >
             <Lock strokeWidth={1.5} className="w-3 h-3" />
@@ -70,7 +73,7 @@ export const ConnectionItem = React.memo(function ConnectionItem({
         )}
         {!conn.managed && onEdit && (
           <button
-            className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-blue-500/20 hover:text-blue-400"
+            className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-brand-tint/20 hover:text-brand"
             onClick={(e) => {
               e.stopPropagation();
               onEdit(conn);
@@ -81,7 +84,7 @@ export const ConnectionItem = React.memo(function ConnectionItem({
         )}
         {!conn.managed && (
           <button
-            className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-500/20 hover:text-red-400"
+            className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-danger-tint/20 hover:text-danger"
             onClick={(e) => {
               e.stopPropagation();
               onDelete(conn.id);

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -63,7 +63,7 @@ export function Sidebar({
     <div className="flex w-full h-full border-r border-border flex-col bg-background select-none">
       <div className="h-14 px-4 flex items-center justify-between border-b border-border">
         <div className="flex items-center gap-2">
-          <div className="w-5 h-5 bg-blue-600 rounded flex items-center justify-center">
+          <div className="w-5 h-5 bg-brand-solid rounded flex items-center justify-center">
             <Zap strokeWidth={1.5} className="w-3 h-3 text-white fill-current" />
           </div>
           <span className="font-medium text-xs tracking-tight bg-gradient-to-r from-foreground to-muted-foreground bg-clip-text text-transparent">
@@ -123,7 +123,7 @@ export function Sidebar({
       <div className="p-3 border-t border-border bg-card/50 backdrop-blur-md">
         <div className="flex items-center justify-between px-2 py-1.5 rounded-lg bg-muted/30 border border-border/50">
           <div className="flex items-center gap-2">
-            <div className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
+            <div className="w-1.5 h-1.5 rounded-full bg-hue-green-tint animate-pulse" />
             <span className="text-xs font-medium text-muted-foreground">Connected</span>
           </div>
           <div className="flex items-center gap-2">

--- a/src/components/studio/BottomPanel.tsx
+++ b/src/components/studio/BottomPanel.tsx
@@ -253,55 +253,55 @@ export function BottomPanel({
       key: "results",
       label: "Results",
       icon: <LayoutGrid strokeWidth={1.5} className="w-3 h-3" />,
-      activeClass: "text-blue-400 border-blue-500 bg-fill",
+      activeClass: "text-hue-blue border-hue-blue-tint bg-fill",
     },
     {
       key: "explain",
       label: "Explain",
       icon: <Zap strokeWidth={1.5} className="w-3 h-3" />,
-      activeClass: "text-amber-400 border-amber-500 bg-fill",
+      activeClass: "text-hue-amber border-hue-amber-tint bg-fill",
     },
     {
       key: "history",
       label: "History",
       icon: <Clock strokeWidth={1.5} className="w-3 h-3" />,
-      activeClass: "text-emerald-400 border-emerald-500 bg-fill",
+      activeClass: "text-hue-emerald border-hue-emerald-tint bg-fill",
     },
     {
       key: "saved",
       label: "Saved",
       icon: <Bookmark strokeWidth={1.5} className="w-3 h-3" />,
-      activeClass: "text-purple-400 border-purple-500 bg-fill",
+      activeClass: "text-hue-purple border-hue-purple-tint bg-fill",
     },
     {
       key: "charts",
       label: "Charts",
       icon: <ChartColumn strokeWidth={1.5} className="w-3 h-3" />,
-      activeClass: "text-cyan-400 border-cyan-500 bg-fill",
+      activeClass: "text-hue-cyan border-hue-cyan-tint bg-fill",
     },
     {
       key: "pivot",
       label: "Pivot",
       icon: <Columns3 strokeWidth={1.5} className="w-3 h-3" />,
-      activeClass: "text-orange-400 border-orange-500 bg-fill",
+      activeClass: "text-hue-orange border-hue-orange-tint bg-fill",
     },
     {
       key: "docs",
       label: "Docs",
       icon: <FileText strokeWidth={1.5} className="w-3 h-3" />,
-      activeClass: "text-teal-400 border-teal-500 bg-fill",
+      activeClass: "text-hue-teal border-hue-teal-tint bg-fill",
     },
     {
       key: "schemadiff",
       label: "Diff",
       icon: <GitCompare strokeWidth={1.5} className="w-3 h-3" />,
-      activeClass: "text-rose-400 border-rose-500 bg-fill",
+      activeClass: "text-hue-rose border-hue-rose-tint bg-fill",
     },
     {
       key: "dashboard",
       label: "Dashboard",
       icon: <LayoutDashboard strokeWidth={1.5} className="w-3 h-3" />,
-      activeClass: "text-indigo-400 border-indigo-500 bg-fill",
+      activeClass: "text-hue-indigo border-hue-indigo-tint bg-fill",
     },
   ];
 
@@ -372,13 +372,13 @@ export function BottomPanel({
                 <div data-testid="export-scope" className="px-2 py-1.5 text-xs text-fg-muted max-w-[15rem]">
                   {exportScope.summary}
                   {exportScope.shortfall !== null && (
-                    <span className="block mt-1 text-amber-400/80">{exportScope.shortfall}</span>
+                    <span className="block mt-1 text-warning/80">{exportScope.shortfall}</span>
                   )}
                 </div>
                 {exportArtifact !== null && (
                   // Stated before the formats, because it changes what the file IS:
                   // these are a run's rows, and the name will say so.
-                  <div data-testid="export-provenance" className="px-2 pb-1.5 text-xs text-blue-300/90">
+                  <div data-testid="export-provenance" className="px-2 pb-1.5 text-xs text-hue-blue-alt/90">
                     Saved as agent run <span className="font-mono text-[0.625rem]">{exportArtifact.runId}</span>&apos;s
                     own file.
                   </div>
@@ -421,9 +421,9 @@ export function BottomPanel({
       {hydratedHere && agentArtifact !== null && (
         <div
           data-testid="agent-provenance"
-          className="flex items-center justify-between gap-2 px-3 py-1 border-b border-blue-500/20 bg-blue-500/5"
+          className="flex items-center justify-between gap-2 px-3 py-1 border-b border-hue-blue-tint/20 bg-hue-blue-tint/5"
         >
-          <span className="text-xs text-blue-300/90">
+          <span className="text-xs text-hue-blue-alt/90">
             Stored by agent run <span className="font-mono text-[0.625rem]">{agentArtifact.runId}</span> via{" "}
             <span className="font-mono text-[0.625rem]">{agentArtifact.operationId}</span>{" "}
             {/* The audit correlation id: what joins these rows to the audit line for

--- a/src/components/studio/QueryToolbar.tsx
+++ b/src/components/studio/QueryToolbar.tsx
@@ -66,7 +66,7 @@ export function QueryToolbar({
     <>
       {/* Playground Mode Banner */}
       {playgroundMode && (
-        <div className="hidden md:flex items-center justify-center gap-2 px-4 py-1 bg-emerald-500/10 border-b border-emerald-500/20 text-emerald-400">
+        <div className="hidden md:flex items-center justify-center gap-2 px-4 py-1 bg-success-tint/10 border-b border-success-tint/20 text-success">
           <FlaskConical strokeWidth={1.5} className="w-3 h-3" />
           <span className="text-xs font-mediumr">Sandbox Mode — All changes will be auto-rolled back</span>
         </div>
@@ -75,9 +75,9 @@ export function QueryToolbar({
       {/* Desktop Query Toolbar */}
       <div className="hidden md:flex items-center justify-between px-4 py-1.5 bg-surface border-b border-hairline">
         <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2 px-2 py-0.5 rounded bg-blue-500/5 border border-blue-500/10">
-            <Terminal strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
-            <span className="text-xs font-medium text-blue-400">Query</span>
+          <div className="flex items-center gap-2 px-2 py-0.5 rounded bg-hue-blue-tint/5 border border-hue-blue-tint/10">
+            <Terminal strokeWidth={1.5} className="w-3 h-3 text-hue-blue" />
+            <span className="text-xs font-medium text-hue-blue">Query</span>
           </div>
           {/* The separator is chrome for Save; with Save withheld it would be a rule
               standing alone, the same reason the control group drops its border (#427). */}
@@ -98,7 +98,7 @@ export function QueryToolbar({
         {isExecuting ? (
           <Button
             size="sm"
-            className="bg-red-600 hover:bg-red-500 text-white font-medium text-xs h-7 px-4 gap-2"
+            className="bg-danger-solid hover:bg-danger-solid-hover text-white font-medium text-xs h-7 px-4 gap-2"
             onClick={onCancelQuery}
           >
             <Square strokeWidth={1.5} className="w-3 h-3 fill-current" />
@@ -107,7 +107,7 @@ export function QueryToolbar({
         ) : (
           <Button
             size="sm"
-            className="bg-blue-600 hover:bg-blue-500 text-white font-medium text-xs h-7 px-4 gap-2"
+            className="bg-brand-solid hover:bg-brand-solid-hover text-white font-medium text-xs h-7 px-4 gap-2"
             onClick={onExecuteQuery}
             disabled={!activeConnection}
           >
@@ -122,13 +122,13 @@ export function QueryToolbar({
             {transaction !== null &&
               (transactionActive ? (
                 <>
-                  <span className="text-[0.625rem] font-medium text-amber-400 px-1.5 py-0.5 bg-amber-500/10 rounded border border-amber-500/20 mr-1">
+                  <span className="text-[0.625rem] font-medium text-warning px-1.5 py-0.5 bg-warning-tint/10 rounded border border-warning-tint/20 mr-1">
                     TXN
                   </span>
                   <Button
                     size="sm"
                     variant="ghost"
-                    className="h-7 text-xs font-medium text-emerald-400 hover:text-emerald-300 hover:bg-emerald-500/10 gap-1"
+                    className="h-7 text-xs font-medium text-success hover:text-success-bright hover:bg-success-tint/10 gap-1"
                     onClick={transaction.commit}
                   >
                     COMMIT
@@ -136,7 +136,7 @@ export function QueryToolbar({
                   <Button
                     size="sm"
                     variant="ghost"
-                    className="h-7 text-xs font-medium text-red-400 hover:text-red-300 hover:bg-red-500/10 gap-1"
+                    className="h-7 text-xs font-medium text-danger hover:text-danger-bright hover:bg-danger-tint/10 gap-1"
                     onClick={transaction.rollback}
                   >
                     ROLLBACK
@@ -161,7 +161,7 @@ export function QueryToolbar({
                 className={cn(
                   "h-7 text-xs font-medium gap-1",
                   playgroundMode
-                    ? "text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20"
+                    ? "text-success bg-success-tint/10 hover:bg-success-tint/20"
                     : "text-fg-muted hover:text-fg-bright",
                 )}
                 onClick={onTogglePlayground}
@@ -180,7 +180,7 @@ export function QueryToolbar({
                 className={cn(
                   "h-7 text-xs font-medium gap-1",
                   editingEnabled
-                    ? "text-amber-400 bg-amber-500/10 hover:bg-amber-500/20"
+                    ? "text-warning bg-warning-tint/10 hover:bg-warning-tint/20"
                     : "text-fg-muted hover:text-fg-bright",
                 )}
                 onClick={onToggleEditing}

--- a/src/components/studio/StudioDesktopHeader.tsx
+++ b/src/components/studio/StudioDesktopHeader.tsx
@@ -35,8 +35,8 @@ export function StudioDesktopHeader({
   return (
     <header className="hidden md:flex h-14 border-b border-hairline items-center justify-between px-4 bg-surface/80 backdrop-blur-xl sticky top-0 z-30">
       <div className="flex items-center gap-3">
-        <div className="p-1.5 rounded-lg bg-blue-500/10 border border-blue-500/20">
-          <Database strokeWidth={1.5} className="w-3.5 h-3.5 text-blue-400" />
+        <div className="p-1.5 rounded-lg bg-brand-tint/10 border border-brand-tint/20">
+          <Database strokeWidth={1.5} className="w-3.5 h-3.5 text-brand" />
         </div>
         <div>
           <h1 className="text-xs font-medium text-fg truncate max-w-[120px]">
@@ -53,7 +53,7 @@ export function StudioDesktopHeader({
               {!activeConnection.environment && (
                 <span>
                   {" "}
-                  • <span className="text-emerald-500/80">Online</span>
+                  • <span className="text-success/80">Online</span>
                 </span>
               )}
             </p>
@@ -70,9 +70,9 @@ export function StudioDesktopHeader({
             <div
               className={cn(
                 "w-2 h-2 rounded-full",
-                connectionPulse === "healthy" && "bg-emerald-500 animate-pulse",
-                connectionPulse === "degraded" && "bg-amber-500",
-                connectionPulse === "error" && "bg-red-500",
+                connectionPulse === "healthy" && "bg-success-tint animate-pulse",
+                connectionPulse === "degraded" && "bg-warning-tint",
+                connectionPulse === "error" && "bg-danger-tint",
               )}
             />
             <span className="text-xs font-medium text-fg-muted">
@@ -84,7 +84,7 @@ export function StudioDesktopHeader({
         <Button
           variant="ghost"
           size="sm"
-          className="h-7 px-3 text-xs font-medium gap-2 text-fg-muted hover:text-purple-400 hover:bg-purple-500/10"
+          className="h-7 px-3 text-xs font-medium gap-2 text-fg-muted hover:text-hue-purple hover:bg-hue-purple-tint/10"
           onClick={() => router.push("/monitoring")}
         >
           <Gauge strokeWidth={1.5} className="w-3 h-3" /> Monitoring
@@ -94,7 +94,7 @@ export function StudioDesktopHeader({
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="sm" className="h-8 gap-2 hover:bg-fill px-2">
-                <User strokeWidth={1.5} className="w-3 h-3 text-blue-400" />
+                <User strokeWidth={1.5} className="w-3 h-3 text-brand" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-56 bg-raised border-hairline-strong text-fg-secondary">
@@ -107,7 +107,7 @@ export function StudioDesktopHeader({
                 <Gauge strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Monitoring
               </DropdownMenuItem>
               <div className="border-t border-hairline my-1" />
-              <DropdownMenuItem onClick={onLogout} className="text-red-400 cursor-pointer">
+              <DropdownMenuItem onClick={onLogout} className="text-danger cursor-pointer">
                 <LogOut strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Logout
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/src/components/studio/StudioMobileHeader.tsx
+++ b/src/components/studio/StudioMobileHeader.tsx
@@ -139,7 +139,7 @@ export function StudioMobileHeader({
                 size="sm"
                 className="h-8 px-2 gap-1 bg-overlay border-hairline-strong hover:bg-fill text-fg-secondary max-w-[160px]"
               >
-                <Database strokeWidth={1.5} className="w-3 h-3 text-blue-400 shrink-0" />
+                <Database strokeWidth={1.5} className="w-3 h-3 text-brand shrink-0" />
                 <span className="truncate text-xs font-medium">
                   {activeConnection ? activeConnection.name : "Select DB"}
                 </span>
@@ -157,12 +157,12 @@ export function StudioMobileHeader({
                     <DropdownMenuItem
                       key={c.id}
                       onClick={() => onSelectConnection(c)}
-                      className={cn("cursor-pointer", activeConnection?.id === c.id && "bg-blue-600/20 text-blue-400")}
+                      className={cn("cursor-pointer", activeConnection?.id === c.id && "bg-brand-solid/20 text-brand")}
                     >
                       <Database strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" />
                       <span className="truncate">{c.name}</span>
                       {activeConnection?.id === c.id && (
-                        <div className="ml-auto w-1.5 h-1.5 rounded-full bg-blue-500" />
+                        <div className="ml-auto w-1.5 h-1.5 rounded-full bg-brand-tint" />
                       )}
                     </DropdownMenuItem>
                   ))}
@@ -178,7 +178,7 @@ export function StudioMobileHeader({
           </DropdownMenu>
 
           {activeConnection && (
-            <span className="text-xs text-emerald-500 font-medium px-1.5 py-0.5 rounded bg-emerald-500/10">Online</span>
+            <span className="text-xs text-success font-medium px-1.5 py-0.5 rounded bg-success-tint/10">Online</span>
           )}
         </div>
 
@@ -186,7 +186,7 @@ export function StudioMobileHeader({
           <Button
             variant="ghost"
             size="sm"
-            className="h-8 w-8 p-0 text-fg-muted hover:text-purple-400"
+            className="h-8 w-8 p-0 text-fg-muted hover:text-hue-purple"
             onClick={() => router.push("/monitoring")}
           >
             <Gauge strokeWidth={1.5} className="w-3.5 h-3.5" />
@@ -201,9 +201,9 @@ export function StudioMobileHeader({
               <div
                 className={cn(
                   "w-1.5 h-1.5 rounded-full",
-                  connectionPulse === "healthy" && "bg-emerald-500 animate-pulse",
-                  connectionPulse === "degraded" && "bg-amber-500",
-                  connectionPulse === "error" && "bg-red-500",
+                  connectionPulse === "healthy" && "bg-success-tint animate-pulse",
+                  connectionPulse === "degraded" && "bg-warning-tint",
+                  connectionPulse === "error" && "bg-danger-tint",
                 )}
               />
             </div>
@@ -234,7 +234,7 @@ export function StudioMobileHeader({
                  */}
                 <ThemeToggle showLabel className="w-full px-2 py-1.5 text-sm" />
                 <div className="border-t border-hairline my-1" />
-                <DropdownMenuItem onClick={onLogout} className="text-red-400 cursor-pointer">
+                <DropdownMenuItem onClick={onLogout} className="text-danger cursor-pointer">
                   <LogOut strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Logout
                 </DropdownMenuItem>
                 <div className="border-t border-hairline mt-1 pt-1 px-2 pb-1">
@@ -265,7 +265,7 @@ export function StudioMobileHeader({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-7 px-2 gap-1 text-xs font-medium text-fg-muted hover:text-blue-400 shrink min-w-0"
+                className="h-7 px-2 gap-1 text-xs font-medium text-fg-muted hover:text-brand shrink min-w-0"
                 onClick={onAskAgent}
               >
                 <Bot strokeWidth={1.5} className="w-3 h-3" />
@@ -298,7 +298,7 @@ export function StudioMobileHeader({
                 >
                   <Copy strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Copy Query
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={onClearQuery} className="cursor-pointer text-xs text-red-400">
+                <DropdownMenuItem onClick={onClearQuery} className="cursor-pointer text-xs text-danger">
                   <Trash2 strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Clear
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={onSaveQuery} className="cursor-pointer text-xs">
@@ -308,7 +308,7 @@ export function StudioMobileHeader({
                 {onExplain && (
                   <>
                     <DropdownMenuSeparator className="bg-fill" />
-                    <DropdownMenuItem onClick={onExplain} className="cursor-pointer text-xs text-amber-400">
+                    <DropdownMenuItem onClick={onExplain} className="cursor-pointer text-xs text-hue-amber">
                       <Zap strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> Explain Plan
                     </DropdownMenuItem>
                   </>
@@ -330,13 +330,10 @@ export function StudioMobileHeader({
                     </DropdownMenuItem>
                   ) : (
                     <>
-                      <DropdownMenuItem
-                        onClick={transaction.commit}
-                        className="cursor-pointer text-xs text-emerald-400"
-                      >
+                      <DropdownMenuItem onClick={transaction.commit} className="cursor-pointer text-xs text-success">
                         <CirclePlay strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> COMMIT
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={transaction.rollback} className="cursor-pointer text-xs text-red-400">
+                      <DropdownMenuItem onClick={transaction.rollback} className="cursor-pointer text-xs text-danger">
                         <CirclePlay strokeWidth={1.5} className="w-3.5 h-3.5 mr-2" /> ROLLBACK
                       </DropdownMenuItem>
                     </>
@@ -364,12 +361,12 @@ export function StudioMobileHeader({
 
             {/* Status badges */}
             {transactionActive && (
-              <span className="text-[0.625rem] font-medium text-amber-400 px-1.5 py-0.5 rounded bg-amber-500/10 border border-amber-500/20">
+              <span className="text-[0.625rem] font-medium text-warning px-1.5 py-0.5 rounded bg-warning-tint/10 border border-warning-tint/20">
                 TXN
               </span>
             )}
             {playgroundMode && (
-              <span className="text-[0.625rem] font-medium text-purple-400 px-1.5 py-0.5 rounded bg-purple-500/10 border border-purple-500/20">
+              <span className="text-[0.625rem] font-medium text-hue-purple px-1.5 py-0.5 rounded bg-hue-purple-tint/10 border border-hue-purple-tint/20">
                 SANDBOX
               </span>
             )}
@@ -378,7 +375,7 @@ export function StudioMobileHeader({
           {isExecuting ? (
             <Button
               size="sm"
-              className="bg-red-600 hover:bg-red-500 text-white font-medium text-xs h-7 px-4 gap-1.5"
+              className="bg-danger-solid hover:bg-danger-solid-hover text-white font-medium text-xs h-7 px-4 gap-1.5"
               onClick={onCancelQuery}
             >
               <Square strokeWidth={1.5} className="w-3 h-3 fill-current" />
@@ -387,7 +384,7 @@ export function StudioMobileHeader({
           ) : (
             <Button
               size="sm"
-              className="bg-blue-600 hover:bg-blue-500 text-white font-medium text-xs h-7 px-4 gap-1.5"
+              className="bg-brand-solid hover:bg-brand-solid-hover text-white font-medium text-xs h-7 px-4 gap-1.5"
               onClick={onExecuteQuery}
               disabled={!activeConnection}
             >

--- a/src/components/studio/StudioTabBar.tsx
+++ b/src/components/studio/StudioTabBar.tsx
@@ -66,7 +66,7 @@ export function StudioTabBar({
           className={cn(
             "h-8 flex items-center px-3 gap-2 rounded-t-md transition-all cursor-pointer min-w-[120px] max-w-[200px] group relative border-t-2",
             activeTabId === tab.id
-              ? "bg-overlay text-fg border-blue-500"
+              ? "bg-overlay text-fg border-brand-tint"
               : "text-fg-muted hover:bg-fill border-transparent",
           )}
         >
@@ -102,7 +102,7 @@ export function StudioTabBar({
                   }, 0);
                 }}
                 onClick={(e) => e.stopPropagation()}
-                className="text-xs font-medium bg-transparent border-b border-blue-500 outline-none w-full text-fg"
+                className="text-xs font-medium bg-transparent border-b border-brand-tint outline-none w-full text-fg"
               />
             </>
           ) : (

--- a/src/lib/db-ui-config.ts
+++ b/src/lib/db-ui-config.ts
@@ -54,7 +54,7 @@ export type ConnectionField = DatabaseUIConfig["connectionFields"][number];
 export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   postgres: {
     icon: PostgreSQLIcon,
-    color: "text-blue-400",
+    color: "text-hue-blue",
     label: "PostgreSQL",
     defaultPort: "5432",
     showConnectionStringToggle: false,
@@ -62,7 +62,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   mysql: {
     icon: MySQLIcon,
-    color: "text-amber-400",
+    color: "text-hue-amber",
     label: "MySQL",
     defaultPort: "3306",
     showConnectionStringToggle: false,
@@ -70,7 +70,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   sqlite: {
     icon: SQLiteIcon,
-    color: "text-cyan-400",
+    color: "text-hue-cyan",
     label: "SQLite",
     defaultPort: "",
     showConnectionStringToggle: false,
@@ -81,7 +81,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     // DuckDB's own mark is a bright yellow (#FFF000), and `text-yellow-400` is already
     // ClickHouse's. yellow-300 is the nearest free shade, and the distinct-colour
     // assertion in tests/unit/lib/db-ui-config.test.ts rules a duplicate out.
-    color: "text-yellow-300",
+    color: "text-hue-yellow-alt",
     label: "DuckDB",
     // Embedded: nothing is listening anywhere, so there is no port to default.
     defaultPort: "",
@@ -100,7 +100,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     // free shade - emerald-400 is MongoDB's, both teals are taken by Couchbase and
     // Elasticsearch, and the distinct-colour assertion in
     // tests/unit/lib/db-ui-config.test.ts rules a duplicate out.
-    color: "text-emerald-300",
+    color: "text-hue-emerald-alt",
     // The protocol's name rather than the product's: one connection here reaches a
     // self-hosted libSQL server OR Turso Cloud, and naming the managed product would
     // read as though the self-hosted one belonged somewhere else.
@@ -120,7 +120,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   mongodb: {
     icon: MongoDBIcon,
-    color: "text-emerald-400",
+    color: "text-hue-emerald",
     label: "MongoDB",
     defaultPort: "27017",
     showConnectionStringToggle: true,
@@ -128,7 +128,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   redis: {
     icon: RedisIcon,
-    color: "text-rose-400",
+    color: "text-hue-rose",
     label: "Redis",
     defaultPort: "6379",
     showConnectionStringToggle: false,
@@ -141,7 +141,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   oracle: {
     icon: OracleIcon,
-    color: "text-red-400",
+    color: "text-hue-red",
     label: "Oracle",
     defaultPort: "1521",
     showConnectionStringToggle: false,
@@ -149,7 +149,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   mssql: {
     icon: MSSQLIcon,
-    color: "text-sky-400",
+    color: "text-hue-sky",
     label: "SQL Server",
     defaultPort: "1433",
     showConnectionStringToggle: false,
@@ -157,7 +157,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   couchbase: {
     icon: CouchbaseIcon,
-    color: "text-orange-400",
+    color: "text-hue-orange",
     label: "Couchbase",
     // Management port. The query ports are discovered from the cluster at connect
     // time (issue #262, decision 3), so only this one is ever stored.
@@ -167,7 +167,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   clickhouse: {
     icon: ClickHouseIcon,
-    color: "text-yellow-400",
+    color: "text-hue-yellow",
     label: "ClickHouse",
     // The HTTP interface port. The provider speaks HTTP only, so the native
     // protocol port 9000 is never a valid value here (issue #264).
@@ -180,7 +180,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     // Issue #265 specified text-sky-400, which mssql already owns; the distinct-colour
     // assertion in tests/unit/lib/db-ui-config.test.ts rules a duplicate out. teal-400
     // is the nearest free shade and is closer to Druid's own petrol-teal mark anyway.
-    color: "text-teal-400",
+    color: "text-hue-teal",
     label: "Apache Druid",
     // The Router port. The Broker on 8082 serves the identical POST /druid/v2/sql and
     // needs no different configuration (live-verified, issue #265); the Router is the
@@ -202,7 +202,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     // and yellow-400 are already owned by druid and clickhouse, and the distinct-colour
     // assertion in tests/unit/lib/db-ui-config.test.ts rules a duplicate out. teal-300
     // is the nearest free shade to the brand teal.
-    color: "text-teal-300",
+    color: "text-hue-teal-alt",
     label: "Elasticsearch",
     // 9200 for both products and both schemes: a TLS deployment serves HTTPS on the
     // SAME port rather than on a second well-known one, so unlike ClickHouse there is
@@ -224,7 +224,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     icon: OpenSearchIcon,
     // OpenSearch's Pacific Blue (#005EB8) is deeper and bluer than postgres' own
     // blue-400, which already owns "blue" here; indigo-400 is the nearest free shade.
-    color: "text-indigo-400",
+    color: "text-hue-indigo",
     label: "OpenSearch",
     // Same 9200 floor, same reason - the fork kept the port.
     defaultPort: "9200",
@@ -236,7 +236,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     // Trino's own mark is a magenta-pink (#DD00A1); pink-400 is the nearest free
     // shade, and the distinct-colour assertion in tests/unit/lib/db-ui-config.test.ts
     // rules a duplicate out.
-    color: "text-pink-400",
+    color: "text-hue-pink",
     // The product's own name, with no vendor word in front of it: "Trino" is what the
     // project calls itself, unlike "Apache Druid".
     label: "Trino",
@@ -261,7 +261,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     // Cassandra's own mark is a mid-cyan eye (#1287B1). sky-400 is mssql's and the
     // distinct-colour assertion in tests/unit/lib/db-ui-config.test.ts rules a
     // duplicate out, so sky-300 is the nearest free shade.
-    color: "text-sky-300",
+    color: "text-hue-sky-alt",
     // The project's own name, vendor word included, exactly as "Apache Druid" is
     // spelled here: the ASF name is how this engine is universally written.
     label: "Apache Cassandra",
@@ -283,7 +283,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   libredb: {
     icon: LibreDBIcon,
-    color: "text-violet-400",
+    color: "text-hue-violet",
     label: "LibreDB",
     defaultPort: "",
     showConnectionStringToggle: false,

--- a/src/lib/db-ui-config.ts
+++ b/src/lib/db-ui-config.ts
@@ -78,9 +78,10 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   duckdb: {
     icon: DuckDBIcon,
-    // DuckDB's own mark is a bright yellow (#FFF000), and `text-yellow-400` is already
-    // ClickHouse's. yellow-300 is the nearest free shade, and the distinct-colour
-    // assertion in tests/unit/lib/db-ui-config.test.ts rules a duplicate out.
+    // DuckDB's own mark is a bright yellow (#FFF000), and `hue-yellow` is already
+    // ClickHouse's. `-alt` is the second step of that hue, kept apart from its base
+    // in both palettes; the distinct-colour assertion in
+    // tests/unit/lib/db-ui-config.test.ts rules a duplicate out.
     color: "text-hue-yellow-alt",
     label: "DuckDB",
     // Embedded: nothing is listening anywhere, so there is no port to default.
@@ -177,9 +178,9 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
   },
   druid: {
     icon: DruidIcon,
-    // Issue #265 specified text-sky-400, which mssql already owns; the distinct-colour
-    // assertion in tests/unit/lib/db-ui-config.test.ts rules a duplicate out. teal-400
-    // is the nearest free shade and is closer to Druid's own petrol-teal mark anyway.
+    // Issue #265 specified sky, which mssql already owns; the distinct-colour
+    // assertion in tests/unit/lib/db-ui-config.test.ts rules a duplicate out.
+    // `hue-teal` was free and is closer to Druid's own petrol-teal mark anyway.
     color: "text-hue-teal",
     label: "Apache Druid",
     // The Router port. The Broker on 8082 serves the identical POST /druid/v2/sql and

--- a/src/lib/monitoring-thresholds.ts
+++ b/src/lib/monitoring-thresholds.ts
@@ -30,11 +30,11 @@ export function evaluateThreshold(value: number, config: ThresholdConfig): Thres
 export function getThresholdColor(level: ThresholdLevel): string {
   switch (level) {
     case "critical":
-      return "border-red-500/50";
+      return "border-danger-tint/50";
     case "warning":
-      return "border-yellow-500/50";
+      return "border-hue-yellow-tint/50";
     case "healthy":
-      return "border-green-500/30";
+      return "border-hue-green-tint/30";
   }
 }
 

--- a/src/lib/monitoring-thresholds.ts
+++ b/src/lib/monitoring-thresholds.ts
@@ -30,7 +30,7 @@ export function evaluateThreshold(value: number, config: ThresholdConfig): Thres
 export function getThresholdColor(level: ThresholdLevel): string {
   switch (level) {
     case "critical":
-      return "border-danger-tint/50";
+      return "border-hue-red-tint/50";
     case "warning":
       return "border-hue-yellow-tint/50";
     case "healthy":

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -130,7 +130,7 @@
    * ── Accents: identity ─────────────────────────────────────────────────
    * Colour that answers WHICH THING, not what state: which engine, which bottom
    * panel, added vs removed, primary key vs foreign key, number vs boolean. Folding
-   * these into the four state roles would repaint nineteen engines in four colours,
+   * these into the four state roles would repaint seventeen engines in four colours,
    * so they get their own family — SELECTED per mode, the way `charts/palette.ts`
    * selects rather than flipping a ramp, and for the same reason: the two modes run
    * out of room in different places. Dark's tightest pair is amber/yellow; light's

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -74,6 +74,118 @@
   --studio-fg-subtle: #a1a1aa;
   /* Below the ramp: decoration and hints — separator dots, empty-state subtext. */
   --studio-fg-faint: #d4d4d8;
+
+  /*
+   * ── Accents: state ────────────────────────────────────────────────────
+   * #402. The neutral ramp was tokenised in #384; the accents were not, so they
+   * kept values selected against a near-black ground and were then asked to serve
+   * two. `text-blue-300` on `bg-blue-500/15` reads at 9.5:1 over `#0a0a0a` and at
+   * 1.46:1 over `#fafafa` — the same two class names, a chip you can see and a
+   * word you cannot read.
+   *
+   * Four roles, each with two text steps. `-bright` is the emphasised one, and it
+   * inverts exactly like `fg-bright` does: brighter than its base in dark, darker
+   * in light. Both directions mean "further from the ground".
+   *
+   * `-tint` is the wash the roles are painted over (`bg-accent-tint/15`), and it is
+   * the SAME value in both palettes on purpose — a wash is alpha over whatever is
+   * behind it, so it already adapts, and the text step above is what has to move.
+   * `-solid` and `-solid-hover` are the filled-button grounds, mode-independent for
+   * the same reason: a button's label sits on the button, not on the page.
+   *
+   * Every value here was selected by measurement, not by eye, and
+   * `tests/unit/theme-accent-contrast.test.ts` re-measures it on every run.
+   */
+  --studio-accent: #1447e6;
+  --studio-accent-bright: #193cb8;
+  --studio-accent-tint: #2b7fff;
+  --studio-accent-solid: #155dfc;
+  --studio-accent-solid-hover: #2b7fff;
+
+  --studio-warning: #973c00;
+  --studio-warning-bright: #7b3306;
+  --studio-warning-tint: #fe9a00;
+  --studio-warning-solid: #e17100;
+  --studio-warning-solid-hover: #fe9a00;
+
+  --studio-success: #006045;
+  --studio-success-bright: #004f3b;
+  --studio-success-tint: #00bc7d;
+  --studio-success-solid: #009966;
+  --studio-success-solid-hover: #00bc7d;
+
+  --studio-danger: #9f0712;
+  --studio-danger-bright: #82181a;
+  --studio-danger-tint: #fb2c36;
+  --studio-danger-solid: #e7000b;
+  --studio-danger-solid-hover: #fb2c36;
+
+  /*
+   * ── Accents: identity ─────────────────────────────────────────────────
+   * Colour that answers WHICH THING, not what state: which engine, which bottom
+   * panel, added vs removed, primary key vs foreign key, number vs boolean. Folding
+   * these into the four state roles would repaint nineteen engines in four colours,
+   * so they get their own family — SELECTED per mode, the way `charts/palette.ts`
+   * selects rather than flipping a ramp, and for the same reason: the two modes run
+   * out of room in different places. Dark's tightest pair is amber/yellow; light's
+   * is blue/indigo.
+   *
+   * `-alt` is a second step of the same hue. For sky, yellow, emerald and teal it
+   * is a second IDENTITY — there are more engines than there are hues, and
+   * `db-ui-config`'s own test asserts every engine colour differs — and those four
+   * therefore join the separation set. Elsewhere it is emphasis on one identity.
+   *
+   * Two deviations from "the lightest step that clears AA", both forced by
+   * separation rather than by contrast: amber sits at -900 because -800 is already
+   * an orange at that lightness and collides with orange itself, and yellow's alt
+   * drops to -950 for the same reason. The warm hues converge as they darken; the
+   * cold ones do not.
+   */
+  --studio-hue-blue: #1447e6;
+  --studio-hue-blue-alt: #193cb8;
+  --studio-hue-blue-tint: #2b7fff;
+  --studio-hue-sky: #00598a;
+  --studio-hue-sky-alt: #024a70;
+  --studio-hue-sky-tint: #00a6f4;
+  --studio-hue-indigo: #432dd7;
+  --studio-hue-indigo-alt: #372aac;
+  --studio-hue-indigo-tint: #615fff;
+  --studio-hue-violet: #7008e7;
+  --studio-hue-violet-alt: #5d0ec0;
+  --studio-hue-violet-tint: #8e51ff;
+  --studio-hue-purple: #8200db;
+  --studio-hue-purple-alt: #6e11b0;
+  --studio-hue-purple-tint: #ad46ff;
+  --studio-hue-pink: #a3004c;
+  --studio-hue-pink-alt: #861043;
+  --studio-hue-pink-tint: #f6339a;
+  --studio-hue-rose: #a50036;
+  --studio-hue-rose-alt: #8b0836;
+  --studio-hue-rose-tint: #ff2056;
+  --studio-hue-red: #9f0712;
+  --studio-hue-red-alt: #82181a;
+  --studio-hue-red-tint: #fb2c36;
+  --studio-hue-orange: #9f2d00;
+  --studio-hue-orange-alt: #7e2a0c;
+  --studio-hue-orange-tint: #ff6900;
+  --studio-hue-amber: #7b3306;
+  --studio-hue-amber-alt: #461901;
+  --studio-hue-amber-tint: #fe9a00;
+  --studio-hue-yellow: #894b00;
+  --studio-hue-yellow-alt: #432004;
+  --studio-hue-yellow-tint: #f0b100;
+  --studio-hue-green: #016630;
+  --studio-hue-green-alt: #0d542b;
+  --studio-hue-green-tint: #00c950;
+  --studio-hue-emerald: #006045;
+  --studio-hue-emerald-alt: #004f3b;
+  --studio-hue-emerald-tint: #00bc7d;
+  --studio-hue-teal: #005f5a;
+  --studio-hue-teal-alt: #022f2e;
+  --studio-hue-teal-tint: #00bba7;
+  --studio-hue-cyan: #005f78;
+  --studio-hue-cyan-alt: #104e64;
+  --studio-hue-cyan-tint: #00b8db;
 }
 
 .dark {
@@ -108,6 +220,85 @@
   --studio-fg-muted: #71717a;
   --studio-fg-subtle: #52525b;
   --studio-fg-faint: #3f3f46;
+
+  /*
+   * ── Accents ───────────────────────────────────────────────────────────
+   * Every value below is the literal the components carried before #402 — the -400
+   * step for a base, -300 for `-bright` and `-alt` — reproduced exactly. Switching
+   * a component onto an accent token must not change how it looks in dark, and
+   * `tests/unit/theme-accent-contrast.test.ts` resolves these against the installed
+   * Tailwind palette rather than against transcribed hexes, so a Tailwind upgrade
+   * that restyles `blue-400` reports itself as the dark-mode change it is.
+   */
+  --studio-accent: #51a2ff;
+  --studio-accent-bright: #8ec5ff;
+  --studio-accent-tint: #2b7fff;
+  --studio-accent-solid: #155dfc;
+  --studio-accent-solid-hover: #2b7fff;
+
+  --studio-warning: #ffb900;
+  --studio-warning-bright: #ffd230;
+  --studio-warning-tint: #fe9a00;
+  --studio-warning-solid: #e17100;
+  --studio-warning-solid-hover: #fe9a00;
+
+  --studio-success: #00d492;
+  --studio-success-bright: #5ee9b5;
+  --studio-success-tint: #00bc7d;
+  --studio-success-solid: #009966;
+  --studio-success-solid-hover: #00bc7d;
+
+  --studio-danger: #ff6467;
+  --studio-danger-bright: #ffa2a2;
+  --studio-danger-tint: #fb2c36;
+  --studio-danger-solid: #e7000b;
+  --studio-danger-solid-hover: #fb2c36;
+
+  --studio-hue-blue: #51a2ff;
+  --studio-hue-blue-alt: #8ec5ff;
+  --studio-hue-blue-tint: #2b7fff;
+  --studio-hue-sky: #00bcff;
+  --studio-hue-sky-alt: #74d4ff;
+  --studio-hue-sky-tint: #00a6f4;
+  --studio-hue-indigo: #7c86ff;
+  --studio-hue-indigo-alt: #a3b3ff;
+  --studio-hue-indigo-tint: #615fff;
+  --studio-hue-violet: #a684ff;
+  --studio-hue-violet-alt: #c4b4ff;
+  --studio-hue-violet-tint: #8e51ff;
+  --studio-hue-purple: #c27aff;
+  --studio-hue-purple-alt: #dab2ff;
+  --studio-hue-purple-tint: #ad46ff;
+  --studio-hue-pink: #fb64b6;
+  --studio-hue-pink-alt: #fda5d5;
+  --studio-hue-pink-tint: #f6339a;
+  --studio-hue-rose: #ff637e;
+  --studio-hue-rose-alt: #ffa1ad;
+  --studio-hue-rose-tint: #ff2056;
+  --studio-hue-red: #ff6467;
+  --studio-hue-red-alt: #ffa2a2;
+  --studio-hue-red-tint: #fb2c36;
+  --studio-hue-orange: #ff8904;
+  --studio-hue-orange-alt: #ffb86a;
+  --studio-hue-orange-tint: #ff6900;
+  --studio-hue-amber: #ffb900;
+  --studio-hue-amber-alt: #ffd230;
+  --studio-hue-amber-tint: #fe9a00;
+  --studio-hue-yellow: #fdc700;
+  --studio-hue-yellow-alt: #ffdf20;
+  --studio-hue-yellow-tint: #f0b100;
+  --studio-hue-green: #05df72;
+  --studio-hue-green-alt: #7bf1a8;
+  --studio-hue-green-tint: #00c950;
+  --studio-hue-emerald: #00d492;
+  --studio-hue-emerald-alt: #5ee9b5;
+  --studio-hue-emerald-tint: #00bc7d;
+  --studio-hue-teal: #00d5be;
+  --studio-hue-teal-alt: #46ecd5;
+  --studio-hue-teal-tint: #00bba7;
+  --studio-hue-cyan: #00d3f2;
+  --studio-hue-cyan-alt: #53eafd;
+  --studio-hue-cyan-tint: #00b8db;
 }
 
 /*
@@ -144,4 +335,74 @@
   --color-fg-muted: var(--studio-fg-muted);
   --color-fg-subtle: var(--studio-fg-subtle);
   --color-fg-faint: var(--studio-fg-faint);
+
+  --color-accent: var(--studio-accent);
+  --color-accent-bright: var(--studio-accent-bright);
+  --color-accent-tint: var(--studio-accent-tint);
+  --color-accent-solid: var(--studio-accent-solid);
+  --color-accent-solid-hover: var(--studio-accent-solid-hover);
+
+  --color-warning: var(--studio-warning);
+  --color-warning-bright: var(--studio-warning-bright);
+  --color-warning-tint: var(--studio-warning-tint);
+  --color-warning-solid: var(--studio-warning-solid);
+  --color-warning-solid-hover: var(--studio-warning-solid-hover);
+
+  --color-success: var(--studio-success);
+  --color-success-bright: var(--studio-success-bright);
+  --color-success-tint: var(--studio-success-tint);
+  --color-success-solid: var(--studio-success-solid);
+  --color-success-solid-hover: var(--studio-success-solid-hover);
+
+  --color-danger: var(--studio-danger);
+  --color-danger-bright: var(--studio-danger-bright);
+  --color-danger-tint: var(--studio-danger-tint);
+  --color-danger-solid: var(--studio-danger-solid);
+  --color-danger-solid-hover: var(--studio-danger-solid-hover);
+
+  --color-hue-blue: var(--studio-hue-blue);
+  --color-hue-blue-alt: var(--studio-hue-blue-alt);
+  --color-hue-blue-tint: var(--studio-hue-blue-tint);
+  --color-hue-sky: var(--studio-hue-sky);
+  --color-hue-sky-alt: var(--studio-hue-sky-alt);
+  --color-hue-sky-tint: var(--studio-hue-sky-tint);
+  --color-hue-indigo: var(--studio-hue-indigo);
+  --color-hue-indigo-alt: var(--studio-hue-indigo-alt);
+  --color-hue-indigo-tint: var(--studio-hue-indigo-tint);
+  --color-hue-violet: var(--studio-hue-violet);
+  --color-hue-violet-alt: var(--studio-hue-violet-alt);
+  --color-hue-violet-tint: var(--studio-hue-violet-tint);
+  --color-hue-purple: var(--studio-hue-purple);
+  --color-hue-purple-alt: var(--studio-hue-purple-alt);
+  --color-hue-purple-tint: var(--studio-hue-purple-tint);
+  --color-hue-pink: var(--studio-hue-pink);
+  --color-hue-pink-alt: var(--studio-hue-pink-alt);
+  --color-hue-pink-tint: var(--studio-hue-pink-tint);
+  --color-hue-rose: var(--studio-hue-rose);
+  --color-hue-rose-alt: var(--studio-hue-rose-alt);
+  --color-hue-rose-tint: var(--studio-hue-rose-tint);
+  --color-hue-red: var(--studio-hue-red);
+  --color-hue-red-alt: var(--studio-hue-red-alt);
+  --color-hue-red-tint: var(--studio-hue-red-tint);
+  --color-hue-orange: var(--studio-hue-orange);
+  --color-hue-orange-alt: var(--studio-hue-orange-alt);
+  --color-hue-orange-tint: var(--studio-hue-orange-tint);
+  --color-hue-amber: var(--studio-hue-amber);
+  --color-hue-amber-alt: var(--studio-hue-amber-alt);
+  --color-hue-amber-tint: var(--studio-hue-amber-tint);
+  --color-hue-yellow: var(--studio-hue-yellow);
+  --color-hue-yellow-alt: var(--studio-hue-yellow-alt);
+  --color-hue-yellow-tint: var(--studio-hue-yellow-tint);
+  --color-hue-green: var(--studio-hue-green);
+  --color-hue-green-alt: var(--studio-hue-green-alt);
+  --color-hue-green-tint: var(--studio-hue-green-tint);
+  --color-hue-emerald: var(--studio-hue-emerald);
+  --color-hue-emerald-alt: var(--studio-hue-emerald-alt);
+  --color-hue-emerald-tint: var(--studio-hue-emerald-tint);
+  --color-hue-teal: var(--studio-hue-teal);
+  --color-hue-teal-alt: var(--studio-hue-teal-alt);
+  --color-hue-teal-tint: var(--studio-hue-teal-tint);
+  --color-hue-cyan: var(--studio-hue-cyan);
+  --color-hue-cyan-alt: var(--studio-hue-cyan-alt);
+  --color-hue-cyan-tint: var(--studio-hue-cyan-tint);
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -87,7 +87,7 @@
    * inverts exactly like `fg-bright` does: brighter than its base in dark, darker
    * in light. Both directions mean "further from the ground".
    *
-   * `-tint` is the wash the roles are painted over (`bg-accent-tint/15`), and it is
+   * `-tint` is the wash the roles are painted over (`bg-brand-tint/15`), and it is
    * the SAME value in both palettes on purpose — a wash is alpha over whatever is
    * behind it, so it already adapts, and the text step above is what has to move.
    * `-solid` and `-solid-hover` are the filled-button grounds, mode-independent for
@@ -96,11 +96,17 @@
    * Every value here was selected by measurement, not by eye, and
    * `tests/unit/theme-accent-contrast.test.ts` re-measures it on every run.
    */
-  --studio-accent: #1447e6;
-  --studio-accent-bright: #193cb8;
-  --studio-accent-tint: #2b7fff;
-  --studio-accent-solid: #155dfc;
-  --studio-accent-solid-hover: #2b7fff;
+  --studio-brand: #1447e6;
+  --studio-brand-bright: #193cb8;
+  --studio-brand-tint: #2b7fff;
+  --studio-brand-solid: #155dfc;
+  --studio-brand-solid-hover: #2b7fff;
+  /*
+   * The three standalone error pages hover the other way — they darken rather than
+   * lighten. Flattening them onto `-solid-hover` inverted the direction AND took
+   * white-on-hover from 6.8:1 to 3.8:1, so they keep a step of their own.
+   */
+  --studio-brand-solid-active: #1447e6;
 
   --studio-warning: #973c00;
   --studio-warning-bright: #7b3306;
@@ -135,47 +141,38 @@
    * `db-ui-config`'s own test asserts every engine colour differs — and those four
    * therefore join the separation set. Elsewhere it is emphasis on one identity.
    *
-   * Two deviations from "the lightest step that clears AA", both forced by
-   * separation rather than by contrast: amber sits at -900 because -800 is already
-   * an orange at that lightness and collides with orange itself, and yellow's alt
-   * drops to -950 for the same reason. The warm hues converge as they darken; the
-   * cold ones do not.
+   * One deviation from "the lightest step that clears AA", forced by separation
+   * rather than by contrast: orange sits at -900, because Tailwind's amber ramp
+   * rotates toward orange as it darkens and amber-800 / orange-800 land 0.029
+   * apart in Oklab — under the shipped dark set's own tightest pair. Teal's alt
+   * drops to -950 against emerald's for the same reason. The warm hues and the
+   * greens converge as they darken; nothing else does.
    */
   --studio-hue-blue: #1447e6;
   --studio-hue-blue-alt: #193cb8;
   --studio-hue-blue-tint: #2b7fff;
   --studio-hue-sky: #00598a;
   --studio-hue-sky-alt: #024a70;
-  --studio-hue-sky-tint: #00a6f4;
   --studio-hue-indigo: #432dd7;
-  --studio-hue-indigo-alt: #372aac;
   --studio-hue-indigo-tint: #615fff;
   --studio-hue-violet: #7008e7;
-  --studio-hue-violet-alt: #5d0ec0;
-  --studio-hue-violet-tint: #8e51ff;
   --studio-hue-purple: #8200db;
   --studio-hue-purple-alt: #6e11b0;
   --studio-hue-purple-tint: #ad46ff;
   --studio-hue-pink: #a3004c;
-  --studio-hue-pink-alt: #861043;
-  --studio-hue-pink-tint: #f6339a;
   --studio-hue-rose: #a50036;
   --studio-hue-rose-alt: #8b0836;
   --studio-hue-rose-tint: #ff2056;
   --studio-hue-red: #9f0712;
-  --studio-hue-red-alt: #82181a;
   --studio-hue-red-tint: #fb2c36;
-  --studio-hue-orange: #9f2d00;
-  --studio-hue-orange-alt: #7e2a0c;
+  --studio-hue-orange: #7e2a0c;
   --studio-hue-orange-tint: #ff6900;
-  --studio-hue-amber: #7b3306;
-  --studio-hue-amber-alt: #461901;
+  --studio-hue-amber: #973c00;
   --studio-hue-amber-tint: #fe9a00;
   --studio-hue-yellow: #894b00;
-  --studio-hue-yellow-alt: #432004;
+  --studio-hue-yellow-alt: #733e0a;
   --studio-hue-yellow-tint: #f0b100;
   --studio-hue-green: #016630;
-  --studio-hue-green-alt: #0d542b;
   --studio-hue-green-tint: #00c950;
   --studio-hue-emerald: #006045;
   --studio-hue-emerald-alt: #004f3b;
@@ -184,8 +181,24 @@
   --studio-hue-teal-alt: #022f2e;
   --studio-hue-teal-tint: #00bba7;
   --studio-hue-cyan: #005f78;
-  --studio-hue-cyan-alt: #104e64;
   --studio-hue-cyan-tint: #00b8db;
+  /*
+   * Two identity hues carry a filled control of their own: Database Docs' "AI
+   * Describe" button is teal because the panel is, and VisualExplain's AI tab is
+   * purple for the same reason. Added on demand rather than sixteen times over —
+   * the other fourteen hues have no solid, and a third one that needs it can ask.
+   *
+   * White on teal-600 measures 3.66:1, and on purple's hover step 4.12:1 — both
+   * under AA. Those are the values the buttons already carried, in both themes, so
+   * they are not this migration's to change; they are filed separately along with
+   * the state solids, which fail the same way.
+   */
+  --studio-hue-teal-solid: #009689;
+  --studio-hue-teal-solid-hover: #00bba7;
+  --studio-hue-purple-solid: #9810fa;
+  --studio-hue-purple-solid-hover: #ad46ff;
+
+  --studio-hue-fuchsia: #8a0194;
 }
 
 .dark {
@@ -230,11 +243,17 @@
    * Tailwind palette rather than against transcribed hexes, so a Tailwind upgrade
    * that restyles `blue-400` reports itself as the dark-mode change it is.
    */
-  --studio-accent: #51a2ff;
-  --studio-accent-bright: #8ec5ff;
-  --studio-accent-tint: #2b7fff;
-  --studio-accent-solid: #155dfc;
-  --studio-accent-solid-hover: #2b7fff;
+  --studio-brand: #51a2ff;
+  --studio-brand-bright: #8ec5ff;
+  --studio-brand-tint: #2b7fff;
+  --studio-brand-solid: #155dfc;
+  --studio-brand-solid-hover: #2b7fff;
+  /*
+   * The three standalone error pages hover the other way — they darken rather than
+   * lighten. Flattening them onto `-solid-hover` inverted the direction AND took
+   * white-on-hover from 6.8:1 to 3.8:1, so they keep a step of their own.
+   */
+  --studio-brand-solid-active: #1447e6;
 
   --studio-warning: #ffb900;
   --studio-warning-bright: #ffd230;
@@ -259,36 +278,26 @@
   --studio-hue-blue-tint: #2b7fff;
   --studio-hue-sky: #00bcff;
   --studio-hue-sky-alt: #74d4ff;
-  --studio-hue-sky-tint: #00a6f4;
   --studio-hue-indigo: #7c86ff;
-  --studio-hue-indigo-alt: #a3b3ff;
   --studio-hue-indigo-tint: #615fff;
   --studio-hue-violet: #a684ff;
-  --studio-hue-violet-alt: #c4b4ff;
-  --studio-hue-violet-tint: #8e51ff;
   --studio-hue-purple: #c27aff;
   --studio-hue-purple-alt: #dab2ff;
   --studio-hue-purple-tint: #ad46ff;
   --studio-hue-pink: #fb64b6;
-  --studio-hue-pink-alt: #fda5d5;
-  --studio-hue-pink-tint: #f6339a;
   --studio-hue-rose: #ff637e;
   --studio-hue-rose-alt: #ffa1ad;
   --studio-hue-rose-tint: #ff2056;
   --studio-hue-red: #ff6467;
-  --studio-hue-red-alt: #ffa2a2;
   --studio-hue-red-tint: #fb2c36;
   --studio-hue-orange: #ff8904;
-  --studio-hue-orange-alt: #ffb86a;
   --studio-hue-orange-tint: #ff6900;
   --studio-hue-amber: #ffb900;
-  --studio-hue-amber-alt: #ffd230;
   --studio-hue-amber-tint: #fe9a00;
   --studio-hue-yellow: #fdc700;
   --studio-hue-yellow-alt: #ffdf20;
   --studio-hue-yellow-tint: #f0b100;
   --studio-hue-green: #05df72;
-  --studio-hue-green-alt: #7bf1a8;
   --studio-hue-green-tint: #00c950;
   --studio-hue-emerald: #00d492;
   --studio-hue-emerald-alt: #5ee9b5;
@@ -297,8 +306,13 @@
   --studio-hue-teal-alt: #46ecd5;
   --studio-hue-teal-tint: #00bba7;
   --studio-hue-cyan: #00d3f2;
-  --studio-hue-cyan-alt: #53eafd;
   --studio-hue-cyan-tint: #00b8db;
+  --studio-hue-teal-solid: #009689;
+  --studio-hue-teal-solid-hover: #00bba7;
+  --studio-hue-purple-solid: #9810fa;
+  --studio-hue-purple-solid-hover: #ad46ff;
+
+  --studio-hue-fuchsia: #ed6aff;
 }
 
 /*
@@ -336,11 +350,12 @@
   --color-fg-subtle: var(--studio-fg-subtle);
   --color-fg-faint: var(--studio-fg-faint);
 
-  --color-accent: var(--studio-accent);
-  --color-accent-bright: var(--studio-accent-bright);
-  --color-accent-tint: var(--studio-accent-tint);
-  --color-accent-solid: var(--studio-accent-solid);
-  --color-accent-solid-hover: var(--studio-accent-solid-hover);
+  --color-brand: var(--studio-brand);
+  --color-brand-bright: var(--studio-brand-bright);
+  --color-brand-tint: var(--studio-brand-tint);
+  --color-brand-solid: var(--studio-brand-solid);
+  --color-brand-solid-hover: var(--studio-brand-solid-hover);
+  --color-brand-solid-active: var(--studio-brand-solid-active);
 
   --color-warning: var(--studio-warning);
   --color-warning-bright: var(--studio-warning-bright);
@@ -365,36 +380,26 @@
   --color-hue-blue-tint: var(--studio-hue-blue-tint);
   --color-hue-sky: var(--studio-hue-sky);
   --color-hue-sky-alt: var(--studio-hue-sky-alt);
-  --color-hue-sky-tint: var(--studio-hue-sky-tint);
   --color-hue-indigo: var(--studio-hue-indigo);
-  --color-hue-indigo-alt: var(--studio-hue-indigo-alt);
   --color-hue-indigo-tint: var(--studio-hue-indigo-tint);
   --color-hue-violet: var(--studio-hue-violet);
-  --color-hue-violet-alt: var(--studio-hue-violet-alt);
-  --color-hue-violet-tint: var(--studio-hue-violet-tint);
   --color-hue-purple: var(--studio-hue-purple);
   --color-hue-purple-alt: var(--studio-hue-purple-alt);
   --color-hue-purple-tint: var(--studio-hue-purple-tint);
   --color-hue-pink: var(--studio-hue-pink);
-  --color-hue-pink-alt: var(--studio-hue-pink-alt);
-  --color-hue-pink-tint: var(--studio-hue-pink-tint);
   --color-hue-rose: var(--studio-hue-rose);
   --color-hue-rose-alt: var(--studio-hue-rose-alt);
   --color-hue-rose-tint: var(--studio-hue-rose-tint);
   --color-hue-red: var(--studio-hue-red);
-  --color-hue-red-alt: var(--studio-hue-red-alt);
   --color-hue-red-tint: var(--studio-hue-red-tint);
   --color-hue-orange: var(--studio-hue-orange);
-  --color-hue-orange-alt: var(--studio-hue-orange-alt);
   --color-hue-orange-tint: var(--studio-hue-orange-tint);
   --color-hue-amber: var(--studio-hue-amber);
-  --color-hue-amber-alt: var(--studio-hue-amber-alt);
   --color-hue-amber-tint: var(--studio-hue-amber-tint);
   --color-hue-yellow: var(--studio-hue-yellow);
   --color-hue-yellow-alt: var(--studio-hue-yellow-alt);
   --color-hue-yellow-tint: var(--studio-hue-yellow-tint);
   --color-hue-green: var(--studio-hue-green);
-  --color-hue-green-alt: var(--studio-hue-green-alt);
   --color-hue-green-tint: var(--studio-hue-green-tint);
   --color-hue-emerald: var(--studio-hue-emerald);
   --color-hue-emerald-alt: var(--studio-hue-emerald-alt);
@@ -403,6 +408,10 @@
   --color-hue-teal-alt: var(--studio-hue-teal-alt);
   --color-hue-teal-tint: var(--studio-hue-teal-tint);
   --color-hue-cyan: var(--studio-hue-cyan);
-  --color-hue-cyan-alt: var(--studio-hue-cyan-alt);
   --color-hue-cyan-tint: var(--studio-hue-cyan-tint);
+  --color-hue-fuchsia: var(--studio-hue-fuchsia);
+  --color-hue-teal-solid: var(--studio-hue-teal-solid);
+  --color-hue-teal-solid-hover: var(--studio-hue-teal-solid-hover);
+  --color-hue-purple-solid: var(--studio-hue-purple-solid);
+  --color-hue-purple-solid-hover: var(--studio-hue-purple-solid-hover);
 }

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -331,7 +331,7 @@ export function StudioWorkspace({
                 onGenerateTestData={features.testDataGenerator ? (name: string) => setTestDataTable(name) : undefined}
               />
             </ResizablePanel>
-            <ResizableHandle className="w-1 bg-transparent hover:bg-blue-500/30 transition-colors" />
+            <ResizableHandle className="w-1 bg-transparent hover:bg-brand-tint/30 transition-colors" />
           </>
         )}
         <ResizablePanel id="workspace-body" defaultSize="78">
@@ -420,7 +420,7 @@ export function StudioWorkspace({
                         </div>
                       </div>
                     </ResizablePanel>
-                    <ResizableHandle className="h-1 bg-fill hover:bg-blue-500/20" />
+                    <ResizableHandle className="h-1 bg-fill hover:bg-brand-tint/20" />
                     <ResizablePanel id="workspace-editor-bottom" defaultSize="60" minSize="20">
                       <BottomPanel
                         mode={queryExec.bottomPanelMode}
@@ -548,7 +548,7 @@ export function StudioWorkspace({
           <div className="px-6 pt-6 pb-4">
             <div className="flex items-start gap-3">
               <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-amber-500/20 to-red-500/10 flex items-center justify-center shrink-0">
-                <TriangleAlert strokeWidth={1.5} className="w-5 h-5 text-amber-400" />
+                <TriangleAlert strokeWidth={1.5} className="w-5 h-5 text-warning" />
               </div>
               <div className="flex-1 min-w-0">
                 <AlertDialogTitle className="text-xs font-medium text-fg mb-1">Load all results?</AlertDialogTitle>
@@ -565,7 +565,7 @@ export function StudioWorkspace({
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={queryExec.handleUnlimitedQuery}
-              className="flex-1 h-9 bg-amber-600 border-0 text-white text-xs font-medium hover:bg-amber-500"
+              className="flex-1 h-9 bg-warning-solid border-0 text-white text-xs font-medium hover:bg-warning-solid-hover"
             >
               Load All
             </AlertDialogAction>

--- a/tests/components/CommandPalette.test.tsx
+++ b/tests/components/CommandPalette.test.tsx
@@ -73,8 +73,8 @@ mock.module("@/lib/db-ui-config", () => ({
     MockDBIcon.displayName = "MockDBIcon";
     return MockDBIcon;
   },
-  getDBConfig: () => ({ icon: () => null, color: "text-blue-400", label: "PostgreSQL", defaultPort: "5432" }),
-  getDBColor: () => "text-blue-400",
+  getDBConfig: () => ({ icon: () => null, color: "text-hue-blue", label: "PostgreSQL", defaultPort: "5432" }),
+  getDBColor: () => "text-hue-blue",
 }));
 
 import { describe, test, expect, afterEach } from "bun:test";

--- a/tests/components/ConnectionModal.mobile.test.tsx
+++ b/tests/components/ConnectionModal.mobile.test.tsx
@@ -178,9 +178,9 @@ function getDefaultForm() {
         value: "postgres",
         label: "PostgreSQL",
         icon: () => React.createElement("span", null, "PG"),
-        color: "text-blue-400",
+        color: "text-hue-blue",
       },
-      { value: "mysql", label: "MySQL", icon: () => React.createElement("span", null, "MY"), color: "text-amber-400" },
+      { value: "mysql", label: "MySQL", icon: () => React.createElement("span", null, "MY"), color: "text-hue-amber" },
     ],
     ...mockFormOverrides,
   };
@@ -209,7 +209,7 @@ const mockFields = (type: string): string[] =>
 mock.module("@/lib/db-ui-config", () => ({
   getDBConfig: (type: string) => ({
     icon: () => null,
-    color: "text-blue-400",
+    color: "text-hue-blue",
     label: type,
     defaultPort: type === "mysql" ? "3306" : type === "mongodb" ? "27017" : "5432",
     showConnectionStringToggle: type === "mongodb",
@@ -217,7 +217,7 @@ mock.module("@/lib/db-ui-config", () => ({
   }),
   takesConnectionField: (type: string, field: string) => mockFields(type).includes(field),
   getDBIcon: () => () => null,
-  getDBColor: () => "text-blue-400",
+  getDBColor: () => "text-hue-blue",
   // See the same note in ConnectionModal.test.tsx: `DB_UI_CONFIG` became an exported
   // binding in #425, so this mock's `{}` now reaches the real `isFileBased` unless the
   // function is mocked here too.

--- a/tests/components/ConnectionModal.test.tsx
+++ b/tests/components/ConnectionModal.test.tsx
@@ -207,17 +207,17 @@ function getDefaultForm() {
         value: "postgres",
         label: "PostgreSQL",
         icon: () => React.createElement("span", null, "PG"),
-        color: "text-blue-400",
+        color: "text-hue-blue",
       },
-      { value: "mysql", label: "MySQL", icon: () => React.createElement("span", null, "MY"), color: "text-amber-400" },
-      { value: "sqlite", label: "SQLite", icon: () => React.createElement("span", null, "SL"), color: "text-cyan-400" },
+      { value: "mysql", label: "MySQL", icon: () => React.createElement("span", null, "MY"), color: "text-hue-amber" },
+      { value: "sqlite", label: "SQLite", icon: () => React.createElement("span", null, "SL"), color: "text-hue-cyan" },
       {
         value: "mongodb",
         label: "MongoDB",
         icon: () => React.createElement("span", null, "MG"),
-        color: "text-emerald-400",
+        color: "text-hue-emerald",
       },
-      { value: "redis", label: "Redis", icon: () => React.createElement("span", null, "RD"), color: "text-red-400" },
+      { value: "redis", label: "Redis", icon: () => React.createElement("span", null, "RD"), color: "text-hue-red" },
     ],
     ...mockFormOverrides,
   };
@@ -248,7 +248,7 @@ const mockFields = (type: string): string[] =>
 mock.module("@/lib/db-ui-config", () => ({
   getDBConfig: (type: string) => ({
     icon: () => null,
-    color: "text-blue-400",
+    color: "text-hue-blue",
     label: type,
     defaultPort: type === "mysql" ? "3306" : type === "mongodb" ? "27017" : "5432",
     // Mirrors the real config: the URI-addressed providers offer the toggle.
@@ -257,7 +257,7 @@ mock.module("@/lib/db-ui-config", () => ({
   }),
   takesConnectionField: (type: string, field: string) => mockFields(type).includes(field),
   getDBIcon: () => () => null,
-  getDBColor: () => "text-blue-400",
+  getDBColor: () => "text-hue-blue",
   // `isFileBased` must be mocked now that `DB_UI_CONFIG` is an exported binding (#425 made
   // it one so the login showcase can enumerate it). The real `isFileBased` reads that
   // binding, and this mock replaces it with `{}`, so leaving the function to the real module
@@ -552,7 +552,7 @@ describe("ConnectionModal", () => {
   test("test result warning message renders as neither success nor failure", () => {
     // A degraded save/connect asks the user to act again - it is not a completed
     // action and not a refusal either, so it must not render as the success
-    // (emerald/CircleCheck) or error (red/CircleX) tone.
+    // (success token/CircleCheck) or error (danger token/CircleX) tone.
     mockFormOverrides = {
       testResult: { tone: "warning", message: "Connected, but this server answered no health data." },
     };

--- a/tests/components/DataProfiler.test.tsx
+++ b/tests/components/DataProfiler.test.tsx
@@ -168,9 +168,9 @@ describe("DataProfiler", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  // ── Null bar coloring: emerald for <20% ──────────────────────────────────
+  // ── Null bar coloring: the success token for <20% ────────────────────────
 
-  test("null bar uses emerald color when nullPercent < 20", async () => {
+  test("null bar uses the success token when nullPercent < 20", async () => {
     const profileWithLowNull = {
       tableName: "users",
       totalRows: 100,
@@ -202,19 +202,19 @@ describe("DataProfiler", () => {
       expect(within(container).queryByText("Column Profiles")).not.toBeNull();
     });
 
-    // The null bar inner div should have emerald class
-    const nullBar = container.querySelector(".bg-emerald-500");
+    // The null bar inner div should carry the success tint
+    const nullBar = container.querySelector(".bg-success-tint");
     expect(nullBar).not.toBeNull();
 
-    // The percent label should also be emerald
+    // The percent label should also carry the success token
     const nullLabel = within(container).queryByText("10% null");
     expect(nullLabel).not.toBeNull();
-    expect(nullLabel!.className).toContain("text-emerald-400");
+    expect(nullLabel!.className).toContain("text-success");
   });
 
-  // ── Null bar coloring: amber for 20-50% ──────────────────────────────────
+  // ── Null bar coloring: the warning token for 20-50% ──────────────────────
 
-  test("null bar uses amber color when nullPercent is between 20 and 50", async () => {
+  test("null bar uses the warning token when nullPercent is between 20 and 50", async () => {
     const profileWithMidNull = {
       tableName: "users",
       totalRows: 100,
@@ -246,17 +246,17 @@ describe("DataProfiler", () => {
       expect(within(container).queryByText("Column Profiles")).not.toBeNull();
     });
 
-    const nullBar = container.querySelector(".bg-amber-500");
+    const nullBar = container.querySelector(".bg-warning-tint");
     expect(nullBar).not.toBeNull();
 
     const nullLabel = within(container).queryByText("35% null");
     expect(nullLabel).not.toBeNull();
-    expect(nullLabel!.className).toContain("text-amber-400");
+    expect(nullLabel!.className).toContain("text-warning");
   });
 
-  // ── Null bar coloring: red for >50% ──────────────────────────────────────
+  // ── Null bar coloring: the danger token for >50% ─────────────────────────
 
-  test("null bar uses red color when nullPercent > 50", async () => {
+  test("null bar uses the danger token when nullPercent > 50", async () => {
     const profileWithHighNull = {
       tableName: "users",
       totalRows: 100,
@@ -288,12 +288,12 @@ describe("DataProfiler", () => {
       expect(within(container).queryByText("Column Profiles")).not.toBeNull();
     });
 
-    const nullBar = container.querySelector(".bg-red-500");
+    const nullBar = container.querySelector(".bg-danger-tint");
     expect(nullBar).not.toBeNull();
 
     const nullLabel = within(container).queryByText("75% null");
     expect(nullLabel).not.toBeNull();
-    expect(nullLabel!.className).toContain("text-red-400");
+    expect(nullLabel!.className).toContain("text-danger");
   });
 
   // ── Min/Max value display ────────────────────────────────────────────────
@@ -431,8 +431,8 @@ describe("DataProfiler", () => {
       expect(view.queryByText("Connection refused")).not.toBeNull();
     });
 
-    // Error should be in a red-styled container
-    const errorDiv = container.querySelector(".bg-red-500\\/10");
+    // Error should be in a danger-styled container
+    const errorDiv = container.querySelector(".bg-danger-tint\\/10");
     expect(errorDiv).not.toBeNull();
   });
 
@@ -469,10 +469,10 @@ describe("DataProfiler", () => {
       expect(view.queryByText("Permission denied for column")).not.toBeNull();
     });
 
-    // Error text should have amber color class
+    // Error text should carry the warning token
     const errorEl = view.queryByText("Permission denied for column");
     expect(errorEl).not.toBeNull();
-    expect(errorEl!.className).toContain("text-amber-400");
+    expect(errorEl!.className).toContain("text-warning");
   });
 
   // ── Sensitive column masking (lock icon + masked values) ─────────────────

--- a/tests/components/MaskingSettings.test.tsx
+++ b/tests/components/MaskingSettings.test.tsx
@@ -163,8 +163,8 @@ describe("MaskingSettings", () => {
     const { container } = render(<MaskingSettings />);
     const view = within(container);
 
-    // Delete buttons have the text-red-400 class and Trash2 icon
-    const deleteButtons = container.querySelectorAll("button.text-red-400");
+    // Delete buttons carry the danger token and a Trash2 icon
+    const deleteButtons = container.querySelectorAll("button.text-danger");
     // There should be exactly 1 delete button (for Phone, the non-builtin)
     expect(deleteButtons.length).toBe(1);
 

--- a/tests/components/QueryHistory.test.tsx
+++ b/tests/components/QueryHistory.test.tsx
@@ -97,8 +97,8 @@ describe("QueryHistory", () => {
     const props = createDefaultProps();
     const { container } = render(<QueryHistory {...props} />);
 
-    const successIndicators = container.querySelectorAll(".bg-emerald-500\\/10");
-    const errorIndicators = container.querySelectorAll(".bg-red-500\\/10");
+    const successIndicators = container.querySelectorAll(".bg-success-tint\\/10");
+    const errorIndicators = container.querySelectorAll(".bg-danger-tint\\/10");
 
     expect(successIndicators.length).toBeGreaterThan(0);
     expect(errorIndicators.length).toBeGreaterThan(0);
@@ -427,7 +427,7 @@ describe("QueryHistory", () => {
 
   // ── Duration > 500ms amber styling ────────────────────────────────────────
 
-  test("duration greater than 500ms shows amber styling", () => {
+  test("duration greater than 500ms shows the warning token styling", () => {
     const slowHistory = [
       {
         id: "h-slow",
@@ -446,10 +446,10 @@ describe("QueryHistory", () => {
     const props = createDefaultProps();
     const { container } = render(<QueryHistory {...props} />);
 
-    // The 750ms duration cell should have amber styling
-    const amberBadge = container.querySelector(".text-amber-400.bg-amber-400\\/10");
-    expect(amberBadge).not.toBeNull();
-    expect(amberBadge!.textContent).toBe("750ms");
+    // The 750ms duration cell should carry the warning token styling
+    const warningBadge = container.querySelector(".text-warning.bg-warning\\/10");
+    expect(warningBadge).not.toBeNull();
+    expect(warningBadge!.textContent).toBe("750ms");
   });
 
   // ── Error message display for failed queries ──────────────────────────────

--- a/tests/components/QuerySafetyDialog.test.tsx
+++ b/tests/components/QuerySafetyDialog.test.tsx
@@ -338,7 +338,7 @@ describe("QuerySafetyDialog", () => {
     });
   });
 
-  test("applies correct severity styling to warnings (critical=red, warning=amber, info=blue)", async () => {
+  test("applies correct severity styling to warnings (critical=danger, warning=warning, info=accent)", async () => {
     const payload = {
       riskLevel: "high",
       summary: "Multiple warnings.",
@@ -372,16 +372,16 @@ describe("QuerySafetyDialog", () => {
     });
 
     const criticalEl = queryByText("Critical warning")!.closest("div");
-    expect(criticalEl?.className).toContain("bg-red-500/5");
-    expect(criticalEl?.className).toContain("border-red-500/20");
+    expect(criticalEl?.className).toContain("bg-danger-tint/5");
+    expect(criticalEl?.className).toContain("border-danger-tint/20");
 
     const warningEl = queryByText("Warning level")!.closest("div");
-    expect(warningEl?.className).toContain("bg-amber-500/5");
-    expect(warningEl?.className).toContain("border-amber-500/20");
+    expect(warningEl?.className).toContain("bg-warning-tint/5");
+    expect(warningEl?.className).toContain("border-warning-tint/20");
 
     const infoEl = queryByText("Info level")!.closest("div");
-    expect(infoEl?.className).toContain("bg-blue-500/5");
-    expect(infoEl?.className).toContain("border-blue-500/20");
+    expect(infoEl?.className).toContain("bg-brand-tint/5");
+    expect(infoEl?.className).toContain("border-brand-tint/20");
   });
 
   test("uses onAnalyzeSafety adapter instead of fetch when provided", async () => {
@@ -530,7 +530,7 @@ describe("QuerySafetyDialog", () => {
     });
   });
 
-  test("high and critical risk buttons have red background class", async () => {
+  test("high and critical risk buttons carry the danger solid background token", async () => {
     // Test critical risk button
     const criticalPayload = {
       riskLevel: "critical",
@@ -559,7 +559,7 @@ describe("QuerySafetyDialog", () => {
     });
 
     const criticalButton = queryByText("Execute Anyway")!.closest("button");
-    expect(criticalButton?.className).toContain("bg-red-600");
+    expect(criticalButton?.className).toContain("bg-danger-solid");
 
     unmount();
     cleanup();
@@ -592,7 +592,7 @@ describe("QuerySafetyDialog", () => {
     });
 
     const highButton = result2.queryByText("Proceed with Caution")!.closest("button");
-    expect(highButton?.className).toContain("bg-red-600");
+    expect(highButton?.className).toContain("bg-danger-solid");
   });
 
   // ── Honesty about text the reading could not resolve (#297) ────────────────

--- a/tests/components/ResultsGrid.test.tsx
+++ b/tests/components/ResultsGrid.test.tsx
@@ -644,7 +644,7 @@ describe("ResultsGrid", () => {
   describe("Inline editing", () => {
     function findEditInput(container: HTMLElement) {
       return Array.from(container.querySelectorAll("input")).find((input) =>
-        input.className.includes("border-blue-500"),
+        input.classList.contains("border-brand-tint"),
       );
     }
 

--- a/tests/components/SchemaDiagram.test.tsx
+++ b/tests/components/SchemaDiagram.test.tsx
@@ -596,17 +596,17 @@ describe("SchemaDiagram", () => {
     expect(view.queryByText("Compact")).not.toBeNull();
   });
 
-  test("compact button has blue text class when compact mode is active", () => {
+  test("compact button has the accent text token when compact mode is active", () => {
     const props = createDefaultProps();
     const { container } = render(<SchemaDiagram {...props} />);
     const view = within(container);
 
     const compactButton = view.getByText("Compact").closest("button")!;
-    expect(compactButton.className).not.toContain("text-blue-400");
+    expect(compactButton.className).not.toContain("text-brand");
 
     fireEvent.click(compactButton);
     const detailButton = view.getByText("Detail").closest("button")!;
-    expect(detailButton.className).toContain("text-blue-400");
+    expect(detailButton.className).toContain("text-brand");
   });
 
   // ── No FK warning ───────────────────────────────────────────────────────
@@ -994,7 +994,7 @@ describe("SchemaDiagram", () => {
       expect(view.queryByText("Selected:")).toBeNull();
       // ...and the surviving table does not inherit any highlight.
       const ordersNode = container.querySelector('[data-node-id="orders"]')!;
-      expect(ordersNode.querySelector(".border-blue-500\\/60")).toBeNull();
+      expect(ordersNode.querySelector(".border-brand-tint\\/60")).toBeNull();
 
       // The drop is permanent: clearing the filter brings the table back to
       // the canvas but must NOT resurrect a selection the user already lost.
@@ -1026,7 +1026,7 @@ describe("SchemaDiagram", () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   describe("Node/Edge highlighting", () => {
-    test("selected node gets highlighted (blue border)", () => {
+    test("selected node gets highlighted (brand-tint border)", () => {
       const props = createDefaultProps();
       const { container } = render(<SchemaDiagram {...props} />);
 
@@ -1034,8 +1034,8 @@ describe("SchemaDiagram", () => {
       const usersNode = container.querySelector('[data-node-id="users"]')!;
       fireEvent.click(usersNode);
 
-      // The TableNode's root div inside the data-node-id div should have blue border
-      const innerDiv = usersNode.querySelector(".border-blue-500\\/60");
+      // The TableNode's root div inside the data-node-id div should carry the brand-tint highlight border
+      const innerDiv = usersNode.querySelector(".border-brand-tint\\/60");
       expect(innerDiv).not.toBeNull();
     });
 
@@ -1049,7 +1049,7 @@ describe("SchemaDiagram", () => {
 
       // The 'users' table should also be highlighted (FK target)
       const usersNode = container.querySelector('[data-node-id="users"]')!;
-      const usersInner = usersNode.querySelector(".border-blue-500\\/60");
+      const usersInner = usersNode.querySelector(".border-brand-tint\\/60");
       expect(usersInner).not.toBeNull();
     });
 
@@ -1063,7 +1063,7 @@ describe("SchemaDiagram", () => {
 
       // The 'orders' table should be highlighted (it references users via FK)
       const ordersNode = container.querySelector('[data-node-id="orders"]')!;
-      const ordersInner = ordersNode.querySelector(".border-blue-500\\/60");
+      const ordersInner = ordersNode.querySelector(".border-brand-tint\\/60");
       expect(ordersInner).not.toBeNull();
     });
 
@@ -1077,7 +1077,7 @@ describe("SchemaDiagram", () => {
 
       // Products should NOT be highlighted
       const productsNode = container.querySelector('[data-node-id="products"]')!;
-      const productsInner = productsNode.querySelector(".border-blue-500\\/60");
+      const productsInner = productsNode.querySelector(".border-brand-tint\\/60");
       expect(productsInner).toBeNull();
       // Products should have default border
       const productsDefault = productsNode.querySelector(".border-hairline-strong");
@@ -1546,8 +1546,10 @@ describe("SchemaDiagram", () => {
 
       // Select users while no FK data exists
       fireEvent.click(container.querySelector('[data-node-id="users"]')!);
-      expect(container.querySelector('[data-node-id="users"]')!.querySelector(".border-blue-500\\/60")).not.toBeNull();
-      expect(container.querySelector('[data-node-id="posts"]')!.querySelector(".border-blue-500\\/60")).toBeNull();
+      expect(
+        container.querySelector('[data-node-id="users"]')!.querySelector(".border-brand-tint\\/60"),
+      ).not.toBeNull();
+      expect(container.querySelector('[data-node-id="posts"]')!.querySelector(".border-brand-tint\\/60")).toBeNull();
 
       // Relations arrive: posts now references users
       const withFk: TableSchema[] = [
@@ -1564,7 +1566,9 @@ describe("SchemaDiagram", () => {
       });
 
       // posts is now a neighbor of the still-selected users -> highlighted
-      expect(container.querySelector('[data-node-id="posts"]')!.querySelector(".border-blue-500\\/60")).not.toBeNull();
+      expect(
+        container.querySelector('[data-node-id="posts"]')!.querySelector(".border-brand-tint\\/60"),
+      ).not.toBeNull();
     });
 
     test("node internals re-measure when FK anchors appear on existing tables", async () => {
@@ -1848,11 +1852,11 @@ describe("SchemaDiagram", () => {
 
       // 'users' should be highlighted (orders has FK to users)
       const usersNode = container.querySelector('[data-node-id="users"]')!;
-      expect(usersNode.querySelector(".border-blue-500\\/60")).not.toBeNull();
+      expect(usersNode.querySelector(".border-brand-tint\\/60")).not.toBeNull();
 
       // 'items' should be highlighted (items has FK to orders)
       const itemsNode = container.querySelector('[data-node-id="items"]')!;
-      expect(itemsNode.querySelector(".border-blue-500\\/60")).not.toBeNull();
+      expect(itemsNode.querySelector(".border-brand-tint\\/60")).not.toBeNull();
     });
 
     test("no-FK warning shown for schema with undefined foreignKeys", () => {

--- a/tests/components/SchemaDiff.test.tsx
+++ b/tests/components/SchemaDiff.test.tsx
@@ -675,22 +675,22 @@ describe("SchemaDiff", () => {
       expect(getByText("Type changed: varchar(100) -> varchar(255)")).toBeTruthy();
     });
 
-    test("added column row has green background", () => {
+    test("added column row has the green hue tint background", () => {
       const { getByText } = renderAndSelectTable("new_table");
       const colRow = getByText("id").closest('div[class*="rounded"]');
-      expect(colRow?.className).toContain("bg-green-500/5");
+      expect(colRow?.className).toContain("bg-hue-green-tint/5");
     });
 
-    test("removed column row has red background", () => {
+    test("removed column row has the red hue tint background", () => {
       const { getByText } = renderAndSelectTable("old_table");
       const colRow = getByText("name").closest('div[class*="rounded"]');
-      expect(colRow?.className).toContain("bg-red-500/5");
+      expect(colRow?.className).toContain("bg-hue-red-tint/5");
     });
 
-    test("modified column row has yellow background", () => {
+    test("modified column row has the yellow hue tint background", () => {
       const { getByText } = renderAndSelectTable("users");
       const colRow = getByText("email").closest('div[class*="rounded"]');
-      expect(colRow?.className).toContain("bg-yellow-500/5");
+      expect(colRow?.className).toContain("bg-hue-yellow-tint/5");
     });
 
     // ── Indexes ──
@@ -713,11 +713,11 @@ describe("SchemaDiff", () => {
     test("index rows have correct backgrounds", () => {
       const { getByText } = renderAndSelectTable("users");
       const addedIdx = getByText("idx_email").closest('div[class*="rounded"]');
-      expect(addedIdx?.className).toContain("bg-green-500/5");
+      expect(addedIdx?.className).toContain("bg-hue-green-tint/5");
       const removedIdx = getByText("idx_old").closest('div[class*="rounded"]');
-      expect(removedIdx?.className).toContain("bg-red-500/5");
+      expect(removedIdx?.className).toContain("bg-hue-red-tint/5");
       const modifiedIdx = getByText("idx_name").closest('div[class*="rounded"]');
-      expect(modifiedIdx?.className).toContain("bg-yellow-500/5");
+      expect(modifiedIdx?.className).toContain("bg-hue-yellow-tint/5");
     });
 
     test('does not render "Indexes" heading when no indexes', () => {
@@ -743,9 +743,9 @@ describe("SchemaDiff", () => {
     test("FK rows have correct backgrounds", () => {
       const { getByText } = renderAndSelectTable("users");
       const addedFK = getByText("org_id").closest('div[class*="rounded"]');
-      expect(addedFK?.className).toContain("bg-green-500/5");
+      expect(addedFK?.className).toContain("bg-hue-green-tint/5");
       const removedFK = getByText("dept_id").closest('div[class*="rounded"]');
-      expect(removedFK?.className).toContain("bg-red-500/5");
+      expect(removedFK?.className).toContain("bg-hue-red-tint/5");
     });
 
     test('does not render "Foreign Keys" heading when no FKs', () => {
@@ -1015,28 +1015,28 @@ describe("SchemaDiff", () => {
       return result;
     }
 
-    test("added badge has green styling", () => {
+    test("added badge has the green hue tint styling", () => {
       const { container } = renderWithDiff();
       const badges = container.querySelectorAll('[data-testid="badge"]');
       const addedBadge = Array.from(badges).find((b) => b.textContent?.includes("Added"));
       expect(addedBadge).toBeTruthy();
-      expect(addedBadge!.className).toContain("bg-green-500/20");
+      expect(addedBadge!.className).toContain("bg-hue-green-tint/20");
     });
 
-    test("removed badge has red styling", () => {
+    test("removed badge has the red hue tint styling", () => {
       const { container } = renderWithDiff();
       const badges = container.querySelectorAll('[data-testid="badge"]');
       const removedBadge = Array.from(badges).find((b) => b.textContent?.includes("Removed"));
       expect(removedBadge).toBeTruthy();
-      expect(removedBadge!.className).toContain("bg-red-500/20");
+      expect(removedBadge!.className).toContain("bg-hue-red-tint/20");
     });
 
-    test("modified badge has yellow styling", () => {
+    test("modified badge has the yellow hue tint styling", () => {
       const { container } = renderWithDiff();
       const badges = container.querySelectorAll('[data-testid="badge"]');
       const modifiedBadge = Array.from(badges).find((b) => b.textContent?.includes("Modified"));
       expect(modifiedBadge).toBeTruthy();
-      expect(modifiedBadge!.className).toContain("bg-yellow-500/20");
+      expect(modifiedBadge!.className).toContain("bg-hue-yellow-tint/20");
     });
   });
 });

--- a/tests/components/SnapshotTimeline.test.tsx
+++ b/tests/components/SnapshotTimeline.test.tsx
@@ -343,12 +343,12 @@ describe("SnapshotTimeline", () => {
       <SnapshotTimeline snapshots={snapshots} onCompare={mock(() => {})} onDelete={mock(() => {})} />,
     );
     // Unselected state: no dot is highlighted, labels use the muted color
-    expect(container.querySelector(".bg-blue-500")).toBeNull();
+    expect(container.querySelector(".bg-brand-tint")).toBeNull();
     expect(container.querySelectorAll(".text-fg-muted.group-hover\\:text-fg-secondary").length).toBe(2);
     fireEvent.click(queryByText("Before migration")!);
     // Selected state: exactly one highlighted dot and one highlighted label
-    expect(container.querySelectorAll(".bg-blue-500.border-blue-400.scale-125").length).toBe(1);
-    expect(container.querySelectorAll(".mt-2.text-center.text-blue-400").length).toBe(1);
+    expect(container.querySelectorAll(".bg-brand-tint.border-brand.scale-125").length).toBe(1);
+    expect(container.querySelectorAll(".mt-2.text-center.text-brand").length).toBe(1);
     expect(container.querySelectorAll(".text-fg-muted.group-hover\\:text-fg-secondary").length).toBe(1);
   });
 

--- a/tests/components/VisualExplain.test.tsx
+++ b/tests/components/VisualExplain.test.tsx
@@ -482,13 +482,13 @@ describe("VisualExplain", () => {
       expect(queryByText("inline code")).not.toBeNull();
     });
 
-    // One SQL fenced block (blue styling) and one non-SQL "text" fenced block (zinc styling).
+    // One SQL fenced block (accent styling) and one non-SQL "text" fenced block (neutral fill styling).
     const pres = container.querySelectorAll("pre");
     expect(pres.length).toBe(2);
 
     const sqlPre = Array.from(pres).find((pre) => pre.textContent?.includes("SELECT * FROM users;"));
     expect(sqlPre).not.toBeUndefined();
-    expect(sqlPre!.className).toContain("bg-blue-500/5");
+    expect(sqlPre!.className).toContain("bg-brand-tint/5");
 
     const nonSqlPre = Array.from(pres).find((pre) => pre.textContent?.includes("plain block content"));
     expect(nonSqlPre).not.toBeUndefined();
@@ -708,17 +708,17 @@ describe("VisualExplain", () => {
       },
     ];
     const { container } = render(<VisualExplain plan={joinPlan} />);
-    // Layers icon for Join has text-purple-400 class
-    const purpleIcon = container.querySelector(".text-purple-400");
+    // Layers icon for Join carries the purple identity hue token
+    const purpleIcon = container.querySelector(".text-hue-purple");
     expect(purpleIcon).not.toBeNull();
   });
 
   test("NodeIcon renders ArrowDown icon for Sort type", () => {
     // sortPlan already has Node Type = 'Sort'
     const { container } = render(<VisualExplain plan={sortPlan} />);
-    // Sort nodes use ArrowDown icon with text-amber-400
-    // Seq Scan also uses amber-400, but sortPlan has 'Sort' not 'Seq Scan'
-    const amberIcon = container.querySelector(".text-amber-400");
+    // Sort nodes use ArrowDown icon with the amber identity hue token
+    // Seq Scan also uses text-hue-amber, but sortPlan has 'Sort' not 'Seq Scan'
+    const amberIcon = container.querySelector(".text-hue-amber");
     expect(amberIcon).not.toBeNull();
   });
 
@@ -737,8 +737,8 @@ describe("VisualExplain", () => {
       },
     ];
     const { container } = render(<VisualExplain plan={aggPlan} />);
-    // Aggregate uses Zap icon with text-pink-400
-    const pinkIcon = container.querySelector(".text-pink-400");
+    // Aggregate uses Zap icon with the pink identity hue token
+    const pinkIcon = container.querySelector(".text-hue-pink");
     expect(pinkIcon).not.toBeNull();
   });
 
@@ -757,8 +757,8 @@ describe("VisualExplain", () => {
       },
     ];
     const { container } = render(<VisualExplain plan={hashPlan} />);
-    // Hash uses HardDrive icon with text-cyan-400
-    const cyanIcon = container.querySelector(".text-cyan-400");
+    // Hash uses HardDrive icon with the cyan identity hue token
+    const cyanIcon = container.querySelector(".text-hue-cyan");
     expect(cyanIcon).not.toBeNull();
   });
 

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -98,7 +98,7 @@ mock.module("@/lib/db-ui-config", () => ({
     const React = require("react");
     return (props: Record<string, unknown>) => React.createElement("span", { ...props, "data-testid": "db-icon" });
   },
-  getDBColor: () => "text-blue-400",
+  getDBColor: () => "text-hue-blue",
 }));
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";

--- a/tests/components/admin/OverviewTab.test.tsx
+++ b/tests/components/admin/OverviewTab.test.tsx
@@ -55,8 +55,8 @@ mock.module("@/lib/db-ui-config", () => ({
     const React = require("react");
     return (props: Record<string, unknown>) => React.createElement("span", { ...props, "data-testid": "db-icon" });
   },
-  getDBColor: () => "text-blue-400",
-  getDBConfig: () => ({ icon: () => null, color: "text-blue-400", label: "PostgreSQL", defaultPort: "5432" }),
+  getDBColor: () => "text-hue-blue",
+  getDBConfig: () => ({ icon: () => null, color: "text-hue-blue", label: "PostgreSQL", defaultPort: "5432" }),
 }));
 
 mock.module("next/link", () => ({

--- a/tests/components/agent/AgentRail.test.tsx
+++ b/tests/components/agent/AgentRail.test.tsx
@@ -1324,7 +1324,7 @@ describe("AgentRail", () => {
 
   /**
    * Small print is print (#100). `text-fg-muted` — zinc-500 in the dark palette — on
-   * this rail's `bg-surface` (#0a0a0a), under the alert's own `bg-red-500/5`, computes
+   * this rail's `bg-surface` (#0a0a0a), under the alert's own `bg-danger-tint/5`, computes
    * to 3.98:1 against WCAG AA's 4.5:1 — measured from the installed Tailwind 4 palette,
    * not estimated — and this text is 10px, so the large-text allowance does not apply.
    * `text-fg-tertiary` (zinc-400) is 7.33:1.

--- a/tests/components/monitoring/PerformanceTab.test.tsx
+++ b/tests/components/monitoring/PerformanceTab.test.tsx
@@ -82,7 +82,7 @@ describe("PerformanceTab", () => {
     expect(card.textContent).toContain("%");
     expect(card.querySelectorAll('[data-slot="progress"]').length).toBe(1);
     expect(card.textContent).toContain("Excellent");
-    expect(card.querySelector("svg")?.getAttribute("class")).toContain("text-green-500");
+    expect(card.querySelector("svg")?.getAttribute("class")).toContain("text-success");
   });
 
   test("reports an unmeasured cache hit ratio as unavailable instead of 0%", () => {
@@ -105,10 +105,10 @@ describe("PerformanceTab", () => {
     for (const rating of ["Excellent", "Good", "Fair", "Poor"]) {
       expect(card.textContent).not.toContain(rating);
     }
-    // Absence is not a fault: no red icon, no red or yellow border, no advice.
+    // Absence is not a fault: no danger icon, no danger or warning border, no advice.
     expect(card.querySelector("svg")?.getAttribute("class")).toContain("text-muted-foreground");
-    expect(card.className).not.toContain("red");
-    expect(card.className).not.toContain("yellow");
+    expect(card.className).not.toContain("danger");
+    expect(card.className).not.toContain("warning");
     expect(queryByText("Low Cache Hit")).toBeNull();
     expect(queryByText("Performing well!")).toBeNull();
   });
@@ -176,10 +176,10 @@ describe("PerformanceTab", () => {
     for (const rating of ["Excellent", "Good", "Fair", "Poor"]) {
       expect(card.textContent).not.toContain(rating);
     }
-    // Absence is not a fault: no red icon, no red or yellow border.
+    // Absence is not a fault: no danger icon, no danger or warning border.
     expect(card.querySelector("svg")?.getAttribute("class")).toContain("text-muted-foreground");
-    expect(card.className).not.toContain("red");
-    expect(card.className).not.toContain("yellow");
+    expect(card.className).not.toContain("danger");
+    expect(card.className).not.toContain("warning");
   });
 
   test("reports unmeasured deadlocks as unavailable instead of a healthy zero", () => {
@@ -193,10 +193,10 @@ describe("PerformanceTab", () => {
     expect(card.textContent).not.toContain("None detected");
     expect(card.textContent).not.toContain("Healthy");
     expect(card.textContent).not.toContain("Attention");
-    // A green icon is a verdict too.
+    // A success-coloured icon is a verdict too.
     expect(card.querySelector("svg")?.getAttribute("class")).toContain("text-muted-foreground");
-    expect(card.className).not.toContain("red");
-    expect(card.className).not.toContain("yellow");
+    expect(card.className).not.toContain("danger");
+    expect(card.className).not.toContain("warning");
   });
 
   // The pin that keeps absence and zero from being collapsed back together: mongodb.ts:856,
@@ -219,7 +219,7 @@ describe("PerformanceTab", () => {
     expect(deadlocks.textContent).toContain("None detected");
     expect(deadlocks.textContent).toContain("Healthy");
     expect(deadlocks.textContent).not.toContain("N/A");
-    expect(deadlocks.querySelector("svg")?.getAttribute("class")).toContain("text-green-500");
+    expect(deadlocks.querySelector("svg")?.getAttribute("class")).toContain("text-success");
   });
 
   test("renders the buffer and deadlock trends as not measured when no sample carries them", () => {

--- a/tests/components/monitoring/PerformanceTab.test.tsx
+++ b/tests/components/monitoring/PerformanceTab.test.tsx
@@ -82,7 +82,7 @@ describe("PerformanceTab", () => {
     expect(card.textContent).toContain("%");
     expect(card.querySelectorAll('[data-slot="progress"]').length).toBe(1);
     expect(card.textContent).toContain("Excellent");
-    expect(card.querySelector("svg")?.getAttribute("class")).toContain("text-success");
+    expect(card.querySelector("svg")?.getAttribute("class")).toContain("text-hue-green");
   });
 
   test("reports an unmeasured cache hit ratio as unavailable instead of 0%", () => {
@@ -219,7 +219,7 @@ describe("PerformanceTab", () => {
     expect(deadlocks.textContent).toContain("None detected");
     expect(deadlocks.textContent).toContain("Healthy");
     expect(deadlocks.textContent).not.toContain("N/A");
-    expect(deadlocks.querySelector("svg")?.getAttribute("class")).toContain("text-success");
+    expect(deadlocks.querySelector("svg")?.getAttribute("class")).toContain("text-hue-green");
   });
 
   test("renders the buffer and deadlock trends as not measured when no sample carries them", () => {

--- a/tests/components/results-grid/RowDetailSheet.test.tsx
+++ b/tests/components/results-grid/RowDetailSheet.test.tsx
@@ -177,8 +177,8 @@ describe("results-grid/RowDetailSheet", () => {
     // Click the first copy button (for "id" field)
     fireEvent.click(copyButtons[0]!);
 
-    // After copy, the Check icon (emerald-400 colored) should replace the Copy icon
-    await waitFor(() => expect(container.querySelector(".text-emerald-400")).not.toBeNull());
+    // After copy, the Check icon (success token) should replace the Copy icon
+    await waitFor(() => expect(container.querySelector(".text-success")).not.toBeNull());
   });
 
   // B43: both of these labels used to flip in the same statement that started the write,
@@ -202,8 +202,8 @@ describe("results-grid/RowDetailSheet", () => {
     );
     fireEvent.click(copyButtons[0]!);
 
-    await waitFor(() => expect(container.querySelector(".text-amber-400")).not.toBeNull());
-    expect(container.querySelector(".text-emerald-400")).toBeNull();
+    await waitFor(() => expect(container.querySelector(".text-warning")).not.toBeNull());
+    expect(container.querySelector(".text-success")).toBeNull();
   });
 
   test("Copy JSON says Copied once the write has reported one", async () => {

--- a/tests/components/schema-explorer/ColumnList.test.tsx
+++ b/tests/components/schema-explorer/ColumnList.test.tsx
@@ -73,8 +73,8 @@ describe("ColumnList", () => {
 
   test("renders Key icon for primary key columns", () => {
     const { container } = render(<ColumnList columns={columnsWithPrimary} indexes={[]} />);
-    // Key icon has text-yellow-500/70 class
-    const keyIcons = container.querySelectorAll(".text-yellow-500\\/70");
+    // Key icon has the text-hue-yellow/70 token class
+    const keyIcons = container.querySelectorAll(".text-hue-yellow\\/70");
     expect(keyIcons.length).toBe(1); // only 'id' is primary
   });
 
@@ -84,7 +84,7 @@ describe("ColumnList", () => {
     const dots = container.querySelectorAll(".bg-muted-foreground\\/50");
     expect(dots.length).toBe(2); // both columns are non-primary
     // No key icons
-    const keyIcons = container.querySelectorAll(".text-yellow-500\\/70");
+    const keyIcons = container.querySelectorAll(".text-hue-yellow\\/70");
     expect(keyIcons.length).toBe(0);
   });
 

--- a/tests/components/sidebar/ConnectionItem.test.tsx
+++ b/tests/components/sidebar/ConnectionItem.test.tsx
@@ -54,8 +54,8 @@ mock.module("@/lib/db-ui-config", () => ({
     MockDBIcon.displayName = "MockDBIcon";
     return MockDBIcon;
   },
-  getDBConfig: () => ({ icon: () => null, color: "text-blue-400", label: "PostgreSQL", defaultPort: "5432" }),
-  getDBColor: () => "text-blue-400",
+  getDBConfig: () => ({ icon: () => null, color: "text-hue-blue", label: "PostgreSQL", defaultPort: "5432" }),
+  getDBColor: () => "text-hue-blue",
 }));
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
@@ -143,7 +143,7 @@ describe("ConnectionItem", () => {
     const connectionDiv = container.firstElementChild;
     expect(connectionDiv).not.toBeNull();
     const className = connectionDiv?.className || "";
-    expect(className.includes("bg-blue-600/10")).toBe(true);
+    expect(className.includes("bg-brand-solid/10")).toBe(true);
   });
 
   test("onSelect fires on click", () => {

--- a/tests/components/sidebar/ConnectionsList.test.tsx
+++ b/tests/components/sidebar/ConnectionsList.test.tsx
@@ -54,8 +54,8 @@ mock.module("@/lib/db-ui-config", () => ({
     MockDBIcon.displayName = "MockDBIcon";
     return MockDBIcon;
   },
-  getDBConfig: () => ({ icon: () => null, color: "text-blue-400", label: "PostgreSQL", defaultPort: "5432" }),
-  getDBColor: () => "text-blue-400",
+  getDBConfig: () => ({ icon: () => null, color: "text-hue-blue", label: "PostgreSQL", defaultPort: "5432" }),
+  getDBColor: () => "text-hue-blue",
 }));
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
@@ -154,10 +154,10 @@ describe("ConnectionsList", () => {
     const pgItem = Array.from(items).find((el) => el.textContent?.includes("Test PostgreSQL"));
     const mysqlItem = Array.from(items).find((el) => el.textContent?.includes("Test MySQL"));
 
-    // Active item should have bg-blue-600/10 class
-    expect(pgItem?.className.includes("bg-blue-600/10")).toBe(true);
+    // Active item should have bg-brand-solid/10 class
+    expect(pgItem?.className.includes("bg-brand-solid/10")).toBe(true);
     // Inactive item should not
-    expect(mysqlItem?.className.includes("bg-blue-600/10")).toBeFalsy();
+    expect(mysqlItem?.className.includes("bg-brand-solid/10")).toBeFalsy();
   });
 
   test("onAddConnection fires from empty state button", () => {

--- a/tests/components/studio/BottomPanel.test.tsx
+++ b/tests/components/studio/BottomPanel.test.tsx
@@ -285,8 +285,8 @@ describe("BottomPanel", () => {
 
     const resultsButton = getByText("Results").closest("button");
     expect(resultsButton).not.toBeNull();
-    // Active tab should have the active class (text-blue-400 for results)
-    expect(resultsButton!.className).toContain("text-blue-400");
+    // Active tab should have the active class (the blue identity hue for results)
+    expect(resultsButton!.className).toContain("text-hue-blue");
   });
 
   test("shows empty state placeholder when currentTab.result is null", () => {

--- a/tests/components/studio/QueryToolbar.test.tsx
+++ b/tests/components/studio/QueryToolbar.test.tsx
@@ -125,7 +125,7 @@ describe("QueryToolbar", () => {
     expect(sandboxText).not.toBeNull();
     const sandboxButton = sandboxText!.closest("button");
     expect(sandboxButton).not.toBeNull();
-    expect(sandboxButton?.className.includes("text-emerald-400")).toBe(true);
+    expect(sandboxButton?.className.includes("text-success")).toBe(true);
   });
 
   test("Edit button highlights when editingEnabled true", () => {
@@ -135,7 +135,7 @@ describe("QueryToolbar", () => {
     expect(editText).not.toBeNull();
     const editButton = editText!.closest("button");
     expect(editButton).not.toBeNull();
-    expect(editButton?.className.includes("text-amber-400")).toBe(true);
+    expect(editButton?.className.includes("text-warning")).toBe(true);
   });
 
   test("No EDIT button when onToggleEditing is not provided (#269)", () => {

--- a/tests/components/studio/StudioDesktopHeader.test.tsx
+++ b/tests/components/studio/StudioDesktopHeader.test.tsx
@@ -171,38 +171,38 @@ describe("StudioDesktopHeader", () => {
       expect(container.querySelector('[title^="Connection:"]')).toBeNull();
     });
 
-    test('renders healthy pulse with "Online" text and green dot', () => {
+    test('renders healthy pulse with "Online" text and a success-token dot', () => {
       const { container } = render(<StudioDesktopHeader {...defaultProps} connectionPulse="healthy" />);
       const pulseContainer = container.querySelector('[title="Connection: healthy"]');
       expect(pulseContainer).toBeTruthy();
 
       const dot = pulseContainer!.querySelector(".rounded-full");
-      expect(dot?.className).toContain("bg-emerald-500");
+      expect(dot?.className).toContain("bg-success-tint");
       expect(dot?.className).toContain("animate-pulse");
 
       // "Online" text in the pulse section
       expect(pulseContainer!.textContent).toContain("Online");
     });
 
-    test('renders degraded pulse with "Slow" text and amber dot', () => {
+    test('renders degraded pulse with "Slow" text and a warning-token dot', () => {
       const { container } = render(<StudioDesktopHeader {...defaultProps} connectionPulse="degraded" />);
       const pulseContainer = container.querySelector('[title="Connection: degraded"]');
       expect(pulseContainer).toBeTruthy();
 
       const dot = pulseContainer!.querySelector(".rounded-full");
-      expect(dot?.className).toContain("bg-amber-500");
+      expect(dot?.className).toContain("bg-warning-tint");
       expect(dot?.className).not.toContain("animate-pulse");
 
       expect(pulseContainer!.textContent).toContain("Slow");
     });
 
-    test('renders error pulse with "Error" text and red dot', () => {
+    test('renders error pulse with "Error" text and a danger-token dot', () => {
       const { container } = render(<StudioDesktopHeader {...defaultProps} connectionPulse="error" />);
       const pulseContainer = container.querySelector('[title="Connection: error"]');
       expect(pulseContainer).toBeTruthy();
 
       const dot = pulseContainer!.querySelector(".rounded-full");
-      expect(dot?.className).toContain("bg-red-500");
+      expect(dot?.className).toContain("bg-danger-tint");
       expect(dot?.className).not.toContain("animate-pulse");
 
       expect(pulseContainer!.textContent).toContain("Error");
@@ -286,10 +286,10 @@ describe("StudioDesktopHeader", () => {
       expect(onLogout).toHaveBeenCalledTimes(1);
     });
 
-    test("Logout menu item has red styling", () => {
+    test("Logout menu item has danger-token styling", () => {
       const { getByText } = render(<StudioDesktopHeader {...defaultProps} />);
       const logoutItem = getByText("Logout").closest('[role="menuitem"]');
-      expect(logoutItem?.className).toContain("text-red-400");
+      expect(logoutItem?.className).toContain("text-danger");
     });
   });
 

--- a/tests/components/studio/StudioTabBar.test.tsx
+++ b/tests/components/studio/StudioTabBar.test.tsx
@@ -62,13 +62,13 @@ describe("StudioTabBar", () => {
     expect(queryByText("Query 2")).not.toBeNull();
   });
 
-  test("active tab has blue border and bg styling", () => {
+  test("active tab has the accent border and raised bg styling", () => {
     const props = createDefaultProps({ activeTabId: "tab-1" });
     const { container } = render(<StudioTabBar {...props} />);
     const tabElements = container.querySelectorAll('[class*="border-t-2"]');
-    expect(tabElements[0]?.className).toContain("border-blue-500");
-    // The accent stays a literal blue (it reads on either ground); the tab's own
-    // ground is the elevated surface token, so it follows the theme.
+    expect(tabElements[0]?.className).toContain("border-brand-tint");
+    // Both sides are tokens now (#402): the accent tint reads on either ground,
+    // and the tab's own ground is the elevated surface token.
     expect(tabElements[0]?.className).toContain("bg-overlay");
   });
 
@@ -170,7 +170,7 @@ describe("StudioTabBar", () => {
     const input = container.querySelector("input")!;
     expect(input).not.toBeNull();
     expect(input.value).toBe("Query 1");
-    expect(input.className).toContain("border-blue-500");
+    expect(input.className).toContain("border-brand-tint");
     expect(input.className).toContain("bg-transparent");
   });
 

--- a/tests/helpers/contrast.ts
+++ b/tests/helpers/contrast.ts
@@ -1,0 +1,198 @@
+/**
+ * Colour arithmetic for the theme tests.
+ *
+ * Every contrast figure this repository has ever recorded — the chart palette's
+ * header, the login showcase comment, `AgentRail`'s "3.98:1" — is PROSE. It was
+ * measured once, by hand, in a browser, and written down. Prose does not fail when
+ * somebody changes the value it describes, which is how a token tuned against a
+ * near-black ground survived into a light theme at 1.46:1 (#402).
+ *
+ * So this is deliberately not a mock or a fixture: it is the measurement, run in
+ * the test process, from the same numbers the browser paints from.
+ *
+ * Three things it has to get right, all of which are easy to get subtly wrong:
+ *
+ *  1. Tailwind v4 ships its palette as `oklch()`, not hex. The conversion has to
+ *     go oklch → Oklab → LMS → linear sRGB → gamma-encoded sRGB, and the vivid
+ *     steps land outside the sRGB gamut and are CLIPPED per channel — which is
+ *     what browsers do, and what makes the result equal Tailwind's own published
+ *     hexes. Skipping the clip silently shifts every ratio.
+ *
+ *  2. An opacity modifier (`bg-accent-tint/15`) is not a colour, it is a colour
+ *     that has to be composited over whatever is behind it before it can be
+ *     measured. `text-x on bg-y/15` is a question about the COMPOSITE, and it is
+ *     the question #402 turned on: blue-300 over `blue-500/15` is 9.48:1 on the
+ *     dark ground and 1.46:1 on the light one — same two class names.
+ *
+ *  3. WCAG relative luminance is defined on LINEAR sRGB, while CSS alpha
+ *     compositing happens in the gamma-encoded space. Compositing in the wrong
+ *     one moves the answer by enough to flip a pass/fail at the 4.5:1 boundary.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type Rgb = readonly [number, number, number];
+
+const clamp01 = (x: number) => Math.min(1, Math.max(0, x));
+
+/** sRGB transfer function, gamma-encoded → linear. */
+const toLinear = (channel: number) =>
+  channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+
+/** sRGB transfer function, linear → gamma-encoded. */
+const toGamma = (channel: number) =>
+  channel <= 0.0031308 ? 12.92 * channel : 1.055 * channel ** (1 / 2.4) - 0.055;
+
+/**
+ * Oklab → linear sRGB (Björn Ottosson's matrices). Kept separate from the oklch
+ * entry point because the identity-palette separation check needs Oklab itself,
+ * not a colour derived from it.
+ */
+function oklabToLinearSrgb(L: number, a: number, b: number): Rgb {
+  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const s = (L - 0.0894841775 * a - 1.291485548 * b) ** 3;
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+}
+
+/** Linear sRGB → Oklab, the inverse of the above. */
+export function toOklab([r, g, b]: Rgb): Rgb {
+  const lr = toLinear(r);
+  const lg = toLinear(g);
+  const lb = toLinear(b);
+  const l = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb);
+  const m = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb);
+  const s = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb);
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 0.2429228246 * m - 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ];
+}
+
+/**
+ * Perceptual distance between two colours. Plain Euclidean distance in Oklab —
+ * which is what Oklab is FOR, and what "these two identity hues are still
+ * distinguishable" has to be asked in. Asking it in sRGB would call
+ * `#00c951` and `#00d492` far apart and `#1447e6` and `#193cb8` close.
+ */
+export function deltaEOk(a: Rgb, b: Rgb): number {
+  const [l1, a1, b1] = toOklab(a);
+  const [l2, a2, b2] = toOklab(b);
+  return Math.hypot(l1 - l2, a1 - a2, b1 - b2);
+}
+
+/** oklch(L% C H) → gamma-encoded sRGB, clipped to gamut the way a browser clips. */
+export function oklchToRgb(lightnessPercent: number, chroma: number, hueDegrees: number): Rgb {
+  const hue = (hueDegrees * Math.PI) / 180;
+  const linear = oklabToLinearSrgb(
+    lightnessPercent / 100,
+    chroma * Math.cos(hue),
+    chroma * Math.sin(hue),
+  );
+  return linear.map((channel) => toGamma(clamp01(channel))) as unknown as Rgb;
+}
+
+export const toHex = (rgb: Rgb): string =>
+  `#${rgb.map((channel) => Math.round(channel * 255).toString(16).padStart(2, "0")).join("")}`;
+
+/**
+ * Parse the colour syntaxes the token layer actually writes: `#rgb`, `#rrggbb`,
+ * `rgb(r g b / a)` and `oklch(L% C H)`. Returns the colour and its alpha
+ * separately, because a token carrying its own alpha (`--studio-hairline`) has to
+ * be composited before it can be measured, exactly like an opacity modifier.
+ */
+export function parseColor(value: string): { rgb: Rgb; alpha: number } {
+  const text = value.trim();
+
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(text);
+  if (hex) {
+    const digits =
+      hex[1].length === 3
+        ? hex[1]
+            .split("")
+            .map((d) => d + d)
+            .join("")
+        : hex[1];
+    const rgb = [0, 2, 4].map((i) => Number.parseInt(digits.slice(i, i + 2), 16) / 255) as unknown as Rgb;
+    return { rgb, alpha: 1 };
+  }
+
+  const rgbFn = /^rgba?\(\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)\s*(?:[/,]\s*([\d.]+%?)\s*)?\)$/i.exec(text);
+  if (rgbFn) {
+    const rgb = [rgbFn[1], rgbFn[2], rgbFn[3]].map((n) => Number(n) / 255) as unknown as Rgb;
+    return { rgb, alpha: parseAlpha(rgbFn[4]) };
+  }
+
+  // `none` is a real oklch component value, and Tailwind writes it for the
+  // achromatic steps (`oklch(98.5% 0 none)` — white has no hue). CSS resolves it
+  // to zero in a plain colour, so parsing it as anything else drops the step.
+  const oklch = /^oklch\(\s*([\d.]+)%\s+([\d.]+|none)\s+([\d.]+|none)\s*(?:\/\s*([\d.]+%?)\s*)?\)$/i.exec(text);
+  if (oklch) {
+    const component = (raw: string) => (raw.toLowerCase() === "none" ? 0 : Number(raw));
+    return {
+      rgb: oklchToRgb(Number(oklch[1]), component(oklch[2]), component(oklch[3])),
+      alpha: parseAlpha(oklch[4]),
+    };
+  }
+
+  throw new Error(`contrast: cannot parse colour ${JSON.stringify(value)}`);
+}
+
+const parseAlpha = (raw: string | undefined): number => {
+  if (raw === undefined) return 1;
+  return raw.endsWith("%") ? Number(raw.slice(0, -1)) / 100 : Number(raw);
+};
+
+/**
+ * Lay `foreground` at `alpha` over `background`, source-over, in the
+ * gamma-encoded space the browser composites in. A tint is only a colour once
+ * this has happened; before that it is a question with two answers, one per
+ * theme, which is the whole of #402.
+ */
+export function composite(foreground: Rgb, background: Rgb, alpha: number): Rgb {
+  return foreground.map((channel, i) => channel * alpha + background[i] * (1 - alpha)) as unknown as Rgb;
+}
+
+/** WCAG 2.1 relative luminance — defined on linear sRGB, not on the hex digits. */
+export function luminance([r, g, b]: Rgb): number {
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+/** WCAG 2.1 contrast ratio. Order-independent by construction. */
+export function contrast(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * The installed Tailwind palette, read from the package rather than transcribed.
+ *
+ * Transcribing it would make the "dark is a no-op" assertion a statement about a
+ * number somebody typed in 2026, not about what the components render. A Tailwind
+ * upgrade that restyles `blue-400` IS a dark-mode change, and this is what makes
+ * the suite say so instead of staying green.
+ */
+export function tailwindPalette(root: string): Map<string, Rgb> {
+  const css = readFileSync(join(root, "node_modules", "tailwindcss", "theme.css"), "utf8");
+  const palette = new Map<string, Rgb>();
+  for (const [, name, body] of css.matchAll(/--color-([a-z]+-\d{2,3}):\s*(oklch\([^)]*\));/g)) {
+    palette.set(name, parseColor(body).rgb);
+  }
+  if (palette.size < 100) {
+    throw new Error(`contrast: only ${palette.size} Tailwind colours parsed — the theme.css format moved`);
+  }
+  return palette;
+}
+
+/** `blue-400` → its sRGB value, or a loud failure naming the step. */
+export function tailwindStep(palette: Map<string, Rgb>, step: string): Rgb {
+  const rgb = palette.get(step);
+  if (!rgb) throw new Error(`contrast: Tailwind has no colour named ${step}`);
+  return rgb;
+}

--- a/tests/helpers/contrast.ts
+++ b/tests/helpers/contrast.ts
@@ -18,7 +18,7 @@
  *     what browsers do, and what makes the result equal Tailwind's own published
  *     hexes. Skipping the clip silently shifts every ratio.
  *
- *  2. An opacity modifier (`bg-accent-tint/15`) is not a colour, it is a colour
+ *  2. An opacity modifier (`bg-brand-tint/15`) is not a colour, it is a colour
  *     that has to be composited over whatever is behind it before it can be
  *     measured. `text-x on bg-y/15` is a question about the COMPOSITE, and it is
  *     the question #402 turned on: blue-300 over `blue-500/15` is 9.48:1 on the
@@ -37,12 +37,10 @@ export type Rgb = readonly [number, number, number];
 const clamp01 = (x: number) => Math.min(1, Math.max(0, x));
 
 /** sRGB transfer function, gamma-encoded → linear. */
-const toLinear = (channel: number) =>
-  channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+const toLinear = (channel: number) => (channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4);
 
 /** sRGB transfer function, linear → gamma-encoded. */
-const toGamma = (channel: number) =>
-  channel <= 0.0031308 ? 12.92 * channel : 1.055 * channel ** (1 / 2.4) - 0.055;
+const toGamma = (channel: number) => (channel <= 0.0031308 ? 12.92 * channel : 1.055 * channel ** (1 / 2.4) - 0.055);
 
 /**
  * Oklab → linear sRGB (Björn Ottosson's matrices). Kept separate from the oklch
@@ -70,9 +68,22 @@ export function toOklab([r, g, b]: Rgb): Rgb {
   const s = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb);
   return [
     0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
-    1.9779984951 * l - 0.2429228246 * m - 0.4505937099 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
     0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
   ];
+}
+
+/**
+ * A round trip through the two matrices above, so a transcription slip in either
+ * one fails loudly instead of quietly measuring distance in a space that is not
+ * Oklab. The a-row cost this file a day: `-2.4285922050` was typed as
+ * `-0.2429228246` and the sign on the s term flipped, which left every ratio
+ * correct (they never touch Oklab) and every separation figure wrong.
+ */
+export function oklabRoundTripError(rgb: Rgb): number {
+  const [L, a, b] = toOklab(rgb);
+  const back = oklabToLinearSrgb(L, a, b).map((channel) => toGamma(clamp01(channel))) as unknown as Rgb;
+  return Math.max(...rgb.map((channel, i) => Math.abs(channel - back[i])));
 }
 
 /**
@@ -90,16 +101,18 @@ export function deltaEOk(a: Rgb, b: Rgb): number {
 /** oklch(L% C H) → gamma-encoded sRGB, clipped to gamut the way a browser clips. */
 export function oklchToRgb(lightnessPercent: number, chroma: number, hueDegrees: number): Rgb {
   const hue = (hueDegrees * Math.PI) / 180;
-  const linear = oklabToLinearSrgb(
-    lightnessPercent / 100,
-    chroma * Math.cos(hue),
-    chroma * Math.sin(hue),
-  );
+  const linear = oklabToLinearSrgb(lightnessPercent / 100, chroma * Math.cos(hue), chroma * Math.sin(hue));
   return linear.map((channel) => toGamma(clamp01(channel))) as unknown as Rgb;
 }
 
 export const toHex = (rgb: Rgb): string =>
-  `#${rgb.map((channel) => Math.round(channel * 255).toString(16).padStart(2, "0")).join("")}`;
+  `#${rgb
+    .map((channel) =>
+      Math.round(channel * 255)
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
 
 /**
  * Parse the colour syntaxes the token layer actually writes: `#rgb`, `#rrggbb`,

--- a/tests/unit/components/column-list.test.tsx
+++ b/tests/unit/components/column-list.test.tsx
@@ -60,8 +60,8 @@ describe("ColumnList", () => {
   test("renders Key icon for primary key column", () => {
     const html = renderToStaticMarkup(<ColumnList columns={[primaryColumn]} indexes={[]} />);
 
-    // Key icon has yellow styling
-    expect(html).toContain("text-yellow-500");
+    // Key icon carries the yellow identity hue token
+    expect(html).toContain("text-hue-yellow");
   });
 
   // ── Non-primary column dot ───────────────────────────────────────────────
@@ -71,7 +71,7 @@ describe("ColumnList", () => {
 
     // Non-primary columns get a dot instead of key icon
     expect(html).toContain("rounded-full");
-    expect(html).not.toContain("text-yellow-500");
+    expect(html).not.toContain("text-hue-yellow");
   });
 
   // ── Type display strips parentheses ──────────────────────────────────────
@@ -101,7 +101,7 @@ describe("ColumnList", () => {
     expect(html).toContain("email");
     expect(html).toContain("bio");
     // Should have both key icon and dot
-    expect(html).toContain("text-yellow-500");
+    expect(html).toContain("text-hue-yellow");
     expect(html).toContain("rounded-full");
   });
 
@@ -151,7 +151,7 @@ describe("ColumnList", () => {
 
     // Should render the wrapper div but no column items
     expect(html).toContain("<div");
-    expect(html).not.toContain("text-yellow-500");
+    expect(html).not.toContain("text-hue-yellow");
     expect(html).not.toContain("rounded-full");
   });
 

--- a/tests/unit/components/results-grid-renderers.test.ts
+++ b/tests/unit/components/results-grid-renderers.test.ts
@@ -109,11 +109,11 @@ describe("renderCompact", () => {
   test("jsonRenderer compact-stringifies objects and arrays on a single line", () => {
     expect(jsonRenderer.renderCompact({ a: 1 })).toEqual({
       display: '{"a":1}',
-      className: "text-blue-400/80 italic font-light",
+      className: "text-hue-blue/80 italic font-light",
     });
     expect(jsonRenderer.renderCompact([1, 2])).toEqual({
       display: "[1,2]",
-      className: "text-blue-400/80 italic font-light",
+      className: "text-hue-blue/80 italic font-light",
     });
   });
 
@@ -125,15 +125,15 @@ describe("renderCompact", () => {
   test("binaryRenderer renders hex in the cell and truncates a long value with its size", () => {
     expect(binaryRenderer.renderCompact({ type: "Buffer", data: [1, 2, 171, 255] })).toEqual({
       display: "\\x0102abff",
-      className: "text-cyan-400/80 font-mono",
+      className: "text-hue-cyan/80 font-mono",
     });
     const long = new Uint8Array(1024 * 1024).fill(0xab);
     expect(binaryRenderer.renderCompact(long).display).toBe(`\\x${"ab".repeat(32)}... (1.0 MB)`);
   });
 
   test("scalarRenderer keeps the status-string coloring", () => {
-    expect(scalarRenderer.renderCompact("active")).toEqual({ display: "active", className: "text-emerald-500/90" });
-    expect(scalarRenderer.renderCompact("disabled")).toEqual({ display: "disabled", className: "text-rose-500/90" });
+    expect(scalarRenderer.renderCompact("active")).toEqual({ display: "active", className: "text-hue-emerald/90" });
+    expect(scalarRenderer.renderCompact("disabled")).toEqual({ display: "disabled", className: "text-hue-rose/90" });
     expect(scalarRenderer.renderCompact("plain")).toEqual({ display: "plain", className: "text-fg-secondary" });
   });
 });
@@ -208,7 +208,7 @@ describe("renderDetail", () => {
     const long = new Uint8Array(1024).fill(0xab);
     expect(binaryRenderer.renderDetail(long)).toEqual({
       text: `\\x${"ab".repeat(1024)}`,
-      className: "text-cyan-400/80 font-mono",
+      className: "text-hue-cyan/80 font-mono",
       preserveWhitespace: false,
     });
     expect(binaryRenderer.renderDetail({ type: "Buffer", data: [] }).text).toBe("\\x");

--- a/tests/unit/components/results-grid-utils.test.ts
+++ b/tests/unit/components/results-grid-utils.test.ts
@@ -21,38 +21,38 @@ describe("formatCellValue parity", () => {
   test("object compact-stringifies on a single line", () => {
     expect(formatCellValue({ a: 1, b: "x" })).toEqual({
       display: '{"a":1,"b":"x"}',
-      className: "text-blue-400/80 italic font-light",
+      className: "text-hue-blue/80 italic font-light",
     });
   });
 
   test("array compact-stringifies on a single line", () => {
     expect(formatCellValue([1, 2, 3])).toEqual({
       display: "[1,2,3]",
-      className: "text-blue-400/80 italic font-light",
+      className: "text-hue-blue/80 italic font-light",
     });
   });
 
   test("number renders via String()", () => {
-    expect(formatCellValue(42)).toEqual({ display: "42", className: "text-amber-500/90 font-medium" });
-    expect(formatCellValue(0)).toEqual({ display: "0", className: "text-amber-500/90 font-medium" });
-    expect(formatCellValue(-1.5)).toEqual({ display: "-1.5", className: "text-amber-500/90 font-medium" });
+    expect(formatCellValue(42)).toEqual({ display: "42", className: "text-hue-amber/90 font-medium" });
+    expect(formatCellValue(0)).toEqual({ display: "0", className: "text-hue-amber/90 font-medium" });
+    expect(formatCellValue(-1.5)).toEqual({ display: "-1.5", className: "text-hue-amber/90 font-medium" });
   });
 
-  test("boolean true is emerald, false is rose", () => {
-    expect(formatCellValue(true)).toEqual({ display: "true", className: "text-emerald-500/90" });
-    expect(formatCellValue(false)).toEqual({ display: "false", className: "text-rose-500/90" });
+  test("boolean true takes the emerald hue token, false the rose one", () => {
+    expect(formatCellValue(true)).toEqual({ display: "true", className: "text-hue-emerald/90" });
+    expect(formatCellValue(false)).toEqual({ display: "false", className: "text-hue-rose/90" });
   });
 
-  test("truthy status strings are emerald, case preserved", () => {
-    expect(formatCellValue("true")).toEqual({ display: "true", className: "text-emerald-500/90" });
-    expect(formatCellValue("ACTIVE")).toEqual({ display: "ACTIVE", className: "text-emerald-500/90" });
-    expect(formatCellValue("Enabled")).toEqual({ display: "Enabled", className: "text-emerald-500/90" });
+  test("truthy status strings take the emerald hue token, case preserved", () => {
+    expect(formatCellValue("true")).toEqual({ display: "true", className: "text-hue-emerald/90" });
+    expect(formatCellValue("ACTIVE")).toEqual({ display: "ACTIVE", className: "text-hue-emerald/90" });
+    expect(formatCellValue("Enabled")).toEqual({ display: "Enabled", className: "text-hue-emerald/90" });
   });
 
-  test("falsy status strings are rose, case preserved", () => {
-    expect(formatCellValue("false")).toEqual({ display: "false", className: "text-rose-500/90" });
-    expect(formatCellValue("INACTIVE")).toEqual({ display: "INACTIVE", className: "text-rose-500/90" });
-    expect(formatCellValue("Disabled")).toEqual({ display: "Disabled", className: "text-rose-500/90" });
+  test("falsy status strings take the rose hue token, case preserved", () => {
+    expect(formatCellValue("false")).toEqual({ display: "false", className: "text-hue-rose/90" });
+    expect(formatCellValue("INACTIVE")).toEqual({ display: "INACTIVE", className: "text-hue-rose/90" });
+    expect(formatCellValue("Disabled")).toEqual({ display: "Disabled", className: "text-hue-rose/90" });
   });
 
   test("plain string renders as-is", () => {

--- a/tests/unit/components/studio-mobile-header.test.tsx
+++ b/tests/unit/components/studio-mobile-header.test.tsx
@@ -106,7 +106,7 @@ describe("StudioMobileHeader", () => {
   test("renders Database icon in connection trigger", () => {
     const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} />);
     expect(html).toContain("lucide-database");
-    expect(html).toContain("text-blue-400");
+    expect(html).toContain("text-brand");
   });
 
   // ── ChevronDown icon in trigger ────────────────────────────────────────
@@ -121,8 +121,8 @@ describe("StudioMobileHeader", () => {
   test("shows Online badge when connection is active", () => {
     const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} />);
     expect(html).toContain("Online");
-    expect(html).toContain("text-emerald-500");
-    expect(html).toContain("bg-emerald-500/10");
+    expect(html).toContain("text-success");
+    expect(html).toContain("bg-success-tint/10");
   });
 
   test("hides Online badge when no active connection", () => {
@@ -135,34 +135,48 @@ describe("StudioMobileHeader", () => {
   test("renders monitoring gauge button", () => {
     const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} />);
     expect(html).toContain("lucide-gauge");
-    expect(html).toContain("hover:text-purple-400");
+    expect(html).toContain("hover:text-hue-purple");
   });
 
   // ── Connection pulse indicator ─────────────────────────────────────────
 
+  /**
+   * Scoped to the indicator rather than matched against the whole header.
+   *
+   * Under the old class names a substring search was accidentally precise:
+   * `bg-amber-500` appeared nowhere else in this markup. The token does — the
+   * read-only badge carries `bg-warning-tint/10` — so the negative below would have
+   * started answering about a different element the first time that badge rendered
+   * in this fixture, and it would have gone red without anything breaking.
+   */
+  const pulse = (connectionPulse: "healthy" | "degraded" | "error" | null): string | null => {
+    const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} connectionPulse={connectionPulse} />);
+    return /<div[^>]*title="Connection: [a-z]+"[^>]*>.*?<\/div>/.exec(html)?.[0] ?? null;
+  };
+
   test("renders healthy pulse indicator", () => {
-    const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} connectionPulse="healthy" />);
-    expect(html).toContain("bg-emerald-500");
-    expect(html).toContain("animate-pulse");
-    expect(html).toContain("Connection: healthy");
+    const indicator = pulse("healthy");
+    expect(indicator).toContain('title="Connection: healthy"');
+    expect(indicator).toContain("bg-success-tint");
+    expect(indicator).toContain("animate-pulse");
   });
 
   test("renders degraded pulse indicator", () => {
-    const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} connectionPulse="degraded" />);
-    expect(html).toContain("bg-amber-500");
-    expect(html).toContain("Connection: degraded");
+    const indicator = pulse("degraded");
+    expect(indicator).toContain('title="Connection: degraded"');
+    expect(indicator).toContain("bg-warning-tint");
   });
 
   test("renders error pulse indicator", () => {
-    const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} connectionPulse="error" />);
-    expect(html).toContain("bg-red-500");
-    expect(html).toContain("Connection: error");
+    const indicator = pulse("error");
+    expect(indicator).toContain('title="Connection: error"');
+    expect(indicator).toContain("bg-danger-tint");
   });
 
   test("hides pulse indicator when null", () => {
-    const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} connectionPulse={null} />);
-    expect(html).not.toContain("Connection:");
-    expect(html).not.toContain("bg-amber-500");
+    // The control the three tests above provide: the same query returns the
+    // element for every other value, so `null` here is absence, not a typo.
+    expect(pulse(null)).toBeNull();
   });
 
   // ── User trigger button ────────────────────────────────────────────────
@@ -217,7 +231,7 @@ describe("StudioMobileHeader", () => {
   test("shows RUN button when not executing", () => {
     const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} isExecuting={false} />);
     expect(html).toContain("RUN");
-    expect(html).toContain("bg-blue-600");
+    expect(html).toContain("bg-brand-solid");
     expect(html).toContain("lucide-play");
     expect(html).not.toContain("CANCEL");
     expect(html).not.toContain("lucide-square");
@@ -226,7 +240,7 @@ describe("StudioMobileHeader", () => {
   test("shows CANCEL button when executing", () => {
     const html = renderToStaticMarkup(<StudioMobileHeader {...defaultProps} isExecuting={true} />);
     expect(html).toContain("CANCEL");
-    expect(html).toContain("bg-red-600");
+    expect(html).toContain("bg-danger-solid");
     expect(html).toContain("lucide-square");
     expect(html).not.toContain("RUN");
     expect(html).not.toContain("lucide-play");
@@ -278,8 +292,8 @@ describe("StudioMobileHeader", () => {
     expect(errorHtml).not.toContain("animate-pulse");
 
     // Each has unique color
-    expect(healthyHtml).toContain("bg-emerald-500");
-    expect(degradedHtml).toContain("bg-amber-500");
-    expect(errorHtml).toContain("bg-red-500");
+    expect(healthyHtml).toContain("bg-success-tint");
+    expect(degradedHtml).toContain("bg-warning-tint");
+    expect(errorHtml).toContain("bg-danger-tint");
   });
 });

--- a/tests/unit/lib/monitoring-thresholds.test.ts
+++ b/tests/unit/lib/monitoring-thresholds.test.ts
@@ -80,19 +80,19 @@ describe("evaluateThreshold (direction=below)", () => {
 // ============================================================================
 
 describe("getThresholdColor", () => {
-  test("healthy returns green CSS class", () => {
+  test("healthy returns the success border token", () => {
     const color = getThresholdColor("healthy");
-    expect(color).toContain("green");
+    expect(color).toBe("border-success-tint/30");
   });
 
-  test("warning returns yellow CSS class", () => {
+  test("warning returns the warning border token", () => {
     const color = getThresholdColor("warning");
-    expect(color).toContain("yellow");
+    expect(color).toBe("border-warning-tint/50");
   });
 
-  test("critical returns red CSS class", () => {
+  test("critical returns the danger border token", () => {
     const color = getThresholdColor("critical");
-    expect(color).toContain("red");
+    expect(color).toBe("border-danger-tint/50");
   });
 });
 

--- a/tests/unit/lib/monitoring-thresholds.test.ts
+++ b/tests/unit/lib/monitoring-thresholds.test.ts
@@ -98,9 +98,22 @@ describe("getThresholdColor", () => {
     expect(color).toBe("border-hue-yellow-tint/50");
   });
 
-  test("critical returns the danger border token", () => {
+  test("critical returns the red identity ring", () => {
     const color = getThresholdColor("critical");
-    expect(color).toBe("border-danger-tint/50");
+    expect(color).toBe("border-hue-red-tint/50");
+  });
+
+  /**
+   * All three from one family. `danger-tint` and `hue-red-tint` are the same value,
+   * so mixing them changed nothing visible — which is exactly why it would have
+   * survived: a reader of one arm would have inferred the wrong rule for the other
+   * two.
+   */
+  test("the three rings come from one vocabulary, not two", () => {
+    const families = (["healthy", "warning", "critical"] as const)
+      .map((level) => /border-(hue|brand|warning|success|danger)/.exec(getThresholdColor(level))?.[1])
+      .filter((family, index, all) => all.indexOf(family) === index);
+    expect(families).toEqual(["hue"]);
   });
 });
 

--- a/tests/unit/lib/monitoring-thresholds.test.ts
+++ b/tests/unit/lib/monitoring-thresholds.test.ts
@@ -80,14 +80,22 @@ describe("evaluateThreshold (direction=below)", () => {
 // ============================================================================
 
 describe("getThresholdColor", () => {
-  test("healthy returns the success border token", () => {
+  /**
+   * Green and yellow, not the emerald-based `success` and amber-based `warning`
+   * roles. The monitoring surfaces have always drawn their threshold ring in
+   * green/yellow/red, and routing them through the state roles would have changed
+   * the hue in dark — so they take the identity hues that reproduce it exactly
+   * (#402). The drift between the two vocabularies is real and is filed, but it is
+   * not this migration's to resolve.
+   */
+  test("healthy returns the green identity ring", () => {
     const color = getThresholdColor("healthy");
-    expect(color).toBe("border-success-tint/30");
+    expect(color).toBe("border-hue-green-tint/30");
   });
 
-  test("warning returns the warning border token", () => {
+  test("warning returns the yellow identity ring", () => {
     const color = getThresholdColor("warning");
-    expect(color).toBe("border-warning-tint/50");
+    expect(color).toBe("border-hue-yellow-tint/50");
   });
 
   test("critical returns the danger border token", () => {

--- a/tests/unit/theme-accent-contrast.test.ts
+++ b/tests/unit/theme-accent-contrast.test.ts
@@ -351,13 +351,22 @@ describe("the dark palette reproduces the literals the components carried", () =
    * what the palette-parity test requires; declaring them DIFFERENTLY would be a
    * silent dark-mode change.
    */
-  for (const role of ["brand", "warning", "success", "danger"]) {
-    for (const suffix of ["tint", "solid", "solid-hover"]) {
-      test(`--studio-${role}-${suffix} is mode-independent`, () => {
-        expect(value(light, `--studio-${role}-${suffix}`)).toBe(value(dark, `--studio-${role}-${suffix}`));
-      });
-    }
-  }
+  /**
+   * Every declared ground, not a hand-listed set of suffixes. The first version
+   * enumerated `tint`/`solid`/`solid-hover` and so silently skipped
+   * `brand-solid-active` — which was added later and is the one most likely to be
+   * tuned in a single palette, because only three pages use it.
+   */
+  const grounds = [...light.keys()].filter((token) => /-(?:tint|solid|solid-hover|solid-active)$/.test(token));
+
+  test("the ground sweep found them (guard against a filter that matches nothing)", () => {
+    expect(grounds).toContain("--studio-brand-solid-active");
+    expect(grounds.length).toBeGreaterThan(20);
+  });
+
+  test("every wash and every filled ground is mode-independent", () => {
+    expect(grounds.filter((token) => value(light, token) !== value(dark, token))).toEqual([]);
+  });
 });
 
 describe("the light values are the ones that were selected", () => {
@@ -426,6 +435,122 @@ describe("a filled control keeps its label", () => {
       "--studio-success-solid",
       "--studio-hue-teal-solid",
     ]);
+  });
+});
+
+/**
+ * The faded sites light still loses on, and the ones both palettes lose on.
+ *
+ * Every entry improved in this migration — the worst went 1.35:1 to 6.80:1 — and
+ * none regressed. They are listed because "improved" is not "fixed", and a number
+ * in a PR description stops being true the moment somebody edits a class.
+ */
+const FADED_LIGHT_ONLY = [
+  "--studio-warning/80",
+  "--studio-success/90",
+  "--studio-warning/90",
+  "--studio-hue-amber/80",
+  "--studio-success/80",
+  "--studio-hue-yellow/90",
+  "--studio-hue-amber/90",
+  "--studio-hue-cyan/80",
+  "--studio-hue-emerald/90",
+];
+
+const FADED_BOTH = [
+  "--studio-brand/20",
+  "--studio-brand/50",
+  "--studio-brand/80",
+  "--studio-danger/70",
+  "--studio-danger/80",
+  "--studio-hue-amber/70",
+  "--studio-hue-blue/80",
+  "--studio-hue-emerald/70",
+  "--studio-hue-purple/40",
+  "--studio-hue-purple/50",
+  "--studio-hue-red/60",
+  "--studio-hue-rose/90",
+  "--studio-hue-yellow/70",
+  "--studio-success/50",
+  "--studio-warning/60",
+  "--studio-warning/70",
+];
+
+/**
+ * Faded accent text — `text-warning/80`, `text-hue-amber/70`, `text-brand/50`.
+ *
+ * The gate above measures the token OPAQUE, which is not what these paint: an
+ * opacity modifier composites the foreground onto its ground before anyone reads
+ * it, and a token that clears AA at full strength can fall well under it at 50%.
+ * A review caught that this file could not see them at all.
+ *
+ * What the measurement says, once it exists: this migration IMPROVED every one of
+ * these sites in light — 38 of 38, worst case 1.35:1 -> 6.80:1 — and regressed
+ * none. It did not lift all of them over AA, and 9 of the survivors fail in dark
+ * too, at values byte-identical to what shipped before #402. So this is not the
+ * failure class #402 is about ("the one failure class that light has and dark does
+ * not"); it is a second one, symmetric across themes, that the accent ramp alone
+ * cannot fix — a faded token needs a per-mode alpha, which is its own design.
+ *
+ * Pinned rather than deferred in prose: the list can only shrink, and the day
+ * somebody fixes one, this test says so.
+ */
+describe("faded accent text is measured, not assumed", () => {
+  const FADED = /\btext-((?:brand|warning|success|danger)(?:-bright)?|hue-[a-z]+(?:-alt)?)\/(\d{1,3})\b/g;
+
+  const sites = (() => {
+    const seen = new Map<string, number>();
+    for (const [, token, alpha] of sourceOfSrc().matchAll(FADED)) {
+      const key = `--studio-${token}`;
+      const value = Number(alpha) / 100;
+      if (!seen.has(`${key}/${alpha}`)) seen.set(`${key}/${alpha}`, value);
+    }
+    return [...seen.entries()].map(([label, alpha]) => ({ label, token: label.split("/")[0], alpha }));
+  })();
+
+  const tintFor = (token: string) => {
+    const hue = /^--studio-hue-([a-z]+)/.exec(token);
+    if (hue) return `--studio-hue-${hue[1]}-tint`;
+    return `${token.replace(/-bright$/, "")}-tint`;
+  };
+
+  /** The worst ratio this faded foreground reaches on any ground it may sit on. */
+  const worstFaded = (palettes: Map<string, string>, token: string, alpha: number) => {
+    const foreground = rgb(palettes, token);
+    const tint = tintFor(token);
+    let worst = Number.POSITIVE_INFINITY;
+    for (const groundToken of GROUNDS) {
+      const base = rgb(palettes, groundToken);
+      const candidates = [base, ...TINT_ALPHAS.map((a) => composite(rgb(palettes, tint), base, a))];
+      for (const ground of candidates) worst = Math.min(worst, contrast(composite(foreground, ground, alpha), ground));
+    }
+    return worst;
+  };
+
+  test("the scan found the faded call sites (guard against a regex that matches nothing)", () => {
+    expect(sites.length).toBeGreaterThan(20);
+    expect(sites.map((s) => s.label)).toContain("--studio-warning/80");
+  });
+
+  /**
+   * Light is allowed to be no worse than dark at the same opacity. Where dark
+   * already failed, light inherits a defect it did not create; where dark passed,
+   * light has to pass too — and that is the #402 contract, applied to a foreground
+   * the original sweep could not see.
+   */
+  test("no faded accent is worse in light than the same accent is in dark", () => {
+    const regressions = sites
+      .filter(({ token, alpha }) => worstFaded(dark, token, alpha) >= AA && worstFaded(light, token, alpha) < AA)
+      .map(({ label }) => label);
+    expect(regressions).toEqual(FADED_LIGHT_ONLY);
+  });
+
+  test("the faded sites that fail in BOTH palettes are the ones that always did", () => {
+    const both = sites
+      .filter(({ token, alpha }) => worstFaded(dark, token, alpha) < AA && worstFaded(light, token, alpha) < AA)
+      .map(({ label }) => label)
+      .sort();
+    expect(both).toEqual(FADED_BOTH);
   });
 });
 

--- a/tests/unit/theme-accent-contrast.test.ts
+++ b/tests/unit/theme-accent-contrast.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  composite,
+  contrast,
+  deltaEOk,
+  parseColor,
+  tailwindPalette,
+  tailwindStep,
+  toHex,
+} from "../helpers/contrast";
+
+/**
+ * #402: the accents kept dark-tuned values on light grounds.
+ *
+ * #384 moved every NEUTRAL colour behind a token and left accents out of scope, so
+ * `bg-blue-500/15 text-blue-300` — a chip you can read on `#0a0a0a` at 9.5:1 — went
+ * on rendering over `#fafafa`, where the same two class names measure 1.46:1. The
+ * pair was never a colour choice; it was a question whose answer depends on what is
+ * behind it, and only one of the two answers had ever been looked at.
+ *
+ * This file is the answer being looked at, every run. It is deliberately NOT a
+ * snapshot of the values: it recomputes the ratios from the tokens as declared and
+ * from the Tailwind palette as installed, so it fails when either moves.
+ *
+ * Three separate contracts, and they fail for different reasons:
+ *
+ *   1. LEGIBILITY — every accent that carries text clears WCAG AA (4.5:1) on every
+ *      ground it can land on, in BOTH palettes. This is the acceptance criterion.
+ *   2. NO-OP IN DARK — the dark value of each token is exactly the Tailwind step the
+ *      components carried before the migration. #384's rule, and the one #384 itself
+ *      broke once (the editor scrollbar). Resolved from `node_modules`, not
+ *      transcribed, so a Tailwind upgrade that restyles `blue-400` reports itself as
+ *      what it is: a dark-mode change.
+ *   3. SEPARATION — the identity hues encode WHICH THING, not what state, so they
+ *      have to stay tellable apart. Selected per mode like `charts/palette.ts`, and
+ *      held to the shipped dark set's own minimum rather than to a number invented
+ *      here.
+ */
+
+const ROOT = join(import.meta.dir, "..", "..");
+const theme = readFileSync(join(ROOT, "src", "styles", "theme.css"), "utf8");
+const palette = tailwindPalette(ROOT);
+
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+function declarations(selector: string): Map<string, string> {
+  const css = stripComments(theme);
+  const start = css.indexOf(`${selector} {`);
+  expect(start).toBeGreaterThan(-1);
+  const end = css.indexOf("\n}", start);
+  expect(end).toBeGreaterThan(start);
+  return new Map(
+    Array.from(css.slice(start, end).matchAll(/(--studio-[a-z0-9-]+)\s*:\s*([^;]+);/g), (m) => [
+      m[1],
+      m[2].trim(),
+    ]),
+  );
+}
+
+const light = declarations(":root");
+const dark = declarations(".dark");
+
+const value = (palette: Map<string, string>, token: string): string => {
+  const declared = palette.get(token);
+  if (!declared) throw new Error(`theme.css declares no ${token}`);
+  return declared;
+};
+
+const rgb = (palettes: Map<string, string>, token: string) => parseColor(value(palettes, token)).rgb;
+
+/**
+ * The grounds a coloured word can actually land on.
+ *
+ * Not a cartesian product of every colour against every other: measured that way,
+ * the SHIPPED dark values fail, which would make the bar wrong rather than the
+ * palette. This is the population as it exists in `src` — the five studio grounds,
+ * a wash of the token's own hue (the #402 failure class), and the accent tile, the
+ * one cross-hue ground that provably carries every identity hue at once (the
+ * selected-engine tile in `ConnectionModal`, `bg-blue-600/10`).
+ *
+ * `/20` is the ceiling because no tint heavier than that carries coloured text
+ * anywhere in `src`; `bg-blue-500/30` and `/50` exist, but as fills, never as a
+ * ground under a word.
+ */
+const GROUNDS = {
+  light: ["--studio-canvas", "--studio-sunken", "--studio-surface", "--studio-raised", "--studio-overlay"],
+  dark: ["--studio-canvas", "--studio-sunken", "--studio-surface", "--studio-raised", "--studio-overlay"],
+} as const;
+const TINT_ALPHAS = [0.05, 0.1, 0.15, 0.2];
+const ACCENT_TILE: ReadonlyArray<readonly [string, number]> = [
+  ["--studio-accent-tint", 0.05],
+  ["--studio-accent-tint", 0.1],
+  ["--studio-accent-solid", 0.1],
+];
+
+const AA = 4.5;
+
+/** The worst ratio `token` reaches anywhere it is allowed to be painted. */
+function worstGround(
+  palettes: Map<string, string>,
+  token: string,
+  ownTint: string,
+): { ratio: number; where: string } {
+  const foreground = rgb(palettes, token);
+  let ratio = Number.POSITIVE_INFINITY;
+  let where = "";
+  const record = (candidate: number, label: string) => {
+    if (candidate < ratio) {
+      ratio = candidate;
+      where = label;
+    }
+  };
+
+  for (const groundToken of GROUNDS.light) {
+    const ground = rgb(palettes, groundToken);
+    record(contrast(foreground, ground), groundToken);
+    for (const alpha of TINT_ALPHAS) {
+      record(
+        contrast(foreground, composite(rgb(palettes, ownTint), ground, alpha)),
+        `${groundToken} + ${ownTint}/${alpha * 100}`,
+      );
+    }
+    for (const [tile, alpha] of ACCENT_TILE) {
+      record(
+        contrast(foreground, composite(rgb(palettes, tile), ground, alpha)),
+        `${groundToken} + ${tile}/${alpha * 100}`,
+      );
+    }
+  }
+  return { ratio, where };
+}
+
+/**
+ * The contract, one row per token: which Tailwind step each palette reproduces, and
+ * which tint the token is washed over when it sits on its own colour.
+ *
+ * The dark column is the whole of "dark does not move" — every one of these is the
+ * literal a component carried before this migration.
+ */
+const TEXT_TOKENS: ReadonlyArray<{ token: string; light: string; dark: string; tint: string }> = [
+  { token: "--studio-accent", light: "blue-700", dark: "blue-400", tint: "--studio-accent-tint" },
+  { token: "--studio-accent-bright", light: "blue-800", dark: "blue-300", tint: "--studio-accent-tint" },
+  { token: "--studio-warning", light: "amber-800", dark: "amber-400", tint: "--studio-warning-tint" },
+  { token: "--studio-warning-bright", light: "amber-900", dark: "amber-300", tint: "--studio-warning-tint" },
+  { token: "--studio-success", light: "emerald-800", dark: "emerald-400", tint: "--studio-success-tint" },
+  { token: "--studio-success-bright", light: "emerald-900", dark: "emerald-300", tint: "--studio-success-tint" },
+  { token: "--studio-danger", light: "red-800", dark: "red-400", tint: "--studio-danger-tint" },
+  { token: "--studio-danger-bright", light: "red-900", dark: "red-300", tint: "--studio-danger-tint" },
+];
+
+/**
+ * The identity palette. `-alt` is a second step of the same hue: sometimes a second
+ * IDENTITY (db-ui-config has more engines than there are hues, and its own test
+ * asserts all of them differ), sometimes just emphasis on one.
+ */
+const HUES: ReadonlyArray<{ hue: string; light: string; lightAlt: string }> = [
+  { hue: "blue", light: "blue-700", lightAlt: "blue-800" },
+  { hue: "sky", light: "sky-800", lightAlt: "sky-900" },
+  { hue: "indigo", light: "indigo-700", lightAlt: "indigo-800" },
+  { hue: "violet", light: "violet-700", lightAlt: "violet-800" },
+  { hue: "purple", light: "purple-700", lightAlt: "purple-800" },
+  { hue: "pink", light: "pink-800", lightAlt: "pink-900" },
+  { hue: "rose", light: "rose-800", lightAlt: "rose-900" },
+  { hue: "red", light: "red-800", lightAlt: "red-900" },
+  { hue: "orange", light: "orange-800", lightAlt: "orange-900" },
+  { hue: "amber", light: "amber-900", lightAlt: "amber-950" },
+  { hue: "yellow", light: "yellow-800", lightAlt: "yellow-950" },
+  { hue: "green", light: "green-800", lightAlt: "green-900" },
+  { hue: "emerald", light: "emerald-800", lightAlt: "emerald-900" },
+  { hue: "teal", light: "teal-800", lightAlt: "teal-950" },
+  { hue: "cyan", light: "cyan-800", lightAlt: "cyan-900" },
+];
+
+/**
+ * The four hues where two engines share a hue and are held apart only by step, so
+ * the `-alt` is a distinct IDENTITY and has to join the separation set. Pinned by
+ * `tests/unit/lib/db-ui-config.test.ts`, which asserts every engine colour differs.
+ */
+const IDENTITY_ALTS = ["sky", "yellow", "emerald", "teal"] as const;
+
+describe("accent text clears WCAG AA on every ground it can land on", () => {
+  for (const { token, tint } of TEXT_TOKENS) {
+    test(`${token} in light`, () => {
+      const { ratio, where } = worstGround(light, token, tint);
+      expect({ token, worst: `${ratio.toFixed(2)}:1`, where }).toEqual({
+        token,
+        worst: `${ratio.toFixed(2)}:1`,
+        where,
+      });
+      expect(ratio).toBeGreaterThanOrEqual(AA);
+    });
+
+    test(`${token} in dark`, () => {
+      expect(worstGround(dark, token, tint).ratio).toBeGreaterThanOrEqual(AA);
+    });
+  }
+
+  for (const { hue } of HUES) {
+    for (const suffix of ["", "-alt"]) {
+      const token = `--studio-hue-${hue}${suffix}`;
+      test(`${token} in both palettes`, () => {
+        expect(worstGround(light, token, `--studio-hue-${hue}-tint`).ratio).toBeGreaterThanOrEqual(AA);
+        expect(worstGround(dark, token, `--studio-hue-${hue}-tint`).ratio).toBeGreaterThanOrEqual(AA);
+      });
+    }
+  }
+});
+
+/**
+ * The regression #402 is about, stated as itself rather than as a floor: the pairing
+ * from the issue's own table. If someone reverts the accent to a -300/-400 step,
+ * every "clears AA" test above fails too — but this one names the defect.
+ */
+describe("the pairing from the issue", () => {
+  test("an accent word on an accent chip is readable in light, not just in dark", () => {
+    for (const palettes of [light, dark]) {
+      const chip = composite(rgb(palettes, "--studio-accent-tint"), rgb(palettes, "--studio-surface"), 0.15);
+      expect(contrast(rgb(palettes, "--studio-accent-bright"), chip)).toBeGreaterThanOrEqual(AA);
+    }
+  });
+
+  test("the value that failed is gone from the light palette", () => {
+    // blue-300 over blue-500/15 over #fafafa measured 1.46:1. Not a floor test —
+    // this asserts the specific value is no longer what light mode paints.
+    expect(value(light, "--studio-accent-bright")).not.toBe(toHex(tailwindStep(palette, "blue-300")));
+  });
+});
+
+describe("the dark palette reproduces the literals the components carried", () => {
+  for (const { token, dark: step } of TEXT_TOKENS) {
+    test(`${token} is still ${step}`, () => {
+      expect(value(dark, token)).toBe(toHex(tailwindStep(palette, step)));
+    });
+  }
+
+  for (const { hue } of HUES) {
+    test(`--studio-hue-${hue} is still ${hue}-400, and its -alt still ${hue}-300`, () => {
+      expect(value(dark, `--studio-hue-${hue}`)).toBe(toHex(tailwindStep(palette, `${hue}-400`)));
+      expect(value(dark, `--studio-hue-${hue}-alt`)).toBe(toHex(tailwindStep(palette, `${hue}-300`)));
+    });
+
+    /**
+     * A wash is the -500 step at some alpha in both palettes — the value the
+     * components already carried as `bg-<hue>-500/10`. Transcribing thirty of these
+     * by hand got `green-500` wrong by one digit on the first attempt; resolving
+     * them is what caught it.
+     */
+    test(`--studio-hue-${hue}-tint is ${hue}-500 in both palettes`, () => {
+      const step = toHex(tailwindStep(palette, `${hue}-500`));
+      expect(value(dark, `--studio-hue-${hue}-tint`)).toBe(step);
+      expect(value(light, `--studio-hue-${hue}-tint`)).toBe(step);
+    });
+  }
+
+  /**
+   * The tints and the solid grounds are the same value in both palettes on purpose:
+   * a wash is alpha over whatever is behind it, so it already adapts, and a filled
+   * button's label contrast does not depend on the page. Declaring them twice is
+   * what the palette-parity test requires; declaring them DIFFERENTLY would be a
+   * silent dark-mode change.
+   */
+  for (const role of ["accent", "warning", "success", "danger"]) {
+    for (const suffix of ["tint", "solid", "solid-hover"]) {
+      test(`--studio-${role}-${suffix} is mode-independent`, () => {
+        expect(value(light, `--studio-${role}-${suffix}`)).toBe(value(dark, `--studio-${role}-${suffix}`));
+      });
+    }
+  }
+});
+
+describe("the light values are the ones that were selected", () => {
+  for (const { token, light: step } of TEXT_TOKENS) {
+    test(`${token} is ${step}`, () => {
+      expect(value(light, token)).toBe(toHex(tailwindStep(palette, step)));
+    });
+  }
+
+  for (const { hue, light: step, lightAlt } of HUES) {
+    test(`--studio-hue-${hue} is ${step}, its -alt ${lightAlt}`, () => {
+      expect(value(light, `--studio-hue-${hue}`)).toBe(toHex(tailwindStep(palette, step)));
+      expect(value(light, `--studio-hue-${hue}-alt`)).toBe(toHex(tailwindStep(palette, lightAlt)));
+    });
+  }
+});
+
+describe("the identity hues stay tellable apart", () => {
+  const closestPair = (palettes: Map<string, string>, tokens: string[]) => {
+    let closest = Number.POSITIVE_INFINITY;
+    let pair = "";
+    for (let i = 0; i < tokens.length; i++) {
+      for (let j = i + 1; j < tokens.length; j++) {
+        const distance = deltaEOk(rgb(palettes, tokens[i]), rgb(palettes, tokens[j]));
+        if (distance < closest) {
+          closest = distance;
+          pair = `${tokens[i]} vs ${tokens[j]}`;
+        }
+      }
+    }
+    return { closest, pair };
+  };
+
+  const identitySet = HUES.map(({ hue }) => `--studio-hue-${hue}`).concat(
+    IDENTITY_ALTS.map((hue) => `--studio-hue-${hue}-alt`),
+  );
+
+  /**
+   * The bar is the SHIPPED dark set's own minimum, not a number chosen here. Dark is
+   * what users look at today and nobody has called it muddy, so a light set that is
+   * no tighter anywhere is a light set that is at least as legible — and the claim
+   * survives someone later retuning dark, because the bar moves with it.
+   */
+  test("the light set is no tighter than the dark set it is modelled on", () => {
+    const darkest = closestPair(dark, identitySet);
+    const lightest = closestPair(light, identitySet);
+    expect({
+      bar: darkest.closest.toFixed(4),
+      barPair: darkest.pair,
+      light: lightest.closest.toFixed(4),
+      lightPair: lightest.pair,
+    }).toEqual({
+      bar: darkest.closest.toFixed(4),
+      barPair: darkest.pair,
+      light: lightest.closest.toFixed(4),
+      lightPair: lightest.pair,
+    });
+    expect(lightest.closest).toBeGreaterThanOrEqual(darkest.closest);
+  });
+
+  /**
+   * `-alt` exists to be a DIFFERENT colour from its base — two engines, or an icon
+   * beside the value it labels. A pair that collapses defeats the reason the token
+   * was added, and does it invisibly: both still clear AA.
+   */
+  test("every -alt is distinguishable from its own base, in both palettes", () => {
+    for (const { hue } of HUES) {
+      for (const palettes of [light, dark]) {
+        expect(deltaEOk(rgb(palettes, `--studio-hue-${hue}`), rgb(palettes, `--studio-hue-${hue}-alt`))).toBeGreaterThan(
+          0.05,
+        );
+      }
+    }
+  });
+
+  /**
+   * The emphasis steps have the same job inside the state roles. In dark `-bright`
+   * is literally brighter; in light it is darker — the same inversion `fg-bright`
+   * already makes, and the reason the token is not called `-light`.
+   */
+  test("every state -bright is distinguishable from its own base, in both palettes", () => {
+    for (const role of ["accent", "warning", "success", "danger"]) {
+      for (const palettes of [light, dark]) {
+        expect(deltaEOk(rgb(palettes, `--studio-${role}`), rgb(palettes, `--studio-${role}-bright`))).toBeGreaterThan(
+          0.05,
+        );
+      }
+    }
+  });
+});

--- a/tests/unit/theme-accent-contrast.test.ts
+++ b/tests/unit/theme-accent-contrast.test.ts
@@ -2,15 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import {
-  composite,
-  contrast,
-  deltaEOk,
-  parseColor,
-  tailwindPalette,
-  tailwindStep,
-  toHex,
-} from "../helpers/contrast";
+import { composite, contrast, deltaEOk, parseColor, tailwindPalette, tailwindStep, toHex } from "../helpers/contrast";
 
 /**
  * #402: the accents kept dark-tuned values on light grounds.
@@ -53,10 +45,7 @@ function declarations(selector: string): Map<string, string> {
   const end = css.indexOf("\n}", start);
   expect(end).toBeGreaterThan(start);
   return new Map(
-    Array.from(css.slice(start, end).matchAll(/(--studio-[a-z0-9-]+)\s*:\s*([^;]+);/g), (m) => [
-      m[1],
-      m[2].trim(),
-    ]),
+    Array.from(css.slice(start, end).matchAll(/(--studio-[a-z0-9-]+)\s*:\s*([^;]+);/g), (m) => [m[1], m[2].trim()]),
   );
 }
 
@@ -91,19 +80,15 @@ const GROUNDS = {
 } as const;
 const TINT_ALPHAS = [0.05, 0.1, 0.15, 0.2];
 const ACCENT_TILE: ReadonlyArray<readonly [string, number]> = [
-  ["--studio-accent-tint", 0.05],
-  ["--studio-accent-tint", 0.1],
-  ["--studio-accent-solid", 0.1],
+  ["--studio-brand-tint", 0.05],
+  ["--studio-brand-tint", 0.1],
+  ["--studio-brand-solid", 0.1],
 ];
 
 const AA = 4.5;
 
 /** The worst ratio `token` reaches anywhere it is allowed to be painted. */
-function worstGround(
-  palettes: Map<string, string>,
-  token: string,
-  ownTint: string,
-): { ratio: number; where: string } {
+function worstGround(palettes: Map<string, string>, token: string, ownTint: string): { ratio: number; where: string } {
   const foreground = rgb(palettes, token);
   let ratio = Number.POSITIVE_INFINITY;
   let where = "";
@@ -141,8 +126,8 @@ function worstGround(
  * literal a component carried before this migration.
  */
 const TEXT_TOKENS: ReadonlyArray<{ token: string; light: string; dark: string; tint: string }> = [
-  { token: "--studio-accent", light: "blue-700", dark: "blue-400", tint: "--studio-accent-tint" },
-  { token: "--studio-accent-bright", light: "blue-800", dark: "blue-300", tint: "--studio-accent-tint" },
+  { token: "--studio-brand", light: "blue-700", dark: "blue-400", tint: "--studio-brand-tint" },
+  { token: "--studio-brand-bright", light: "blue-800", dark: "blue-300", tint: "--studio-brand-tint" },
   { token: "--studio-warning", light: "amber-800", dark: "amber-400", tint: "--studio-warning-tint" },
   { token: "--studio-warning-bright", light: "amber-900", dark: "amber-300", tint: "--studio-warning-tint" },
   { token: "--studio-success", light: "emerald-800", dark: "emerald-400", tint: "--studio-success-tint" },
@@ -165,13 +150,14 @@ const HUES: ReadonlyArray<{ hue: string; light: string; lightAlt: string }> = [
   { hue: "pink", light: "pink-800", lightAlt: "pink-900" },
   { hue: "rose", light: "rose-800", lightAlt: "rose-900" },
   { hue: "red", light: "red-800", lightAlt: "red-900" },
-  { hue: "orange", light: "orange-800", lightAlt: "orange-900" },
-  { hue: "amber", light: "amber-900", lightAlt: "amber-950" },
-  { hue: "yellow", light: "yellow-800", lightAlt: "yellow-950" },
+  { hue: "orange", light: "orange-900", lightAlt: "orange-950" },
+  { hue: "amber", light: "amber-800", lightAlt: "amber-900" },
+  { hue: "yellow", light: "yellow-800", lightAlt: "yellow-900" },
   { hue: "green", light: "green-800", lightAlt: "green-900" },
   { hue: "emerald", light: "emerald-800", lightAlt: "emerald-900" },
   { hue: "teal", light: "teal-800", lightAlt: "teal-950" },
   { hue: "cyan", light: "cyan-800", lightAlt: "cyan-900" },
+  { hue: "fuchsia", light: "fuchsia-800", lightAlt: "fuchsia-900" },
 ];
 
 /**
@@ -180,6 +166,26 @@ const HUES: ReadonlyArray<{ hue: string; light: string; lightAlt: string }> = [
  * `tests/unit/lib/db-ui-config.test.ts`, which asserts every engine colour differs.
  */
 const IDENTITY_ALTS = ["sky", "yellow", "emerald", "teal"] as const;
+
+/**
+ * What theme.css actually declares, and what each declaration is supposed to be.
+ *
+ * Driven from the file rather than from the table above, in both directions: a
+ * token the table does not know about fails, and a token the table needs but the
+ * file no longer has fails too. A table alone would go quietly stale the first time
+ * an unused token was pruned — which is exactly what happened while writing this.
+ */
+const declaredHue = new Set([...light.keys()].filter((token) => token.startsWith("--studio-hue-")));
+const declaredHueText = [...declaredHue].filter((token) => !token.endsWith("-tint") && !/-solid(-hover)?$/.test(token));
+
+const expectedSteps = new Map<string, { light: string; dark: string }>();
+for (const { hue, light: base, lightAlt } of HUES) {
+  expectedSteps.set(`--studio-hue-${hue}`, { light: base, dark: `${hue}-400` });
+  expectedSteps.set(`--studio-hue-${hue}-alt`, { light: lightAlt, dark: `${hue}-300` });
+  expectedSteps.set(`--studio-hue-${hue}-tint`, { light: `${hue}-500`, dark: `${hue}-500` });
+  expectedSteps.set(`--studio-hue-${hue}-solid`, { light: `${hue}-600`, dark: `${hue}-600` });
+  expectedSteps.set(`--studio-hue-${hue}-solid-hover`, { light: `${hue}-500`, dark: `${hue}-500` });
+}
 
 describe("accent text clears WCAG AA on every ground it can land on", () => {
   for (const { token, tint } of TEXT_TOKENS) {
@@ -198,14 +204,15 @@ describe("accent text clears WCAG AA on every ground it can land on", () => {
     });
   }
 
-  for (const { hue } of HUES) {
-    for (const suffix of ["", "-alt"]) {
-      const token = `--studio-hue-${hue}${suffix}`;
-      test(`${token} in both palettes`, () => {
-        expect(worstGround(light, token, `--studio-hue-${hue}-tint`).ratio).toBeGreaterThanOrEqual(AA);
-        expect(worstGround(dark, token, `--studio-hue-${hue}-tint`).ratio).toBeGreaterThanOrEqual(AA);
-      });
-    }
+  for (const token of declaredHueText) {
+    const hue = /--studio-hue-([a-z]+)/.exec(token)![1];
+    test(`${token} in both palettes`, () => {
+      // A hue with no wash of its own is only ever painted on a studio ground or
+      // the accent tile; `worstGround` falls back to the accent tint for it.
+      const ownTint = light.has(`--studio-hue-${hue}-tint`) ? `--studio-hue-${hue}-tint` : "--studio-brand-tint";
+      expect(worstGround(light, token, ownTint).ratio).toBeGreaterThanOrEqual(AA);
+      expect(worstGround(dark, token, ownTint).ratio).toBeGreaterThanOrEqual(AA);
+    });
   }
 });
 
@@ -217,15 +224,15 @@ describe("accent text clears WCAG AA on every ground it can land on", () => {
 describe("the pairing from the issue", () => {
   test("an accent word on an accent chip is readable in light, not just in dark", () => {
     for (const palettes of [light, dark]) {
-      const chip = composite(rgb(palettes, "--studio-accent-tint"), rgb(palettes, "--studio-surface"), 0.15);
-      expect(contrast(rgb(palettes, "--studio-accent-bright"), chip)).toBeGreaterThanOrEqual(AA);
+      const chip = composite(rgb(palettes, "--studio-brand-tint"), rgb(palettes, "--studio-surface"), 0.15);
+      expect(contrast(rgb(palettes, "--studio-brand-bright"), chip)).toBeGreaterThanOrEqual(AA);
     }
   });
 
   test("the value that failed is gone from the light palette", () => {
     // blue-300 over blue-500/15 over #fafafa measured 1.46:1. Not a floor test —
     // this asserts the specific value is no longer what light mode paints.
-    expect(value(light, "--studio-accent-bright")).not.toBe(toHex(tailwindStep(palette, "blue-300")));
+    expect(value(light, "--studio-brand-bright")).not.toBe(toHex(tailwindStep(palette, "blue-300")));
   });
 });
 
@@ -236,24 +243,45 @@ describe("the dark palette reproduces the literals the components carried", () =
     });
   }
 
-  for (const { hue } of HUES) {
-    test(`--studio-hue-${hue} is still ${hue}-400, and its -alt still ${hue}-300`, () => {
-      expect(value(dark, `--studio-hue-${hue}`)).toBe(toHex(tailwindStep(palette, `${hue}-400`)));
-      expect(value(dark, `--studio-hue-${hue}-alt`)).toBe(toHex(tailwindStep(palette, `${hue}-300`)));
+  test("every declared identity hue is the step it claims, in both palettes", () => {
+    const wrong = [...declaredHue].filter((token) => {
+      const expected = expectedSteps.get(token);
+      if (!expected) return true;
+      return (
+        value(light, token) !== toHex(tailwindStep(palette, expected.light)) ||
+        value(dark, token) !== toHex(tailwindStep(palette, expected.dark))
+      );
     });
+    expect(wrong).toEqual([]);
+  });
 
-    /**
-     * A wash is the -500 step at some alpha in both palettes — the value the
-     * components already carried as `bg-<hue>-500/10`. Transcribing thirty of these
-     * by hand got `green-500` wrong by one digit on the first attempt; resolving
-     * them is what caught it.
-     */
-    test(`--studio-hue-${hue}-tint is ${hue}-500 in both palettes`, () => {
+  /**
+   * The reverse direction. Without it, deleting `--studio-hue-teal-alt` would leave
+   * every remaining assertion green — the suite would simply stop checking the
+   * token that keeps Elasticsearch from looking like Druid.
+   */
+  test("every hue the identity palette is built on is declared", () => {
+    const missing = HUES.flatMap(({ hue }) => (light.has(`--studio-hue-${hue}`) ? [] : [hue]));
+    expect(missing).toEqual([]);
+    for (const hue of IDENTITY_ALTS) expect(light.has(`--studio-hue-${hue}-alt`)).toBe(true);
+  });
+
+  /**
+   * A wash is the -500 step at some alpha in both palettes — the value the
+   * components already carried as `bg-<hue>-500/10`. Transcribing thirty of these
+   * by hand got `green-500` wrong by one digit on the first attempt; resolving them
+   * against the installed palette is what caught it.
+   */
+  test("every declared hue wash is that hue's -500 step, in both palettes", () => {
+    const tints = [...declaredHue].filter((token) => token.endsWith("-tint"));
+    expect(tints.length).toBeGreaterThan(5);
+    for (const token of tints) {
+      const hue = /--studio-hue-([a-z]+)-tint/.exec(token)![1];
       const step = toHex(tailwindStep(palette, `${hue}-500`));
-      expect(value(dark, `--studio-hue-${hue}-tint`)).toBe(step);
-      expect(value(light, `--studio-hue-${hue}-tint`)).toBe(step);
-    });
-  }
+      expect(value(dark, token)).toBe(step);
+      expect(value(light, token)).toBe(step);
+    }
+  });
 
   /**
    * The tints and the solid grounds are the same value in both palettes on purpose:
@@ -262,7 +290,7 @@ describe("the dark palette reproduces the literals the components carried", () =
    * what the palette-parity test requires; declaring them DIFFERENTLY would be a
    * silent dark-mode change.
    */
-  for (const role of ["accent", "warning", "success", "danger"]) {
+  for (const role of ["brand", "warning", "success", "danger"]) {
     for (const suffix of ["tint", "solid", "solid-hover"]) {
       test(`--studio-${role}-${suffix} is mode-independent`, () => {
         expect(value(light, `--studio-${role}-${suffix}`)).toBe(value(dark, `--studio-${role}-${suffix}`));
@@ -278,12 +306,10 @@ describe("the light values are the ones that were selected", () => {
     });
   }
 
-  for (const { hue, light: step, lightAlt } of HUES) {
-    test(`--studio-hue-${hue} is ${step}, its -alt ${lightAlt}`, () => {
-      expect(value(light, `--studio-hue-${hue}`)).toBe(toHex(tailwindStep(palette, step)));
-      expect(value(light, `--studio-hue-${hue}-alt`)).toBe(toHex(tailwindStep(palette, lightAlt)));
-    });
-  }
+  test("the identity table covers every declared hue token", () => {
+    const unaccounted = [...declaredHue].filter((token) => !expectedSteps.has(token));
+    expect(unaccounted).toEqual([]);
+  });
 });
 
 describe("the identity hues stay tellable apart", () => {
@@ -305,6 +331,11 @@ describe("the identity hues stay tellable apart", () => {
   const identitySet = HUES.map(({ hue }) => `--studio-hue-${hue}`).concat(
     IDENTITY_ALTS.map((hue) => `--studio-hue-${hue}-alt`),
   );
+
+  test("the separation set is the whole identity palette (guard against a shrinking set)", () => {
+    expect(identitySet.every((token) => light.has(token))).toBe(true);
+    expect(identitySet.length).toBeGreaterThan(15);
+  });
 
   /**
    * The bar is the SHIPPED dark set's own minimum, not a number chosen here. Dark is
@@ -335,11 +366,10 @@ describe("the identity hues stay tellable apart", () => {
    * was added, and does it invisibly: both still clear AA.
    */
   test("every -alt is distinguishable from its own base, in both palettes", () => {
-    for (const { hue } of HUES) {
+    for (const token of [...declaredHue].filter((t) => t.endsWith("-alt"))) {
+      const base = token.replace(/-alt$/, "");
       for (const palettes of [light, dark]) {
-        expect(deltaEOk(rgb(palettes, `--studio-hue-${hue}`), rgb(palettes, `--studio-hue-${hue}-alt`))).toBeGreaterThan(
-          0.05,
-        );
+        expect(deltaEOk(rgb(palettes, base), rgb(palettes, token))).toBeGreaterThan(0.05);
       }
     }
   });
@@ -350,7 +380,7 @@ describe("the identity hues stay tellable apart", () => {
    * already makes, and the reason the token is not called `-light`.
    */
   test("every state -bright is distinguishable from its own base, in both palettes", () => {
-    for (const role of ["accent", "warning", "success", "danger"]) {
+    for (const role of ["brand", "warning", "success", "danger"]) {
       for (const palettes of [light, dark]) {
         expect(deltaEOk(rgb(palettes, `--studio-${role}`), rgb(palettes, `--studio-${role}-bright`))).toBeGreaterThan(
           0.05,

--- a/tests/unit/theme-accent-contrast.test.ts
+++ b/tests/unit/theme-accent-contrast.test.ts
@@ -44,13 +44,21 @@ import {
 const ROOT = join(import.meta.dir, "..", "..");
 const theme = readFileSync(join(ROOT, "src", "styles", "theme.css"), "utf8");
 
-/** Every component source, concatenated, for the scans that have to read the code. */
+/**
+ * Every component source, concatenated, for the scans that have to read the code.
+ *
+ * Sorted, because `readdirSync` returns filesystem order: an unsorted walk makes
+ * every scan built on it machine-ordered, which is invisible on one machine and a
+ * failing assertion on the next. This suite shipped that bug once.
+ */
 function sourceOfSrc(): string {
   const walk = (dir: string): string[] =>
-    readdirSync(dir).flatMap((entry) => {
-      const path = join(dir, entry);
-      return statSync(path).isDirectory() ? walk(path) : /\.tsx?$/.test(entry) ? [path] : [];
-    });
+    readdirSync(dir)
+      .sort()
+      .flatMap((entry) => {
+        const path = join(dir, entry);
+        return statSync(path).isDirectory() ? walk(path) : /\.tsx?$/.test(entry) ? [path] : [];
+      });
   return walk(join(ROOT, "src"))
     .map((path) => readFileSync(path, "utf8"))
     .join("\n");
@@ -446,15 +454,15 @@ describe("a filled control keeps its label", () => {
  * in a PR description stops being true the moment somebody edits a class.
  */
 const FADED_LIGHT_ONLY = [
-  "--studio-warning/80",
-  "--studio-success/90",
-  "--studio-warning/90",
   "--studio-hue-amber/80",
-  "--studio-success/80",
-  "--studio-hue-yellow/90",
   "--studio-hue-amber/90",
   "--studio-hue-cyan/80",
   "--studio-hue-emerald/90",
+  "--studio-hue-yellow/90",
+  "--studio-success/80",
+  "--studio-success/90",
+  "--studio-warning/80",
+  "--studio-warning/90",
 ];
 
 const FADED_BOTH = [
@@ -541,7 +549,8 @@ describe("faded accent text is measured, not assumed", () => {
   test("no faded accent is worse in light than the same accent is in dark", () => {
     const regressions = sites
       .filter(({ token, alpha }) => worstFaded(dark, token, alpha) >= AA && worstFaded(light, token, alpha) < AA)
-      .map(({ label }) => label);
+      .map(({ label }) => label)
+      .sort();
     expect(regressions).toEqual(FADED_LIGHT_ONLY);
   });
 

--- a/tests/unit/theme-accent-contrast.test.ts
+++ b/tests/unit/theme-accent-contrast.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-import { composite, contrast, deltaEOk, parseColor, tailwindPalette, tailwindStep, toHex } from "../helpers/contrast";
+import {
+  composite,
+  contrast,
+  deltaEOk,
+  luminance,
+  parseColor,
+  tailwindPalette,
+  tailwindStep,
+  toHex,
+} from "../helpers/contrast";
 
 /**
  * #402: the accents kept dark-tuned values on light grounds.
@@ -34,6 +43,18 @@ import { composite, contrast, deltaEOk, parseColor, tailwindPalette, tailwindSte
 
 const ROOT = join(import.meta.dir, "..", "..");
 const theme = readFileSync(join(ROOT, "src", "styles", "theme.css"), "utf8");
+
+/** Every component source, concatenated, for the scans that have to read the code. */
+function sourceOfSrc(): string {
+  const walk = (dir: string): string[] =>
+    readdirSync(dir).flatMap((entry) => {
+      const path = join(dir, entry);
+      return statSync(path).isDirectory() ? walk(path) : /\.tsx?$/.test(entry) ? [path] : [];
+    });
+  return walk(join(ROOT, "src"))
+    .map((path) => readFileSync(path, "utf8"))
+    .join("\n");
+}
 const palette = tailwindPalette(ROOT);
 
 const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, "");
@@ -70,15 +91,48 @@ const rgb = (palettes: Map<string, string>, token: string) => parseColor(value(p
  * one cross-hue ground that provably carries every identity hue at once (the
  * selected-engine tile in `ConnectionModal`, `bg-blue-600/10`).
  *
- * `/20` is the ceiling because no tint heavier than that carries coloured text
- * anywhere in `src`; `bg-blue-500/30` and `/50` exist, but as fills, never as a
- * ground under a word.
+ * The alpha ladder runs to `/30`. An earlier draft stopped at `/20` on the claim
+ * that nothing heavier carried text — which was wrong: `AgentRail` and
+ * `ConsentCard` put `-bright` text on a `/25` hover wash, including the very pill
+ * this issue is about. The ladder is now a round ceiling rather than a survey, so
+ * it cannot go stale the next time a call site picks a heavier wash.
  */
-const GROUNDS = {
-  light: ["--studio-canvas", "--studio-sunken", "--studio-surface", "--studio-raised", "--studio-overlay"],
-  dark: ["--studio-canvas", "--studio-sunken", "--studio-surface", "--studio-raised", "--studio-overlay"],
-} as const;
-const TINT_ALPHAS = [0.05, 0.1, 0.15, 0.2];
+// One list, not one per mode: the ground TOKENS are the same in both palettes —
+// it is their values that differ, and `worstGround` reads those from whichever
+// palette it is handed.
+const GROUNDS = [
+  "--studio-canvas",
+  "--studio-sunken",
+  "--studio-surface",
+  "--studio-raised",
+  "--studio-overlay",
+] as const;
+/**
+ * Derived from `src`, not asserted about it.
+ *
+ * The first draft hard-coded a `/20` ceiling on the claim that nothing heavier
+ * carried text. That was wrong — `AgentRail` and `ConsentCard` put `-bright` text
+ * on a `/25` hover wash, including the very pill this issue is about — and it was
+ * wrong in the way a comment is always wrong: silently, and only until someone
+ * reads it. Scanning for the alphas that a wash is actually painted at means the
+ * ladder cannot drift away from the code again.
+ *
+ * Alphas above `TEXT_CEILING` are fills — a progress bar, a pulsing dot, a resize
+ * handle — never a ground under a word, and including them would force every token
+ * two steps darker to satisfy a case that does not exist.
+ */
+const TEXT_CEILING = 0.25;
+const TINT_ALPHAS = (() => {
+  const src = sourceOfSrc();
+  const found = new Set<number>();
+  for (const [, alpha] of src.matchAll(
+    /\bbg-(?:brand|warning|success|danger|hue-[a-z]+)(?:-tint|-solid)?\/(\d{1,3})\b/g,
+  )) {
+    const value = Number(alpha) / 100;
+    if (value <= TEXT_CEILING) found.add(value);
+  }
+  return [...found].sort((a, b) => a - b);
+})();
 const ACCENT_TILE: ReadonlyArray<readonly [string, number]> = [
   ["--studio-brand-tint", 0.05],
   ["--studio-brand-tint", 0.1],
@@ -99,7 +153,7 @@ function worstGround(palettes: Map<string, string>, token: string, ownTint: stri
     }
   };
 
-  for (const groundToken of GROUNDS.light) {
+  for (const groundToken of GROUNDS) {
     const ground = rgb(palettes, groundToken);
     record(contrast(foreground, ground), groundToken);
     for (const alpha of TINT_ALPHAS) {
@@ -188,15 +242,22 @@ for (const { hue, light: base, lightAlt } of HUES) {
 }
 
 describe("accent text clears WCAG AA on every ground it can land on", () => {
+  /**
+   * The ladder is scanned out of `src`, so an empty or truncated scan would make
+   * every test below measure plain grounds only — passing loudly while checking
+   * nothing that matters.
+   */
+  test("the alpha ladder was actually found in the source", () => {
+    expect(TINT_ALPHAS).toContain(0.25);
+    expect(TINT_ALPHAS.length).toBeGreaterThanOrEqual(4);
+  });
+
   for (const { token, tint } of TEXT_TOKENS) {
     test(`${token} in light`, () => {
       const { ratio, where } = worstGround(light, token, tint);
-      expect({ token, worst: `${ratio.toFixed(2)}:1`, where }).toEqual({
-        token,
-        worst: `${ratio.toFixed(2)}:1`,
-        where,
-      });
-      expect(ratio).toBeGreaterThanOrEqual(AA);
+      // The ground is in the assertion, not beside it: a bare numeric comparison
+      // fails with "4.21 is not >= 4.5" and says nothing about WHERE.
+      expect([token, where, ratio >= AA]).toEqual([token, where, true]);
     });
 
     test(`${token} in dark`, () => {
@@ -312,6 +373,62 @@ describe("the light values are the ones that were selected", () => {
   });
 });
 
+/**
+ * The filled controls. These are excluded from the AA text sweep above — they are
+ * GROUNDS, not text — so without this block nothing measures the one thing that
+ * matters about them: whether their label survives.
+ *
+ * The migration got this wrong once. Three standalone error pages hovered DOWN the
+ * ramp (`bg-blue-600 hover:bg-blue-700`) where the rest of the app hovers up, and
+ * flattening them onto `-solid-hover` inverted the direction and took white from
+ * 6.8:1 to 3.8:1. Every gate stayed green.
+ */
+describe("a filled control keeps its label", () => {
+  const WHITE = parseColor("#ffffff").rgb;
+  const label = (token: string) => contrast(rgb(light, token), WHITE);
+
+  test("the two roles that carry a white label clear AA, resting and on hover", () => {
+    for (const token of ["--studio-brand-solid", "--studio-brand-solid-active", "--studio-danger-solid"]) {
+      expect([token, label(token) >= AA]).toEqual([token, true]);
+    }
+  });
+
+  /**
+   * `-solid-active` exists ONLY to be darker than the ground it hovers from. If it
+   * ever stops being darker it is not merely wrong, it is pointless — and the three
+   * pages that use it would silently go back to the regression above.
+   */
+  test("the active step is darker than the ground it hovers from", () => {
+    expect(luminance(rgb(light, "--studio-brand-solid-active"))).toBeLessThan(
+      luminance(rgb(light, "--studio-brand-solid")),
+    );
+  });
+
+  /**
+   * Deferred, deliberately, and pinned so the deferral is a fact rather than a
+   * sentence. `warning`, `success` and the teal "AI Describe" button are filled at
+   * their -600 step under a white label, which is around 3.2-3.7:1 — under AA, in
+   * BOTH themes, and under AA before this migration too. Darkening them enough for
+   * white is a visible change to a control this issue never claimed, so it is filed
+   * separately; when it lands, this test fails and says so.
+   *
+   * Hover steps are excluded on purpose: every `-solid-hover` lightens, so none of
+   * them clears AA against white, and that is the convention the app already had.
+   * The resting state is what a label has to survive.
+   */
+  test("the roles whose white label is still under AA are exactly the two that already were", () => {
+    const resting = [...light.keys()].filter((token) => /-solid$/.test(token));
+    expect(resting.length).toBeGreaterThan(4);
+    // Names, not ratios: a rounded number pinned here would fail on a rendering
+    // change that moves nothing anyone can see.
+    expect(resting.filter((token) => label(token) < AA)).toEqual([
+      "--studio-warning-solid",
+      "--studio-success-solid",
+      "--studio-hue-teal-solid",
+    ]);
+  });
+});
+
 describe("the identity hues stay tellable apart", () => {
   const closestPair = (palettes: Map<string, string>, tokens: string[]) => {
     let closest = Number.POSITIVE_INFINITY;
@@ -346,18 +463,11 @@ describe("the identity hues stay tellable apart", () => {
   test("the light set is no tighter than the dark set it is modelled on", () => {
     const darkest = closestPair(dark, identitySet);
     const lightest = closestPair(light, identitySet);
-    expect({
-      bar: darkest.closest.toFixed(4),
-      barPair: darkest.pair,
-      light: lightest.closest.toFixed(4),
-      lightPair: lightest.pair,
-    }).toEqual({
-      bar: darkest.closest.toFixed(4),
-      barPair: darkest.pair,
-      light: lightest.closest.toFixed(4),
-      lightPair: lightest.pair,
-    });
-    expect(lightest.closest).toBeGreaterThanOrEqual(darkest.closest);
+    expect([lightest.pair, darkest.pair, lightest.closest >= darkest.closest]).toEqual([
+      lightest.pair,
+      darkest.pair,
+      true,
+    ]);
   });
 
   /**

--- a/tests/unit/theme-token-usage.test.ts
+++ b/tests/unit/theme-token-usage.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+/**
+ * The token layer only holds if adding a literal is harder than adding a token.
+ *
+ * #384 tokenised the neutrals and left the accents behind; nothing failed, so the
+ * accents kept dark-tuned values on a light ground for four months (#402). That was
+ * not an oversight anyone could have caught by reading a diff — 955 colour literals
+ * across 68 files look exactly like 954 do.
+ *
+ * Two guards, pointing in opposite directions:
+ *
+ *   - Nothing in `src` paints a colour Tailwind chose. A new `text-blue-400` fails
+ *     here, at the moment it is written, rather than in whichever theme the author
+ *     did not happen to be looking at.
+ *   - Nothing in `theme.css` is declared and unused. A token nobody reaches for is a
+ *     value nobody has checked, and the next person to need that colour will not
+ *     find it — they will write a literal.
+ */
+
+const ROOT = join(import.meta.dir, "..", "..");
+const SRC = join(ROOT, "src");
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return sourceFiles(path);
+    return /\.tsx?$/.test(entry) ? [path] : [];
+  });
+}
+
+const files = sourceFiles(SRC).map((path) => ({
+  path: relative(ROOT, path),
+  text: readFileSync(path, "utf8"),
+}));
+
+const HUES = "blue|sky|indigo|violet|purple|cyan|teal|emerald|green|lime|yellow|amber|orange|red|rose|pink|fuchsia";
+
+/**
+ * `from-`, `via-`, `to-` and `shadow-` are the decorative half — gradients, blur
+ * orbs, glow rings. They are never read as text, they are never the only signal for
+ * anything, and giving each of them a token would mean tokenising a hundred values
+ * to change none of them. They stay literal, deliberately, and this pattern is the
+ * record of that decision rather than an oversight.
+ */
+const LITERAL = new RegExp(
+  `\\b(?:text|bg|border|ring|divide|outline|decoration)-(?:${HUES})-\\d{2,3}(?:/\\d{1,3})?\\b`,
+  "g",
+);
+
+describe("no component paints a colour Tailwind chose", () => {
+  /**
+   * `src/components/ui/**` is vendored shadcn and stays upstream-pure — it is
+   * restyled from `globals.css`, never edited. It happens to contain no accent
+   * literal at all, so the exemption costs nothing today; it is here so that a
+   * `shadcn add` does not turn into a failing build.
+   */
+  const owned = files.filter(({ path }) => !path.startsWith("src/components/ui/"));
+
+  test("the sweep actually reaches the components (guard against an empty walk)", () => {
+    expect(owned.length).toBeGreaterThan(100);
+    expect(owned.some(({ path }) => path === "src/components/agent/AgentRail.tsx")).toBe(true);
+  });
+
+  test("every accent is a token", () => {
+    const offenders = owned.flatMap(({ path, text }) =>
+      text.split("\n").flatMap((line, index) =>
+        // Prose may name a Tailwind step to explain which value a token
+        // reproduces; that is documentation, not a painted colour.
+        /^\s*(?:\/\/|\*|\/\*)/.test(line)
+          ? []
+          : Array.from(line.matchAll(LITERAL), (m) => `${path}:${index + 1}  ${m[0]}`),
+      ),
+    );
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("no token is declared and unreachable", () => {
+  const theme = readFileSync(join(ROOT, "src", "styles", "theme.css"), "utf8");
+  const globals = readFileSync(join(ROOT, "src", "app", "globals.css"), "utf8");
+  const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+  /**
+   * Only the accent families. The surface and text ramps predate this guard and a
+   * couple of their steps are held in reserve as a documented ramp rather than for
+   * a specific call site; widening the guard to them is a separate argument, and
+   * making it here would mean deleting ramp steps to get the suite green.
+   */
+  const accentTokens = Array.from(
+    new Set(
+      Array.from(
+        stripComments(theme).matchAll(/(--studio-(?:brand|warning|success|danger|hue)[a-z0-9-]*)\s*:/g),
+        (m) => m[1],
+      ),
+    ),
+  );
+
+  test("the token sweep found the family (guard against a regex that matches nothing)", () => {
+    expect(accentTokens.length).toBeGreaterThan(40);
+    expect(accentTokens).toContain("--studio-brand");
+  });
+
+  test("every accent token is reachable as a utility", () => {
+    const mapping = stripComments(theme);
+    const unmapped = accentTokens.filter((token) => !mapping.includes(`var(${token})`));
+    expect(unmapped).toEqual([]);
+  });
+
+  test("every accent token is used by something", () => {
+    const haystack = files.map(({ text }) => text).join("\n") + stripComments(globals);
+    const unused = accentTokens.filter((token) => {
+      // `--studio-brand-tint` is reached as `bg-accent-tint`, `text-accent-tint`,
+      // `border-accent-tint/20`, … so the utility suffix is what has to appear.
+      const utility = token.replace("--studio-", "");
+      return !new RegExp(
+        `[-:\\[\\s"'\`](?:text|bg|border|ring|divide|outline|decoration|from|via|to)-${utility}\\b`,
+      ).test(haystack);
+    });
+    expect(unused).toEqual([]);
+  });
+});

--- a/tests/unit/theme-token-usage.test.ts
+++ b/tests/unit/theme-token-usage.test.ts
@@ -40,10 +40,14 @@ const HUES = "blue|sky|indigo|violet|purple|cyan|teal|emerald|green|lime|yellow|
 
 /**
  * `from-`, `via-`, `to-` and `shadow-` are the decorative half — gradients, blur
- * orbs, glow rings. They are never read as text, they are never the only signal for
- * anything, and giving each of them a token would mean tokenising a hundred values
- * to change none of them. They stay literal, deliberately, and this pattern is the
+ * orbs, glow rings — and they stay literal deliberately, so this pattern is the
  * record of that decision rather than an oversight.
+ *
+ * "Never read as text" would be too strong: the login hero paints its headline with
+ * `bg-gradient-to-r … bg-clip-text`, where the gradient IS the letterform. That one
+ * lives inside a subtree that re-declares the dark palette, so it is a dark-on-dark
+ * mark in both themes and the light ramp never reaches it. It is the exception that
+ * makes the rule worth stating rather than a hole in it.
  */
 const LITERAL = new RegExp(
   `\\b(?:text|bg|border|ring|divide|outline|decoration)-(?:${HUES})-\\d{2,3}(?:/\\d{1,3})?\\b`,
@@ -115,8 +119,10 @@ describe("no token is declared and unreachable", () => {
       // `--studio-brand-tint` is reached as `bg-accent-tint`, `text-accent-tint`,
       // `border-accent-tint/20`, … so the utility suffix is what has to appear.
       const utility = token.replace("--studio-", "");
+      // `\b` matches between a letter and a hyphen, so `bg-brand-tint` would have
+      // satisfied `--studio-brand`. The token has to END there.
       return !new RegExp(
-        `[-:\\[\\s"'\`](?:text|bg|border|ring|divide|outline|decoration|from|via|to)-${utility}\\b`,
+        `[-:\\[\\s"'\`](?:text|bg|border|ring|divide|outline|decoration|from|via|to)-${utility}(?![a-zA-Z0-9-])`,
       ).test(haystack);
     });
     expect(unused).toEqual([]);

--- a/tests/unit/theme-token-usage.test.ts
+++ b/tests/unit/theme-token-usage.test.ts
@@ -23,12 +23,16 @@ import { join, relative } from "node:path";
 const ROOT = join(import.meta.dir, "..", "..");
 const SRC = join(ROOT, "src");
 
+/** Sorted: `readdirSync` returns filesystem order, so an unsorted walk makes every
+ * list built on it machine-ordered — green here, red on the next machine. */
 function sourceFiles(dir: string): string[] {
-  return readdirSync(dir).flatMap((entry) => {
-    const path = join(dir, entry);
-    if (statSync(path).isDirectory()) return sourceFiles(path);
-    return /\.tsx?$/.test(entry) ? [path] : [];
-  });
+  return readdirSync(dir)
+    .sort()
+    .flatMap((entry) => {
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) return sourceFiles(path);
+      return /\.tsx?$/.test(entry) ? [path] : [];
+    });
 }
 
 const files = sourceFiles(SRC).map((path) => ({


### PR DESCRIPTION
Closes #402.

## What the issue claimed, and what actually measured

The defect is real and the direction was right. Two figures in the table were not.

| claim | issue | measured |
|---|---|---|
| `text-blue-300` on `bg-blue-500/15` over `#fafafa` | 1.46 : 1 | **1.457 : 1** confirmed |
| the same pairing on `#0a0a0a` | "comfortable" | **9.48 : 1** confirmed |
| `text-blue-400` on its ground | 2.26 / 2.38 | **2.527 : 1** |
| `text-amber-300` on `#fafafa` | ~2.0 | **1.386 : 1** |
| `text-amber-500` on `#fafafa` | 2.05 | **2.055 : 1** confirmed |

The two wrong ones look like a mislabelled row and a pre-v4 palette value; neither changes the conclusion. One premise did not survive: "one deliberate literal remains in `src`" — there are ~32 `*-white` sites, though those are #384's neutral scope, not this one.

Every line reference in the issue had drifted (`AgentRail.tsx:1028` → `:1989`, `BottomPanel.tsx:204` → `:256`, and so on), and the surface is larger than the table: **955 colour literals across 68 files**.

**The load-bearing correction:** the obvious light steps do not work. `blue-600` measures 4.23 and `amber-700` 4.06 on their own `/15` tint — both fail. The tint is ~1.19× harder than the plain ground across the whole ramp, and it flips the verdict for exactly the two steps a reviewer reaches for first.

**And the two acceptance criteria are not in tension.** Dark `blue-300` sits at 9.48 on its own tint. Nothing in dark needs to move.

## What this does

Two families, because colour here answers two different questions.

**State** — `brand` / `warning` / `success` / `danger`, each with `-bright` (emphasis), `-tint` (the wash it sits on), `-solid` / `-solid-hover` (filled grounds). Used where colour tracks a changing condition.

**Identity** — `--studio-hue-<h>` for the hues the app uses, some with `-alt` (a second step) and `-tint`. Used where colour is a fixed label: which engine, which panel, added vs removed, primary key vs foreign key, number vs boolean. Folding these into four state roles would repaint nineteen engines in four colours. Selected per mode the way `lib/charts/palette.ts` selects, rather than flipping a ramp — the two modes run out of room in different places.

**It is `brand`, not `accent`.** shadcn owns `--accent` (its neutral hover ground, `#f5f5f5`) and `globals.css` maps `--color-accent` to it *after* importing the studio layer, so a token of that name loses the cascade in silence: `.text-accent{color:var(--accent)}` — near-white text on a white page. Only the compiled stylesheet shows this; no unit test can see it. Caught in the browser.

## Acceptance

- [x] **Accent text clears 4.5:1 on its own ground in both themes, by measurement.** Light floor 4.79:1, dark floor 4.97:1 across every token, on all five studio grounds and on washes of its own hue at every alpha the code actually paints.
- [x] **Accents resolve through the token layer.** `dist/styles.css` carries all 135 declarations; `build:lib` + `attw` green.
- [x] **Dark does not visibly change.** A pair-by-pair audit of the diff resolves every removed literal and every added token to a hex: **93 differences, all of them the one sanctioned class below, zero others.**

### The one deliberate dark change

A `-500` (or `-200`) **text** literal was drift — the codebase used three steps of one hue for one meaning. Those collapse onto the base token and move one step in dark. 93 sites, all text, no backgrounds or borders. Everything else is byte-for-byte identical, resolved against the installed Tailwind palette rather than transcribed, so a Tailwind upgrade that restyles `blue-400` fails the suite instead of shipping quietly.

## Verified in a real browser

Chrome, production build, live PostgreSQL, both themes, resolving computed colour through a canvas because Tailwind emits `color-mix(in oklab, …)` for every opacity modifier.

The issue's own element — the active agent-mode pill, `bg-blue-500/15` — composites to `#dbe8fb`, exactly the ground the issue predicted:

| | before | after |
|---|---|---|
| light | `#8ec5ff` on `#dbe8fb` — **1.46 : 1** | `#193cb8` on `#dbe8fb` — **7.11 : 1** |
| dark | `#8ec5ff` on `#0e1c2f` — 9.48 : 1 | `#8ec5ff` on `#0e1c2f` — **9.48 : 1**, unchanged |

Sweeping every accent-coloured node on the studio screen: **zero below AA in light**, worst 4.51:1.

## The measurement is now a gate

Every contrast figure this repo has ever recorded is prose — `charts/palette.ts`'s header, `AgentRail.tsx:2583`, the login showcase comment. Prose does not fail when the value it describes moves, which is exactly how a dark-tuned token survived into a light theme for four months.

`tests/helpers/contrast.ts` does the arithmetic the browser does (oklch → Oklab → clipped sRGB, compositing in the gamma space, luminance in the linear one) and reads the Tailwind palette out of `node_modules` rather than transcribing it. `theme-accent-contrast.test.ts` re-measures every token on every ground each run; `theme-token-usage.test.ts` fails on a colour literal in `src` and on a token nothing reaches.

Both were mutation-probed: reverting the light accent to `blue-300`, moving a dark value one step, collapsing `teal-alt` onto `emerald-alt`, colliding amber with orange, lightening a solid below AA, and dropping a token from the `@theme` map each fail; the unmutated tree is clean.

## What an independent review found, and what it changed

A five-lens adversarial review raised 49 findings; 17 survived refutation. Three mattered:

**The Oklab matrix in my own helper was wrong.** The a-row had `-0.2429228246` where Ottosson has `-2.4285922050`, with the sign on the s term flipped. Contrast never touches Oklab, so every ratio stayed correct — but every *separation* figure was measured in a space that is not Oklab, including the ones that chose the identity palette. Corrected, verified against Ottosson's published values, and given a round-trip check. In the right space the natural assignment wins: `hue-amber` returns to amber-800 (the step `warning` already uses) and yellow's alt to -900; orange moves to -900 instead, because Tailwind's amber ramp rotates into orange as it darkens.

**Three error pages hovered the wrong way.** They used `bg-blue-600 hover:bg-blue-700` — hover *darkens* — where the rest of the app lightens. Flattening them onto `-solid-hover` inverted the direction and took white-on-hover from 6.8:1 to 3.8:1. They get `-solid-active`, and a new test measures what a filled control's label survives; the AA sweep had excluded solids as grounds, so nothing did.

**Nine monitoring grounds repainted in dark.** `bg-green-500` → `bg-success-tint` is emerald, not green; `bg-yellow-500` → `bg-warning-tint` is amber. A hue change in dark, outside the stated exception. They now take the identity hues that reproduce them exactly.

Also fixed: two assertions that compared an object to itself and could never fail, a `GROUNDS.dark` that was never read, a tint ceiling asserted rather than derived (four live sites use `/25`, one of them the pill this issue is about — the ladder is now scanned out of `src`), and a word boundary that let `bg-brand-tint` satisfy `--studio-brand`.

## Deliberately not done

- **Filled `warning` / `success` / teal buttons carry a white label at 3.2–3.7:1.** Under AA, in both themes, and under AA before this migration. Darkening them is a visible change to a control #402 never claimed. Pinned by name in the suite so the deferral is a fact rather than a sentence; when it is fixed, that test fails and says so.
- **Gradients, blur orbs and glow shadows stay literal.** Never read as text. The one place a gradient *is* the letterform (the login hero's `bg-clip-text` headline) sits inside a subtree that re-declares the dark palette, so the light ramp never reaches it.
- **Colour that no CSS token can reach**: a Recharts/SVG presentation attribute, Monaco's theme object, and the per-connection colour a user picks (with its hardcoded hex fallback).
- **Hue drift between vocabularies.** The monitoring surfaces say green/yellow where the studio says emerald/amber, and `SchemaDiff` likewise. Preserving dark meant preserving the drift. Worth a follow-up; not worth changing dark pixels here.

## Verification

`format` · `lint` (134 warnings, vs 135 on main) · `typecheck` · `knip` · `chart:check` · `channels:showcase:check` · `readme:check` · `security:check` · `test` (10771 pass, 0 fail) · `build` · `build:lib` + `attw` · **coverage 45983/45983 lines (100.00%)**.

cc @omerfarukbolat — you filed this; the calibration in it is what made it tractable. Two numbers in the table did not reproduce (noted above), and the tint effect turned out to be the thing that decides which step works.
