### PR TITLE
chore(release): 0.14.1

### DIFF
--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting sixteen engines - PostgreSQL, MySQL, SQLite, DuckDB, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra and libSQL
 type: application
-version: 0.1.59
-appVersion: "0.14.0"
+version: 0.1.60
+appVersion: "0.14.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -46,6 +46,12 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
+  # False: 0.1.60 tracks app release 0.14.1, which repairs how the light theme is
+  # painted and how two wire families are asked for a query plan. Accent colours were
+  # picked for a dark ground and reused on the light one, so warning, success and danger
+  # text sat as low as 1.46:1 against the surface behind it; and both EXPLAIN grammars
+  # are now measured when the connection opens rather than assumed from the type id. No
+  # template, value or default moves, and the image is where every one of them lands.
   # False: 0.1.58 tracks app release 0.13.7, which adds one metadata field to
   # package.json and nothing else. The npm artifact declared no licence, so
   # @libredb/studio showed as unlicensed on the registry while the repository shipped
@@ -95,7 +101,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.14.0
+      image: ghcr.io/libredb/libredb-studio:0.14.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -107,13 +113,13 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "The object browser now lists only your own tables on six PostgreSQL-family engines. It was showing each engine internal schema as if it were user data - 61 objects on TimescaleDB where 2 were the user tables (the rest hypertable chunks and catalog), 10 on AlloyDB Omni, 4 on Apache Cloudberry - and on CockroachDB the Monitoring overview counted 98 tables for the 2 the browser listed, so the two panels disagreed inside one app. Extension-created schemas are now excluded by ownership rather than by name, so a schema you created yourself is never hidden"
-    - "A row count the engine has not actually measured now reads as blank instead of 0. PostgreSQL writes -1 into pg_class.reltuples for a table nothing has analysed yet, which was being clamped to zero - so every table in a freshly restored dump claimed to be empty until autovacuum caught up. A genuine empty table still reads 0"
-    - "Materialize and CockroachDB recover instead of failing. Their object browsers were blank and their Monitoring pages showed a connection error; both now read schema and render every panel, with statistics those engines do not publish marked unavailable rather than reported as zero. Materialized views are listed beside tables"
-    - "A table dropped while the schema was being read no longer fails the whole read. Under concurrent DDL this killed roughly a quarter of schema loads on PostgreSQL; the relation is now resolved without raising"
-    - "Monitoring panels tell two absences apart. A statistic an engine simply does not publish now says so, and is no longer presented as a database fault; a query the engine actually refused still shows its own error, so a restriction you can act on stays visible"
-    - "SQL Server and Oracle overviews no longer report a size they could not read as 0 bytes"
-    - "Track app release 0.14.0 (appVersion bump; default image tag follows)"
+    - "The light theme stops painting dark-tuned accent colour. Warning, success and danger text, the query editor Explain control and the monitoring status rings were drawn in colours chosen against a dark ground and reused unchanged on the light one, where the worst of them sat at 1.46:1 against the surface behind it. Every accent is now a token measured on the ground it is drawn on, and the measurement runs as a test rather than being recorded in a comment"
+    - "Both themes now clear a 4.79:1 contrast floor for accent text, measured per token on every surface it can land on"
+    - "Engine identity colours are separated by measurement instead of by eye, so two engines listed next to each other no longer read as the same colour on either theme"
+    - "The Overview and Health panels answer on the MySQL-wire engines that refused a filter they never needed. SHOW STATUS is now read bare and the wanted rows picked out of the answer, so Apache Doris renders instead of failing outright, and a status variable an engine does not publish reads as absent rather than as a fabricated default"
+    - "A query plan is asked for in the grammar the server actually accepts, measured when the connection opens on both wire families. The Explain panel was sending one MySQL form and one PostgreSQL form to every relative of each, so it showed an empty no-plan state on Materialize, CockroachDB, TiDB, StarRocks, SingleStore, Apache Doris and Databend. All seven now render their own plan"
+    - "LOG_LEVEL is documented in .env.example, and an environment variable the app reads can no longer go undocumented without failing a test"
+    - "Track app release 0.14.1 (appVersion bump; default image tag follows)"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.59 \
+  --version 0.1.60 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/deploy/aws/ami/template.pkr.hcl
+++ b/deploy/aws/ami/template.pkr.hcl
@@ -117,9 +117,15 @@ build {
     ]
   }
 
