### PR TITLE
fix(packaging): use systemctl try-restart in the deb/rpm postinstall

### DIFF
--- a/packaging/linux/scripts/postinstall.sh
+++ b/packaging/linux/scripts/postinstall.sh
@@ -3,18 +3,30 @@
 # postinstall for the libredb-studio .deb/.rpm packages (nfpm scripts:).
 #
 # Runs on install and upgrade. deb postinst receives "configure" for both;
-# rpm %post receives 1 (install) or 2 (upgrade) - restarting only when the
-# service is already active covers upgrades in both worlds without touching
-# fresh installs (the package never enables or starts the service itself;
-# operators do that with "systemctl enable --now libredb-studio").
+# rpm %post receives 1 (install) or 2 (upgrade). The same two commands are
+# correct in all of those cases: reload the unit files, then "try-restart",
+# which systemd documents as "stop and then start ... if the units are
+# running. This does nothing if units are not running". So an upgrade picks
+# up the new payload and a fresh install is left alone - the package never
+# enables or starts the service itself (operators do that with
+# "systemctl enable --now libredb-studio"). try-restart replaces an
+# "is-active" probe followed by "restart": one command instead of two, and
+# no window between the probe and the restart.
+#
+# SYSTEMD_RUNTIME_DIR is the systemd-presence probe. LIBREDB_SYSTEMD_RUNTIME_DIR
+# overrides it for tests only, so they can exercise both the systemd and the
+# non-systemd branch without depending on how the host running them is booted
+# (same reason the launcher honours LIBREDB_STUDIO_HOME - see
+# packaging/linux/libredb-studio). Real installs never set it and keep the
+# /run/systemd/system default.
 # ==============================================================================
 set -e
 
-if [ -d /run/systemd/system ]; then
+SYSTEMD_RUNTIME_DIR="${LIBREDB_SYSTEMD_RUNTIME_DIR:-/run/systemd/system}"
+
+if [ -d "$SYSTEMD_RUNTIME_DIR" ]; then
   systemctl daemon-reload >/dev/null 2>&1 || true
-  if systemctl is-active --quiet libredb-studio.service 2>/dev/null; then
-    systemctl restart libredb-studio.service >/dev/null 2>&1 || true
-  fi
+  systemctl try-restart libredb-studio.service >/dev/null 2>&1 || true
 fi
 
 exit 0

