### PR TITLE
docs(sqlite): replace 7 stale line-number citations with named citations

### DIFF
--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -106,8 +106,8 @@ out in parallel.
 ### 2.4 Registration & lifecycle
 
 The factory wires LibreDB in via a dynamic import so the `@libredb/libredb` driver is only loaded
-when a LibreDB connection is actually opened
-([`factory.ts:100`](../../src/lib/db/factory.ts)):
+when a LibreDB connection is actually opened by
+`createDatabaseProvider()` ([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case 'libredb': {

--- a/docs/providers/sqlite.md
+++ b/docs/providers/sqlite.md
@@ -147,7 +147,7 @@ on the normal path, and carrying the read-only flag only when
 
 ### 3.1 File path resolution & the admin-trusted path model
 
-`getDatabasePath()` ([sqlite.ts:133](../../src/lib/db/providers/sql/sqlite.ts)) resolves the target:
+`getDatabasePath()` ([`sqlite.ts`](../../src/lib/db/providers/sql/sqlite.ts)) resolves the target:
 `connectionString` (stripping a `file:` prefix) → else `database` → else `:memory:`. Non-`:memory:`
 paths are `path.resolve()`-d to an absolute path and **rejected if they contain a NUL byte**. Parent
 directories are created on connect.
@@ -162,16 +162,16 @@ directories are created on connect.
 
 ### 3.2 PRAGMAs on connect
 
-`connect()` opens the file with `{ create: true, readwrite: true }` and sets
+`connect()` ([`sqlite.ts`](../../src/lib/db/providers/sql/sqlite.ts)) opens the file with `{ create: true, readwrite: true }` and sets
 `PRAGMA foreign_keys = ON`, `journal_mode = WAL`, `synchronous = NORMAL`
-([sqlite.ts:104](../../src/lib/db/providers/sql/sqlite.ts)) — FK enforcement on, WAL for better
+— FK enforcement on, WAL for better
 concurrency, NORMAL sync for a speed/durability balance. The agent read-only profile runs a
 different open sequence entirely — `journal_mode = WAL` is itself a write and fails on a read-only
 handle ([§12.1](#121-where-the-boundary-is)).
 
 ### 3.3 Read vs write dispatch
 
-`query()` ([sqlite.ts:159](../../src/lib/db/providers/sql/sqlite.ts)) branches on
+`query()` ([`sqlite.ts`](../../src/lib/db/providers/sql/sqlite.ts)) branches on
 `isReadOnlyQuery(sql)` (inherited): reads use `stmt.all()` and return rows; writes use `stmt.run()`
 and return `{ changes }`. `rowCount = rows.length || changes`. Both drivers are **synchronous** —
 the provider wraps them in the async signature but there is no real concurrency or cancellation.
@@ -210,7 +210,7 @@ const c = { id: 'lite-3', name: 'App', type: 'sqlite',
   connectionString: 'file:/data/app.db', createdAt: new Date() };
 ```
 
-`validate()` ([sqlite.ts:67](../../src/lib/db/providers/sql/sqlite.ts)) requires either `database`
+`validate()` ([`sqlite.ts`](../../src/lib/db/providers/sql/sqlite.ts)) requires either `database`
 or `connectionString` (else "Database file path is required … or `:memory:`"). Note
 `getCapabilities().supportsConnectionString` is `false`, yet `connectionString` *is* honoured as a
 path by `getDatabasePath()` — the flag reflects that there is no network DSN, not that the field is
@@ -309,7 +309,7 @@ pinned by tests rather than left to be discovered.
 
 ## 6. Schema introspection
 
-`getSchema()` ([sqlite.ts:203](../../src/lib/db/providers/sql/sqlite.ts)) reads `sqlite_master`
+`getSchema()` ([`sqlite.ts`](../../src/lib/db/providers/sql/sqlite.ts)) reads `sqlite_master`
 (excluding `sqlite_*` internal objects) and, per table, runs the SQLite PRAGMAs:
 
 | Data | Source |
@@ -441,7 +441,7 @@ placeholder `indexSize` already used, and every consumer gates on the absent `ta
 
 ## 8. Maintenance
 
-`runMaintenance(type, target?)` ([sqlite.ts:432](../../src/lib/db/providers/sql/sqlite.ts)); `analyze`
+`runMaintenance(type, target?)` ([`sqlite.ts`](../../src/lib/db/providers/sql/sqlite.ts)); `analyze`
 and `reindex` targets are quoted via `escapeIdentifier()`:
 
 | Type | Action |
@@ -489,7 +489,7 @@ answers with nothing both while it is in flight and when it failed.
 
 ## 9. Capabilities & labels
 
-### `getCapabilities()` ([sqlite.ts:133](../../src/lib/db/providers/sql/sqlite.ts))
+### `getCapabilities()` ([`sqlite.ts`](../../src/lib/db/providers/sql/sqlite.ts))
 
 | Capability | Value |
 |------------|-------|

--- a/tests/unit/provider-docs-monitoring-citations.test.ts
+++ b/tests/unit/provider-docs-monitoring-citations.test.ts
@@ -110,6 +110,19 @@ const NAMED_CITATIONS = [
     ],
   },
   {
+    doc: "docs/providers/sqlite.md",
+    source: "src/lib/db/providers/sql/sqlite.ts",
+    methods: [
+      "getDatabasePath",
+      "connect",
+      "query",
+      "validate",
+      "getSchema",
+      "runMaintenance",
+      "getCapabilities",
+    ],
+  },
+  {
     doc: "docs/providers/mongodb.md",
     source: "src/lib/db/providers/document/mongodb.ts",
     methods: [
@@ -226,6 +239,13 @@ describe("provider docs rewritten this round: code cited by name, whole file", (
       "`createDatabaseProvider()` ([`factory.ts`](../../src/lib/db/factory.ts))",
     );
     expect(read(FACTORY)).toMatch(/^export async function createDatabaseProvider\(/m);
+  });
+
+  test("libredb.md names the factory's entry point rather than a line inside it", () => {
+    expect(read("docs/providers/libredb.md")).toContain(
+      "`createDatabaseProvider()` ([`factory.ts`](../../src/lib/db/factory.ts))",
+    );
+    expect(read("docs/providers/libredb.md")).not.toMatch(/factory\.ts:\d/);
   });
 });
 


### PR DESCRIPTION
Rewrites sqlite.md .ts:N citations to named declaration links (mssql/mongodb style) and pins the doc in NAMED_CITATIONS. Also fixes the welcome factory.ts line citation in libredb.md. Closes #587.