+  # `env {{ .Vars }}`, not a bare `sudo -E bash`: Packer's declared
+  # environment_vars ride in that one expansion, which the default
+  # execute_command carries and a custom one has to carry itself. Without it the
+  # variables are declared and never delivered, and 01-install.sh dies on
+  # `IMAGE_REF: unbound variable` a quarter of an hour into the build. Passing
+  # them as arguments to `env` also keeps them out of sudo's environment policy.
   provisioner "shell" {
     script           = "scripts/01-install.sh"
-    execute_command  = "sudo -E bash '{{ .Path }}'"
+    execute_command  = "sudo -E env {{ .Vars }} bash '{{ .Path }}'"
     environment_vars = ["IMAGE_REF=${var.image_ref}", "DEBIAN_FRONTEND=noninteractive", "NEEDRESTART_MODE=a"]
   }
 
@@ -137,7 +143,7 @@ build {
 
   provisioner "shell" {
     script          = "scripts/02-configure.sh"
-    execute_command = "sudo -E bash '{{ .Path }}'"
+    execute_command = "sudo -E env {{ .Vars }} bash '{{ .Path }}'"
     environment_vars = [
       "IMAGE_REF=${var.image_ref}",
       "VERSION=${var.version}",

--- a/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -21,8 +21,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Database, Developer Tools
-    containerImage: ghcr.io/libredb/libredb-studio-operator:0.14.0
-    createdAt: "2026-09-06T10:51:59Z"
+    containerImage: ghcr.io/libredb/libredb-studio-operator:0.14.1
+    createdAt: "2026-09-06T22:05:10Z"
     description: Open-source web-based SQL IDE for sixteen engines - PostgreSQL, MySQL,
       Oracle, SQL Server, SQLite, DuckDB, MongoDB, Redis, Couchbase, ClickHouse, Apache
       Druid, Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra and libSQL
@@ -35,7 +35,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: libredb-studio-operator.v0.14.0
+  name: libredb-studio-operator.v0.14.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -259,7 +259,7 @@ spec:
                 - --leader-elect
                 - --leader-election-id=libredb-studio-operator
                 - --health-probe-bind-address=:8081
-                image: ghcr.io/libredb/libredb-studio-operator:0.14.0
+                image: ghcr.io/libredb/libredb-studio-operator:0.14.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -374,4 +374,4 @@ spec:
   provider:
     name: LibreDB
     url: https://libredb.org
-  version: 0.14.0
+  version: 0.14.1

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/libredb/libredb-studio-operator
-  newTag: 0.14.0
+  newTag: 0.14.1

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting sixteen engines - PostgreSQL, MySQL, SQLite, DuckDB, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra and libSQL
 type: application
-version: 0.1.59
-appVersion: "0.14.0"
+version: 0.1.60
+appVersion: "0.14.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
 icon: https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg
@@ -46,6 +46,12 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/prerelease: "false"
+  # False: 0.1.60 tracks app release 0.14.1, which repairs how the light theme is
+  # painted and how two wire families are asked for a query plan. Accent colours were
+  # picked for a dark ground and reused on the light one, so warning, success and danger
+  # text sat as low as 1.46:1 against the surface behind it; and both EXPLAIN grammars
+  # are now measured when the connection opens rather than assumed from the type id. No
+  # template, value or default moves, and the image is where every one of them lands.
   # False: 0.1.58 tracks app release 0.13.7, which adds one metadata field to
   # package.json and nothing else. The npm artifact declared no licence, so
   # @libredb/studio showed as unlicensed on the registry while the repository shipped
@@ -95,7 +101,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: libredb-studio
-      image: ghcr.io/libredb/libredb-studio:0.14.0
+      image: ghcr.io/libredb/libredb-studio:0.14.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -107,13 +113,13 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "The object browser now lists only your own tables on six PostgreSQL-family engines. It was showing each engine internal schema as if it were user data - 61 objects on TimescaleDB where 2 were the user tables (the rest hypertable chunks and catalog), 10 on AlloyDB Omni, 4 on Apache Cloudberry - and on CockroachDB the Monitoring overview counted 98 tables for the 2 the browser listed, so the two panels disagreed inside one app. Extension-created schemas are now excluded by ownership rather than by name, so a schema you created yourself is never hidden"
-    - "A row count the engine has not actually measured now reads as blank instead of 0. PostgreSQL writes -1 into pg_class.reltuples for a table nothing has analysed yet, which was being clamped to zero - so every table in a freshly restored dump claimed to be empty until autovacuum caught up. A genuine empty table still reads 0"
-    - "Materialize and CockroachDB recover instead of failing. Their object browsers were blank and their Monitoring pages showed a connection error; both now read schema and render every panel, with statistics those engines do not publish marked unavailable rather than reported as zero. Materialized views are listed beside tables"
-    - "A table dropped while the schema was being read no longer fails the whole read. Under concurrent DDL this killed roughly a quarter of schema loads on PostgreSQL; the relation is now resolved without raising"
-    - "Monitoring panels tell two absences apart. A statistic an engine simply does not publish now says so, and is no longer presented as a database fault; a query the engine actually refused still shows its own error, so a restriction you can act on stays visible"
-    - "SQL Server and Oracle overviews no longer report a size they could not read as 0 bytes"
-    - "Track app release 0.14.0 (appVersion bump; default image tag follows)"
+    - "The light theme stops painting dark-tuned accent colour. Warning, success and danger text, the query editor Explain control and the monitoring status rings were drawn in colours chosen against a dark ground and reused unchanged on the light one, where the worst of them sat at 1.46:1 against the surface behind it. Every accent is now a token measured on the ground it is drawn on, and the measurement runs as a test rather than being recorded in a comment"
+    - "Both themes now clear a 4.79:1 contrast floor for accent text, measured per token on every surface it can land on"
+    - "Engine identity colours are separated by measurement instead of by eye, so two engines listed next to each other no longer read as the same colour on either theme"
+    - "The Overview and Health panels answer on the MySQL-wire engines that refused a filter they never needed. SHOW STATUS is now read bare and the wanted rows picked out of the answer, so Apache Doris renders instead of failing outright, and a status variable an engine does not publish reads as absent rather than as a fabricated default"
+    - "A query plan is asked for in the grammar the server actually accepts, measured when the connection opens on both wire families. The Explain panel was sending one MySQL form and one PostgreSQL form to every relative of each, so it showed an empty no-plan state on Materialize, CockroachDB, TiDB, StarRocks, SingleStore, Apache Doris and Databend. All seven now render their own plan"
+    - "LOG_LEVEL is documented in .env.example, and an environment variable the app reads can no longer go undocumented without failing a test"
+    - "Track app release 0.14.1 (appVersion bump; default image tag follows)"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.59 \
+  --version 0.1.60 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libredb/studio",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "private": false,
   "publishConfig": {

--- a/tests/unit/aws-ami-descriptor.test.ts
+++ b/tests/unit/aws-ami-descriptor.test.ts
@@ -69,6 +69,20 @@ describe("AWS AMI Packer template", () => {
       const readsVar = /(IMAGE_REF|VERSION|SUPPORT_EMAIL)/.test(script ? read(`scripts/${script}.sh`) : body);
       if (usesVar || readsVar)
         expect({ script, hasEnv: /environment_vars/.test(body) }).toEqual({ script, hasEnv: true });
+
+      // Declaring environment_vars is not delivering them. Packer's default
+      // execute_command is `chmod +x {{.Path}}; {{.Vars}} {{.Path}}`, and the
+      // vars ride in that `{{ .Vars }}` expansion alone - so a custom
+      // execute_command that omits it silently drops every declared variable,
+      // and the block above stays green while the build dies fifteen minutes
+      // in on `IMAGE_REF: unbound variable`. Assert the delivery, not the
+      // declaration.
+      const execute = /execute_command\s*=\s*"([^"]*)"/.exec(body)?.[1];
+      if (execute !== undefined && /environment_vars/.test(body))
+        expect({ script, deliversVars: /\{\{\s*\.Vars\s*\}\}/.test(execute) }).toEqual({
+          script,
+          deliversVars: true,
+        });
     }
   });
 


### PR DESCRIPTION
Cuts 0.14.1 and fixes the AMI build that has been red on main since the workflow landed.

## 0.14.1

The release the light theme has been waiting for. #402 landed on main after 0.14.0 was tagged: warning, success and danger text, the query editor Explain control and the monitoring status rings were all painted in colours chosen against a dark ground and reused unchanged on the light one, where the worst of them measured 1.46:1 against the surface behind it. Every accent is now a token measured on the ground it is drawn on, and the measurement runs as a test instead of being recorded in a comment. Also in the release: LOG_LEVEL documented, three docs sweeps, a Spanish README, and the AWS Marketplace AMI package.

Chart 0.1.60, appVersion 0.14.1. No template or value moves, so `artifacthub.io/changes` records four entries and `containsSecurityUpdates` stays false.

## The AMI fix

`AWS AMI Build` has failed every run with `IMAGE_REF: unbound variable`, fifteen minutes into the Packer build. The provisioners declare `environment_vars`, but a custom `execute_command` only delivers them where it expands `{{ .Vars }}` itself, and `sudo -E bash '{{ .Path }}'` does not. So IMAGE_REF, VERSION and SUPPORT_EMAIL were never set.

The guard that was supposed to catch this asserted the declaration rather than the delivery, which is why it stayed green through every failed build. It now asserts the expansion, and it was probed against both provisioner blocks before the fix.

## Gates

format, lint, typecheck, knip, chart:check, readme:check, security:check, channels:showcase:check, helm lint --strict, build, build:lib, attw, gofmt/go vet/go test, full test suite, coverage 45983/45983 (100.00%).