### PR TITLE
docs(contributing): say that a claim is a courtesy, not a lock

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,14 @@ label have not been vetted for outside pickup; ask in an issue first if one inte
 
 - **Claim before you start.** Comment on the issue so two people do not build the same fix. A
   claimed issue with no activity for two weeks is open again.
+- **A claim is a courtesy, not a lock.** It cannot reach somebody who already had the issue open,
+  because GitHub sends no notification for a comment on a page you are already reading. So two
+  people do occasionally arrive at the same issue, and when that happens neither of them did
+  anything wrong. We decide by the clock rather than by the claim: work that was already in flight
+  when the claim was posted is not queue-jumping, and a pull request that is already delivered is
+  reviewed on its merits. Nobody is asked to write the same change twice, so whoever does not land
+  it is offered the nearest open issue instead, and a review on the other pull request is credited
+  here the same as code.
 - **What counts.** A PR that references its issue, includes tests and passes the gate above. During
   October we also add `hacktoberfest-accepted` to merged PRs from the labeled list, for participants
   whose program still looks for it.


### PR DESCRIPTION
Two contributors reached #621 ten minutes apart. It was claimed at 13:04 UTC, and #627 arrived at 13:16 with a commit dated 13:14. A change of that shape, two providers plus both provider docs plus eight tests, is not written in ten minutes, so the work predated the claim, and its author could not have seen the claim either: GitHub sends no notification for a comment on an issue you already have open.

The claim bullet in `CONTRIBUTING.md` read as an exclusive hold and said nothing about that case, which left the outcome looking like a judgement of one of the two people. It is not one. This adds the rule the collision was actually decided by, so the next pair of contributors can read it before it happens to them rather than after:

- the clock rather than the claim, since work already in flight is not queue-jumping
- delivered work reviewed on its merits
- nobody asked to write the same change twice
- the nearest open issue, plus review credit, for whoever does not land it

Worth noting what this exposed: the sentence contributors actually read first, "Comment to claim it before you start", is not in a template at all. `.github/ISSUE_TEMPLATE/` holds only `bug_report.md` and `feature_request.md`, and neither mentions claiming; the sentence is hand-copied into the body of each curated issue, where nothing in the repository can guard it. Making `CONTRIBUTING.md` the single authority does not change the rule, but it is the first time the rule lives somewhere checkable. Repointing those issue footers at this section is a separate change.

## Deliberately not in this PR

**No test.** The paragraph carries no cross-file invariant to guard, and pinning its prose verbatim would fail on the next honest edit while proving nothing. `tests/unit/contributors-doc.test.ts` guards what is guardable here, the ladder's two halves and the absence of a count, and it still passes: 9 tests, and the new bullet is a list item rather than a rung heading, so rung extraction is untouched.

**The staleness window is unchanged.** "A claimed issue with no activity for two weeks is open again" stays as it is. Shortening it, or distinguishing a claim with a branch behind it from one without, is a policy decision rather than a wording fix, and it belongs in its own change.

## Verification

`bun run format`, `bun run lint`, `bun run readme:check` and `bun run security:check` pass, and `bun test tests/unit/contributors-doc.test.ts` is 9 pass / 0 fail.
