### PR TITLE
docs(providers): cite factory.ts by its entry point, not a line

### DIFF
--- a/docs/providers/clickhouse.md
+++ b/docs/providers/clickhouse.md
@@ -126,8 +126,8 @@ is overridden, for the trailing-clause trap in [§3.8](#38-the-preparequery-over
 
 ### 2.4 Registration & lifecycle
 
-The factory wires ClickHouse in via a dynamic import
-([`factory.ts:87`](../../src/lib/db/factory.ts)):
+The factory wires ClickHouse in via a dynamic import inside `createDatabaseProvider()`
+([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case 'clickhouse': {

--- a/docs/providers/couchbase.md
+++ b/docs/providers/couchbase.md
@@ -119,8 +119,8 @@ a SQL dialect is expressed through `queryLanguage: "sql"`, not through the class
 
 ### 2.4 Registration & lifecycle
 
-The factory wires Couchbase in via a dynamic import
-([`factory.ts:93`](../../src/lib/db/factory.ts)):
+The factory wires Couchbase in via a dynamic import inside `createDatabaseProvider()`
+([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case 'couchbase': {

--- a/docs/providers/druid.md
+++ b/docs/providers/druid.md
@@ -131,7 +131,8 @@ the case [`docs/ADDING_A_PROVIDER.md`](../ADDING_A_PROVIDER.md) names ClickHouse
 
 ### 2.4 Registration & lifecycle
 
-The factory wires Druid in via a dynamic import ([`factory.ts:95`](../../src/lib/db/factory.ts)):
+The factory wires Druid in via a dynamic import inside `createDatabaseProvider()`
+([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case "druid": {

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -129,8 +129,8 @@ both exports honestly thin (each one names its product and nothing else).
 
 ### 2.4 Registration & lifecycle
 
-The factory wires the type-id in via a dynamic import
-([factory.ts:118](../../src/lib/db/factory.ts)):
+The factory wires the type-id in via a dynamic import inside `createDatabaseProvider()`
+([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case "elasticsearch": {

--- a/docs/providers/libredb.md
+++ b/docs/providers/libredb.md
@@ -106,8 +106,8 @@ out in parallel.
 ### 2.4 Registration & lifecycle
 
 The factory wires LibreDB in via a dynamic import so the `@libredb/libredb` driver is only loaded
-when a LibreDB connection is actually opened
-([`factory.ts:100`](../../src/lib/db/factory.ts)):
+when a LibreDB connection is actually opened by `createDatabaseProvider()`
+([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case 'libredb': {

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -134,8 +134,8 @@ OpenSearchProvider (search/index.ts:967)         ElasticsearchProvider (search/i
 
 ### 2.4 Registration & lifecycle
 
-The factory wires the type-id in via a dynamic import
-([factory.ts:123](../../src/lib/db/factory.ts)):
+The factory wires the type-id in via a dynamic import inside `createDatabaseProvider()`
+([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case "opensearch": {

--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -88,7 +88,8 @@ rather than reimplementing them:
 ### 2.3 Registration & lifecycle
 
 The factory loads the provider via dynamic import so the `pg` driver is only pulled in when a
-PostgreSQL connection is opened ([`factory.ts:62`](../../src/lib/db/factory.ts)):
+PostgreSQL connection is opened by `createDatabaseProvider()`
+([`factory.ts`](../../src/lib/db/factory.ts)):
 
 ```ts
 case 'postgres': {

--- a/tests/unit/provider-docs-monitoring-citations.test.ts
+++ b/tests/unit/provider-docs-monitoring-citations.test.ts
@@ -25,13 +25,14 @@
  * same eight, and the docs in scope carry no `:<line>` suffix.
  *
  * SCOPE, deliberately narrow: the whole of every document in `NAMED_CITATIONS`, plus the
- * monitoring seam of the two search docs. The rest of `docs/providers/` still cites code by line
- * in quantity — a pre-existing backlog this round did not open — and the two search docs are
- * guarded only inside their monitoring section. Nothing here asserts that the uncovered
+ * monitoring seam of the two search docs, plus one file across every provider doc: `factory.ts`
+ * is cited by its entry point and never by a line. The rest of `docs/providers/` still cites code
+ * by line in quantity — a pre-existing backlog this round did not open — and the two search docs
+ * are guarded only inside their monitoring section. Nothing here asserts that the uncovered
  * citations are correct; they are simply not measured yet.
  */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 const ROOT = path.resolve(import.meta.dir, "../..");
@@ -42,6 +43,12 @@ const SEARCH_PROVIDER = "src/lib/db/providers/sql/search/index.ts";
 const BASE_PROVIDER = "src/lib/db/base-provider.ts";
 const MIGRATION_GENERATOR = "src/lib/schema-diff/migration-generator.ts";
 const FACTORY = "src/lib/db/factory.ts";
+
+/** Sorted: `readdirSync` returns filesystem order — green here, red on the next machine. */
+const PROVIDER_DOCS = readdirSync(path.join(ROOT, "docs/providers"))
+  .filter((entry) => entry.endsWith(".md"))
+  .sort()
+  .map((entry) => `docs/providers/${entry}`);
 
 /**
  * The docs this round rewrote, the source their prose links to, and the method names that now
@@ -238,12 +245,19 @@ describe("provider docs rewritten this round: code cited by name, whole file", (
   }
 
   test("provider docs name the factory's entry point rather than a line inside it", () => {
-    for (const { doc } of NAMED_CITATIONS.filter((citation) =>
-      read(citation.doc).includes("`createDatabaseProvider()`"),
-    )) {
+    // Selected on the entry point's NAME, not on the link: fourteen docs link `factory.ts`, and
+    // one of them (oracle.md) does so without naming the function — prose it does not owe.
+    const docs = PROVIDER_DOCS.filter((doc) => read(doc).includes("`createDatabaseProvider()`"));
+    // A derived population can derive to nothing, and a loop over nothing passes; renaming the
+    // phrase everywhere used to shed four assertions and stay green (#620).
+    expect(docs.length).toBeGreaterThan(0);
+    for (const doc of docs) {
       expect(read(doc)).toMatch(
         /`createDatabaseProvider\(\)`\s*\(\[`factory\.ts`\]\(\.\.\/\.\.\/src\/lib\/db\/factory\.ts\)\)/,
       );
+    }
+    for (const doc of PROVIDER_DOCS) {
+      expect(read(doc), `${doc} cites a line inside factory.ts`).not.toMatch(/factory\.ts:\d/);
     }
     expect(read(FACTORY)).toMatch(/^export async function createDatabaseProvider\(/m);
   });


### PR DESCRIPTION
## Description

Both halves of #620.

**Gap 2 — seven provider docs cited a line inside `factory.ts`, all stale.** `postgres.md` (`:62`, end of a docblock), `clickhouse.md` (`:87`), `couchbase.md` (`:93`), `druid.md` (`:95`, the libsql import), `libredb.md` (`:100`, the oracle import), `elasticsearch.md` (`:118`) and `opensearch.md` (`:123`) now name `createDatabaseProvider()` and link the file without a coordinate, the way `mssql.md`, `mysql.md`, `mongodb.md` and `redis.md` already do. `grep -rn 'factory\.ts:[0-9]' docs/providers/` returns nothing.

**Gap 1 — the guard could go vacuous.** The factory test filtered `NAMED_CITATIONS`, so renaming the phrase in every doc shed four assertions and stayed green. The population is now a sorted walk of `docs/providers/*.md` (the `theme-token-usage` idiom), selected on the entry point's **name** rather than on the link — `oracle.md` links `factory.ts` without naming the function and owes no such sentence — with a derived non-empty assertion and no pinned count. The same test also asserts no provider doc carries a `factory.ts:<line>`, so the seven fixes above cannot rot back.

---

## Type of Change

- [x] Documentation update
- [x] Test addition or update

---

## Related Issue

Fixes #620

---

## Changes Made

- `docs/providers/{postgres,clickhouse,couchbase,druid,libredb,elasticsearch,opensearch}.md`: one sentence each in Registration & lifecycle
- `tests/unit/provider-docs-monitoring-citations.test.ts`: `PROVIDER_DOCS` from a sorted `readdirSync`, non-empty guard, `factory.ts:\d` ban across all provider docs, scope note updated

---

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

---

Measured on this branch:

| | pass | fail | assertions |
| --- | --- | --- | --- |
| `tests/unit/provider-docs-monitoring-citations.test.ts` | 27 | 0 | 237 |
| same, with `` `createDatabaseProvider()` `` renamed in all 11 docs that cite it | 26 | **1** (`expect(docs.length).toBeGreaterThan(0)`) | 207 |

Before the test change, the second row was 27 / 0 / 207 — the four (now eleven) assertions vanished and nothing went red.

`bun run format`, `bun run lint` (0 errors), `bun run typecheck` and `bun run knip` are clean. `bun test tests/unit` passes except for the chart tests without `helm` on PATH (#570), `sqlite-driver` under Bun 1.3.11 (no `node:sqlite`; the repo pins 1.4.2) and `packaging-standalone-zip` without a standalone build — none of which touch these files.

---

### Test Environment
- **LibreDB Studio Version**: main @ b39381f
- **OS**: macOS
- **Node.js/Bun Version**: Bun 1.3.11

---

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
