### PR TITLE
chore(distribution): mark the CasaOS channel live

### DIFF
--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -563,7 +563,7 @@ channels:
 
   - id: casaos
     name: CasaOS App Store
-    status: pending
+    status: live
     category: paas-catalogs
     platforms: [container]
     runtime: channel_supplied
@@ -578,12 +578,12 @@ channels:
       upstream_repo: https://github.com/IceWhaleTech/CasaOS-AppStore
       docs: docs/DISTRIBUTION.md
     pin:
-      strategy: none
-      note: PR IceWhaleTech/CasaOS-AppStore#992 is open, so nothing is listed yet. On merge, flip to live
-        and add a remote_file pin on
-        https://raw.githubusercontent.com/IceWhaleTech/CasaOS-AppStore/main/Apps/LibreDBStudio/docker-compose.yml
-        with extract 'libredb-studio:(\d+\.\d+\.\d+)'. Installs a Docker container on the user's own device,
-        so the platform is container.
+      strategy: remote_file
+      url: https://raw.githubusercontent.com/IceWhaleTech/CasaOS-AppStore/main/Apps/LibreDBStudio/docker-compose.yml
+      extract: 'libredb-studio:(\d+\.\d+\.\d+)'
+      note: Merged in IceWhaleTech/CasaOS-AppStore#992 (7 Sep 2026); live in the CasaOS App Store. The pin
+        reads the image tag in Apps/LibreDBStudio/docker-compose.yml, the file a bump PR touches. Installs a
+        Docker container on the user's own device, so the platform is container.
 
   - id: umbrel
     name: Umbrel App Store

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -34,9 +34,9 @@ channel count.
 
 ## Coverage snapshot
 
-**36 channels · 27 live · 8 pending · 1 deprecated**
+**36 channels · 28 live · 7 pending · 1 deprecated**
 
-Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 4 · Kubernetes 3 · Cloud 11**
+Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 5 · Kubernetes 3 · Cloud 11**
 
 | Category | Live | Pending | Deprecated |
 | --- | ---: | ---: | ---: |
@@ -45,7 +45,7 @@ Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 4 · K
 | Kubernetes & operators | 2 | 1 | 0 |
 | Package managers | 5 | 0 | 1 |
 | OS / desktop packages | 3 | 0 | 0 |
-| PaaS catalogs (listed) | 8 | 4 | 0 |
+| PaaS catalogs (listed) | 9 | 3 | 0 |
 | Deploy recipes | 3 | 0 | 0 |
 | Cloud marketplaces | 2 | 3 | 0 |
 
@@ -74,6 +74,7 @@ Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 4 · K
 | [AppImageHub](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Manual, on demand | [desktop/README.md](../desktop/README.md) |
 | [Linux .deb / .rpm](https://github.com/libredb/libredb-studio/releases/latest) | OS / desktop packages | Linux | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [CapRover official](https://github.com/caprover/one-click-apps) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/caprover/README.md](../deploy/caprover/README.md) |
+| [CasaOS App Store](https://github.com/IceWhaleTech/CasaOS-AppStore) | PaaS catalogs (listed) | Container | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Cosmos servapp marketplace](https://github.com/azukaar/cosmos-servapps-official) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/cosmos/README.md](../deploy/cosmos/README.md) |
 | [Dokploy template catalog](https://templates.dokploy.com) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/dokploy/README.md](../deploy/dokploy/README.md) |
 | [Kubero template catalog](https://www.kubero.dev/templates) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [deploy/kubero/README.md](../deploy/kubero/README.md) |
@@ -81,7 +82,6 @@ Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 4 · K
 | [Sealos App Store template](https://sealos.io/products/app-store/libredb-studio) | PaaS catalogs (listed) | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [TrueNAS SCALE apps](https://apps.truenas.com/catalog/libredb-studio_community/) | PaaS catalogs (listed) | Container | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Unraid Community Apps](https://ca.unraid.net/apps/libredb-studio-0a5x41a1cy1kay) | PaaS catalogs (listed) | Container | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| [CasaOS App Store](https://github.com/IceWhaleTech/CasaOS-AppStore) | PaaS catalogs (listed) | Container | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Easypanel template catalog](https://easypanel.io/templates) | PaaS catalogs (listed) | Cloud | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Portainer app templates](https://github.com/portainer/templates) | PaaS catalogs (listed) | Container | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Umbrel App Store](https://github.com/getumbrel/umbrel-apps) | PaaS catalogs (listed) | Container | pending | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |

--- a/src/lib/distribution/channels.generated.ts
+++ b/src/lib/distribution/channels.generated.ts
@@ -37,6 +37,7 @@ export const LIVE_CHANNELS: readonly ShowcaseChannel[] = [
   { id: "kubero", label: "Kubero template catalog", group: "paas" },
   { id: "sealos", label: "Sealos App Store template", group: "paas" },
   { id: "truenas-scale", label: "TrueNAS SCALE apps", group: "paas" },
+  { id: "casaos", label: "CasaOS App Store", group: "paas" },
   { id: "rancher-partner", label: "Rancher Partner Charts", group: "kubernetes" },
   { id: "digitalocean", label: "DigitalOcean Marketplace", group: "paas" },
   { id: "gcp-marketplace", label: "Google Cloud Marketplace", group: "paas" },


### PR DESCRIPTION
IceWhaleTech/CasaOS-AppStore#992 merged on 7 September 2026, so LibreDB Studio is now listed in the CasaOS App Store.

This flips the `casaos` channel from `pending` to `live` and replaces the placeholder pin with the `remote_file` pin the previous note already specified: it reads the image tag from `Apps/LibreDBStudio/docker-compose.yml` in the upstream repository, which is the file a bump PR touches.

Verified before opening: the YAML parses, and the pin URL with `libredb-studio:(\d+\.\d+\.\d+)` currently extracts 0.13.7, the version live upstream. It will read 0.14.1 once the pending bump PR IceWhaleTech/CasaOS-AppStore#1050 merges.