--- a/tests/unit/packaging-postinstall-restart.test.ts
+++ b/tests/unit/packaging-postinstall-restart.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the deb/rpm postinstall service-restart contract
+ * (packaging/linux/scripts/postinstall.sh, wired by packaging/linux/nfpm.yaml).
+ *
+ * The script is exercised as a real subprocess against a stub "systemctl"
+ * placed first on PATH; the stub appends its own argv to a log file, so the
+ * assertions are about the observable sequence of systemctl invocations
+ * rather than about the script's text. LIBREDB_SYSTEMD_RUNTIME_DIR points the
+ * systemd probe at a temp directory, so the outcome never depends on whether
+ * the host running the tests is booted with systemd.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = join(import.meta.dir, "../../packaging/linux/scripts/postinstall.sh");
+
+function stubSystemctl(exitCode: number, logPath: string): string {
+  return `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(logPath)}\nexit ${exitCode}\n`;
+}
+
+describe("packaging/linux/scripts/postinstall.sh service restart", () => {
+  const fixtureRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function runPostinstall({
+    systemd,
+    systemctlExitCode = 0,
+    arg = "configure",
+  }: {
+    systemd: boolean;
+    systemctlExitCode?: number;
+    arg?: string;
+  }) {
+    const root = mkdtempSync(join(tmpdir(), "libredb-postinstall-"));
+    fixtureRoots.push(root);
+
+    const binDir = join(root, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const logPath = join(root, "systemctl.log");
+    const stubPath = join(binDir, "systemctl");
+    writeFileSync(stubPath, stubSystemctl(systemctlExitCode, logPath));
+    chmodSync(stubPath, 0o755);
+
+    const runtimeDir = join(root, "run-systemd-system");
+    if (systemd) mkdirSync(runtimeDir, { recursive: true });
+
+    const result = Bun.spawnSync(["sh", SCRIPT, arg], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        LIBREDB_SYSTEMD_RUNTIME_DIR: runtimeDir,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const calls = existsSync(logPath)
+      ? readFileSync(logPath, "utf8")
+          .split("\n")
+          .filter((line) => line.length > 0)
+      : [];
+    return { exitCode: result.exitCode, calls };
+  }
+
+  test("reloads units and then try-restarts the service, in that order", () => {
+    const { exitCode, calls } = runPostinstall({ systemd: true });
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual(["daemon-reload", "try-restart libredb-studio.service"]);
+  });
+
+  test("never probes is-active and never issues a bare restart", () => {
+    const { calls } = runPostinstall({ systemd: true });
+    // Positive control first: the log is non-empty and carries the new
+    // command, so the two negatives below cannot pass vacuously.
+    expect(calls).toContain("try-restart libredb-studio.service");
+    expect(calls.some((call) => call.includes("is-active"))).toBe(false);
+    expect(calls.some((call) => /^restart\b/.test(call))).toBe(false);
+  });
+
+  test("invokes systemctl at all only when systemd is the init system", () => {
+    // Control: with the probed directory present, systemctl is invoked.
+    const withSystemd = runPostinstall({ systemd: true });
+    expect(withSystemd.calls.length).toBeGreaterThan(0);
+
+    const withoutSystemd = runPostinstall({ systemd: false });
+    expect(withoutSystemd.calls).toEqual([]);
+    expect(withoutSystemd.exitCode).toBe(0);
+  });
+
+  test("exits 0 even when systemctl fails", () => {
+    const { exitCode, calls } = runPostinstall({ systemd: true, systemctlExitCode: 1 });
+    expect(exitCode).toBe(0);
+    // Control: both commands were still attempted despite the failures.
+    expect(calls).toEqual(["daemon-reload", "try-restart libredb-studio.service"]);
+  });
+
+  test("behaves the same for the rpm %post upgrade argument", () => {
+    const { exitCode, calls } = runPostinstall({ systemd: true, arg: "2" });
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual(["daemon-reload", "try-restart libredb-studio.service"]);
+  });
+});


### PR DESCRIPTION
Reported by mikhailnov on opennet.ru, in the 0.13.7 announcement thread:
https://www.opennet.ru/opennews/art.shtml?num=66216

## The change

`packaging/linux/scripts/postinstall.sh` restarted the service on upgrade with
an `is-active` probe followed by `restart`:

    if systemctl is-active --quiet libredb-studio.service 2>/dev/null; then
      systemctl restart libredb-studio.service >/dev/null 2>&1 || true
    fi

That is exactly what `systemctl try-restart` does. `man systemctl`: "Stop and
then start one or more units specified on the command line if the units are
running. This does nothing if units are not running." So the two forms are
equivalent on the property the package depends on - a fresh install is left
untouched, because the package never enables or starts the unit itself, and an
upgrade of a running service picks up the new payload. The single command is
also atomic where the pair was not: nothing can start the service in the window
between the probe and the restart.

The script now runs, inside the same systemd check:

    systemctl daemon-reload >/dev/null 2>&1 || true
    systemctl try-restart libredb-studio.service >/dev/null 2>&1 || true

Both still `|| true`, so a systemctl failure never fails `deb postinst` or
`rpm %post`. The header comment was rewritten to explain try-restart instead of
the old is-active reasoning.

## Testability

The systemd probe was hard-coded to `/run/systemd/system`, which a test cannot
control - assertions would silently depend on how the host running them is
booted, and would pass vacuously in a container. It is now:

    SYSTEMD_RUNTIME_DIR="${LIBREDB_SYSTEMD_RUNTIME_DIR:-/run/systemd/system}"

Same reason `packaging/linux/libredb-studio` honours `LIBREDB_STUDIO_HOME`. The
default is unchanged, so real installs behave byte for byte as before.

`preremove.sh` and `postremove.sh` are untouched and keep the hard-coded probe;
they have no test.

## What the new test asserts

`tests/unit/packaging-postinstall-restart.test.ts` follows
`tests/unit/packaging-bind-address.test.ts`: it runs the real script with
`Bun.spawnSync` against a stub `systemctl` first on PATH that appends its argv
to a log file. Every negative is paired with a positive control:

- with systemd present, the log is exactly `daemon-reload` then
  `try-restart libredb-studio.service`, in that order;
- the log contains no `is-active` and no bare `restart` - control: the same log
  does contain the try-restart line, so an empty log cannot pass it;
- without systemd, no systemctl call happens at all and the script exits 0 -
  control: the systemd-present case in the same test asserts the log is
  non-empty;
- when the stub systemctl exits 1, the script still exits 0 and both commands
  were still attempted (this is what `|| true` buys, for deb postinst and rpm
  %post alike);
- the rpm `%post` upgrade argument `2` produces the same sequence as deb
  `configure`.

Verified red before the implementation: all 5 tests failed, the first on
`is-active --quiet libredb-studio.service` where `try-restart` was expected.

## Gates

`bun run format`, `lint`, `typecheck`, `knip`, `chart:check`,
`channels:showcase:check`, `readme:check`, `security:check`, `test` and `build`
all pass locally.
