### PR TITLE
chore(distribution): mark the AWS Marketplace channel live

### DIFF
--- a/.github/workflows/aws-ami-build.yml
+++ b/.github/workflows/aws-ami-build.yml
@@ -10,19 +10,22 @@ name: AWS AMI Build
 # job rather than in a release-only `if:` that a dispatch would walk straight
 # past.
 #
-# Until the listing is live, no machine path may build: the preflight job reads
-# `aws-marketplace` in distribution/channels.yaml and stands down unless its
-# status is `live`. A person who names a version in the dispatch input still
-# builds - that is how the AMI for the first submission gets made - so the
-# channel status is the switch, and flipping it to `live` is the whole change
-# needed to turn the release path on.
+# No machine path builds while the listing is not on sale: the preflight job
+# reads `aws-marketplace` in distribution/channels.yaml and stands down unless
+# its status is `live`. A person who names a version in the dispatch input builds
+# either way - that is how the AMI for the first submission was made - so the
+# channel status is the switch, and no edit here is needed when a listing goes
+# public. The channel went live on 7 Sep 2026, which opened the `release:
+# published` trigger below - it fires only for a draft published by hand, since
+# release-artifacts.yml publishes with GITHUB_TOKEN and no workflow dispatches
+# this one.
 on:
   release:
     types: [published]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release tag to ship - must exist on ghcr.io/libredb/libredb-studio (e.g. 0.14.0). Leave empty to use package.json; while the AWS channel is not live in distribution/channels.yaml a version is REQUIRED, an empty run stands down.'
+        description: 'Release tag to ship - must exist on ghcr.io/libredb/libredb-studio (e.g. 0.14.1). Leave empty to use package.json, which builds while the AWS channel is live in distribution/channels.yaml; while it is not live a version is REQUIRED and an empty run stands down.'
         required: false
         type: string
 

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -9,6 +9,10 @@ Same shape as the DigitalOcean droplet and the Azure VM image: Ubuntu 24.04, the
 published container pinned by digest, run by a systemd unit, credentials
 generated on the buyer's own instance at first boot.
 
+Listed since 7 September 2026:
+<https://aws.amazon.com/marketplace/pp/prodview-tsahkrgdqpnws> — product
+`prod-jq7wwg5ifhcfe`, first published version 0.14.1.
+
 ## Layout
 
 | Path | What it is |
@@ -30,23 +34,24 @@ keep in sync.
 ## Build
 
 Through the **AWS AMI Build** workflow: Actions -> AWS AMI Build -> Run
-workflow, **with the version** - while the listing is not live, naming it is
-what marks the run as a person's rather than a machine's (the listing gate
-below), so an empty run stands down. Once the channel is live, empty falls back
-to the `package.json` version at the ref. The run resolves the tag to a digest,
-waits for the image if the push is still in flight, assumes the OIDC build role
-and prints the AMI ID, the base image and the next portal steps in the job
-summary.
+workflow. The channel is live, so an empty version falls back to the
+`package.json` version at the ref and builds; name a version to ship anything
+else. (While the channel was pending, naming a version was what marked a run as
+a person's rather than a machine's - the listing gate below - and an empty run
+stood down.) The run resolves the tag to a digest, waits for the image if the
+push is still in flight, assumes the OIDC build role and prints the AMI ID, the
+base image and the next portal steps in the job summary.
 
 The workflow also declares `release: published`, but that trigger fires only
 when a human publishes a draft by hand: `release-artifacts.yml` publishes with
 `GITHUB_TOKEN`, and a GITHUB_TOKEN-created event starts no workflow. Making
 every release build an AMI means adding `gh workflow run aws-ami-build.yml
 --ref "refs/tags/$TAG"` to that file's `dispatch-downstream` job. That is safe to
-add whenever somebody wants it: a chained run names no version, so the preflight
-job below stands down quietly and the run is a green no-op until the repository
-variables exist. It is left out here only because it edits the release pipeline,
-which is outside what this change touches.
+add only with that consequence in mind: the channel is live and the three
+repository variables were set for the first build, so a chained run would build
+and register a marketplace AMI on every release, and nothing in this repository
+ever deregisters one. It is left out because it edits the release pipeline, and
+because registering an AMI per release is a decision rather than a default.
 
 A preflight job decides whether there is anything to build, on every path, so
 that the chain dispatch above behaves like a release rather than like a person:
@@ -64,16 +69,19 @@ Before any of that, it checks whether the product is on sale at all.
 listing, and while it is anything but `live` every machine path - a published
 release, the chained dispatch above - stands down quietly, so a release can
 never register a marketplace AMI for a product nobody can buy. A dispatch that
-NAMES a version builds regardless, because that is how the AMI the first
-submission needs gets made. Flipping the status to `live` is the whole switch:
-there is nothing to edit in the workflow when the listing goes public.
+NAMES a version builds regardless, which is how the AMI for the first
+submission was made. Flipping the status to `live` was the whole switch when the
+listing went public - nothing in the workflow had to change. What it opens is
+this workflow's own `release: published` trigger, which fires only for a draft a
+person publishes by hand (see above); no other workflow dispatches this one, so
+an ordinary release still builds no AMI.
 
 Locally, against the seller account:
 
 ```bash
 cd deploy/aws/ami
 export AWS_PROFILE=libredb-seller
-VERSION=0.14.0
+VERSION=0.14.1
 DIGEST=$(docker buildx imagetools inspect ghcr.io/libredb/libredb-studio:$VERSION --format '{{.Manifest.Digest}}')
 SUPPORT=$(gh variable get AWS_SUPPORT_EMAIL)   # the same mailbox the workflow uses
 packer init .
@@ -97,14 +105,14 @@ DIGEST=$(curl -sSI -H "Authorization: Bearer $TOKEN" \
 Whichever method you use, assert the value starts with `sha256:` before passing
 it to Packer.
 
-> **The scan verdict is still open.** Phase 0 of the plan measures whether the AWS
-> AMI scanner objects to CVEs inside the pre-pulled container layers, which is not
-> documented anywhere. Pre-pulling is the preferred design - deterministic, no
-> registry dependency at launch - but if the scan fails on container-layer CVEs
-> the fallback order is: rebuild the app image on a freshly patched base and
-> re-pin, then pull at first boot instead (allowed only if disclosed in the
-> listing), then ship the standalone `.deb`. Record the verdict here once it is
-> known.
+> **The scan accepts the pre-pulled layers.** Whether the AWS AMI scanner would
+> object to CVEs inside a pre-pulled container image is documented nowhere, so it
+> was an open question until the first submission: `ami-08263251d25dc8ced` passed
+> and shipped as published version 0.14.1 on 7 September 2026. Pre-pulling stays
+> the design - deterministic, no registry dependency at launch. If a later scan
+> does fail on container-layer CVEs, the fallback order is: rebuild the app image
+> on a freshly patched base and re-pin, then pull at first boot instead (allowed
+> only if disclosed in the listing), then ship the standalone `.deb`.
 
 ## Rules that are not style preferences
 
@@ -158,7 +166,9 @@ request and AMI **45 days before** any announcement that depends on it.
 3. Launch from the raw AMI and walk the short checklist: health, login, reload
    (the `AUTH_COOKIE_SECURE` trap), rotation, reboot.
 4. Portal -> Request changes -> Add new version, with the same ingestion role,
-   `ubuntu`, port 22, endpoint `http` `/` `3000`.
+   `ubuntu`, port 22, endpoint `http` `/` `3000`, and the Region set recorded in
+   `listing/listing-fields.md` — automatic enrolment in future Regions is off, so
+   Regions are chosen per version rather than inherited.
 5. Once the new version is live, restrict the previous one. Do **not** deregister
    an AMI or delete its snapshot while a version request is in flight.
 

--- a/deploy/aws/listing/listing-fields.md
+++ b/deploy/aws/listing/listing-fields.md
@@ -43,6 +43,15 @@ sentence verbatim, which is what the AMI product checklist asks for.
 
 Developer Tools; Database. Pick the closest subcategories the portal offers.
 
+## Region availability
+
+Thirty-three of the 36 Regions the portal lists. The two GovCloud Regions are
+excluded because they need a separately verified account, and me-central-1
+because t3.small does not exist there - a Region carrying none of the listed
+instance types fails the submission with INSTANCE_TYPES_NOT_AVAILABLE. Automatic
+enrolment in future Regions is off, because a new Region can open without
+t3.small and would fail the same way.
+
 ## Pricing
 
 Free. The buyer pays only for the EC2 instance, EBS storage and data transfer
@@ -52,7 +61,7 @@ they use. No software charges, no metering, no contract.
 
 | Field | Value |
 |---|---|
-| Version title | The app version being shipped, e.g. `0.14.0` |
+| Version title | The app version being shipped - `0.14.1` for the initial listing |
 | AMI ID | From the AWS AMI Build job summary; must exist in us-east-1 in the seller account with an unencrypted snapshot |
 | IAM access role ARN | The AMI ingestion role, published by the build job summary from the `AWS_AMI_INGESTION_ROLE_ARN` repository variable - one source, so the two cannot drift |
 | Operating system | Ubuntu 24.04 |
@@ -96,15 +105,16 @@ marker to enforce - check the portal's own counter when pasting.
 
 | Field | Value |
 |---|---|
-| Support email | Monitored mailbox, decided with the seller account (not the GitHub issue tracker alone) |
-| Support phone | The number recorded on the seller account |
+| Support email | The address in the `AWS_SUPPORT_EMAIL` repository variable - the same mailbox the build prints into every buyer's banner, so the two cannot drift |
+| Support phone | The number on the seller-account profile |
 | Support website | https://github.com/libredb/libredb-studio/issues |
 
 ## EULA and refunds
 
-EULA: the MIT licence text, which is the honest choice for an MIT-licensed
-product, unless the Standard Contract for AWS Marketplace is adopted instead
-(a legal decision, not an engineering one).
+EULA: the Standard Contract for AWS Marketplace (SCMP), chosen for the initial
+listing. The MIT licence text is the alternative and remains available through an
+update request - which of the two carries less risk for a free product is a legal
+decision, not an engineering one.
 
 Refund policy: the product is free and incurs no software charges, so no
 refunds apply. AWS infrastructure charges are handled by AWS.

--- a/deploy/aws/listing/usage-instructions.md
+++ b/deploy/aws/listing/usage-instructions.md
@@ -153,7 +153,7 @@ matching GitHub release. They carry one of the labels AWS uses:
 - `Important` - a bug fix or a change in behaviour worth planning for.
 - `Optional` - new features and routine maintenance.
 
-Version 0.14.0 is the initial listing and is labelled `Optional`.
+Version 0.14.1 is the initial listing and is labelled `Optional`.
 
 ## 13. Upgrades
 

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -798,27 +798,30 @@ channels:
   - id: aws-marketplace
     name: AWS Marketplace (free AMI product)
     short_name: AWS Marketplace
-    status: pending
+    status: live
     category: cloud-marketplaces
     platforms: [cloud]
     runtime: channel_supplied
     tier: 4
     kind: marketplace
     update:
+      # The AMI and every listing field are submitted through the AWS Marketplace
+      # Management Portal, and a visibility change is reviewed by hand by Seller
+      # Operations, so nothing here can be CI-driven.
       method: manual_ui
       sla: on_demand
     links:
+      catalog: https://aws.amazon.com/marketplace/pp/prodview-tsahkrgdqpnws
       docs: deploy/aws/README.md
     pin:
       strategy: none
-      note: Nothing is listed yet - the AMI product exists as a descriptor only (deploy/aws/ holds
-        the Packer build, the first-boot units and every portal field), the same reason the Azure
-        offer carries an entry. This status is load-bearing rather than documentation -
-        .github/workflows/aws-ami-build.yml reads it and refuses every machine-triggered build
-        while it is not live, so a release cannot register a marketplace AMI for a product that is
-        not on sale. On publication, flip to live (that alone turns the release path on) and add
-        the listing URL as links.catalog; there is no pin to add, because the listed version lives
-        in the AWS Marketplace Management Portal the way Azure's lives in Partner Center.
+      note: Published 7 Sep 2026 as a free AMI product (0.14.1, ami-08263251d25dc8ced). This status
+        is load-bearing rather than documentation - .github/workflows/aws-ami-build.yml reads it and
+        stands down on every machine-triggered path while it is not live. Live opens that workflow's
+        own release trigger, which fires only for a draft published by hand; no other workflow
+        dispatches it, so an ordinary release still builds no AMI.
+        There is no pin to read, because the listed version lives in the AWS Marketplace Management
+        Portal the way Azure's lives in Partner Center; it is checked by hand against the portal.
 
   - id: winget
     name: winget community repository (LibreDB.Studio)

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -34,9 +34,9 @@ channel count.
 
 ## Coverage snapshot
 
-**36 channels · 28 live · 7 pending · 1 deprecated**
+**36 channels · 29 live · 6 pending · 1 deprecated**
 
-Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 5 · Kubernetes 3 · Cloud 11**
+Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 5 · Kubernetes 3 · Cloud 12**
 
 | Category | Live | Pending | Deprecated |
 | --- | ---: | ---: | ---: |
@@ -47,7 +47,7 @@ Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 5 · K
 | OS / desktop packages | 3 | 0 | 0 |
 | PaaS catalogs (listed) | 9 | 3 | 0 |
 | Deploy recipes | 3 | 0 | 0 |
-| Cloud marketplaces | 2 | 3 | 0 |
+| Cloud marketplaces | 3 | 2 | 0 |
 
 <!-- END:CHANNEL-SCORECARD -->
 
@@ -88,9 +88,9 @@ Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 5 · K
 | [Fly.io launch config](https://github.com/libredb/libredb-studio/blob/main/fly.toml) | Deploy recipes | Cloud | live | Manual, on demand | [FLY.md](FLY.md) |
 | [Koyeb deploy button](https://github.com/libredb/libredb-studio/tree/main/deploy/koyeb) | Deploy recipes | Cloud | live | Manual, on demand | [deploy/koyeb/README.md](../deploy/koyeb/README.md) |
 | [Render Blueprint](https://github.com/libredb/libredb-studio/blob/main/render.yaml) | Deploy recipes | Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-tsahkrgdqpnws) | Cloud marketplaces | Cloud | live | Manual, on demand | [deploy/aws/README.md](../deploy/aws/README.md) |
 | [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/libredb-studio) | Cloud marketplaces | Cloud | live | Manual, on demand | [deploy/digitalocean/README.md](../deploy/digitalocean/README.md) |
 | [Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/libredb-public/libredb-studio) | Cloud marketplaces | Kubernetes, Cloud | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
-| AWS Marketplace | Cloud marketplaces | Cloud | pending | Manual, on demand | [deploy/aws/README.md](../deploy/aws/README.md) |
 | Azure Marketplace | Cloud marketplaces | Cloud | pending | Manual, on demand | [deploy/azure/README.md](../deploy/azure/README.md) |
 | [Koyeb One-Click Apps catalog](https://www.koyeb.com/deploy) | Cloud marketplaces | Cloud | pending | Manual, on demand | [deploy/koyeb/CATALOG_SUBMISSION.md](../deploy/koyeb/CATALOG_SUBMISSION.md) |
 

--- a/src/lib/distribution/channels.generated.ts
+++ b/src/lib/distribution/channels.generated.ts
@@ -41,6 +41,7 @@ export const LIVE_CHANNELS: readonly ShowcaseChannel[] = [
   { id: "rancher-partner", label: "Rancher Partner Charts", group: "kubernetes" },
   { id: "digitalocean", label: "DigitalOcean Marketplace", group: "paas" },
   { id: "gcp-marketplace", label: "Google Cloud Marketplace", group: "paas" },
+  { id: "aws-marketplace", label: "AWS Marketplace", group: "paas" },
   { id: "winget", label: "winget", group: "packages" },
   { id: "chocolatey", label: "Chocolatey", group: "packages" },
   { id: "flatpark", label: "FlatPark (Flatpak)", group: "packages" },

--- a/tests/unit/aws-ami-descriptor.test.ts
+++ b/tests/unit/aws-ami-descriptor.test.ts
@@ -614,8 +614,15 @@ describe("AWS AMI build workflow", () => {
     // Substrings alone let the README say the OPPOSITE of the code and stay
     // green - which is exactly how a sentence claiming a chain dispatch would
     // "fail on the unset variables" survived two reviews. Assert the claim.
+    //
+    // What the claim must say changed when the channel went live: a chained run
+    // names no version, and the gate it used to stand down on is the channel
+    // status, so with `aws-marketplace` live the same edit now builds and
+    // registers an AMI per release. The paragraph has to say that, because a
+    // reader deciding whether to add the dispatch line is deciding exactly this.
     const chain = readme.slice(readme.indexOf("dispatch-downstream"), readme.indexOf("A preflight job"));
-    expect(chain).toMatch(/stands down/);
+    expect(chain).toMatch(/register a\s+marketplace AMI on every release/);
+    expect(chain).not.toMatch(/green no-op/);
     expect(chain).not.toMatch(/would\s+fail/);
     const preflightPara = readme.slice(readme.indexOf("A preflight job"));
     expect(preflightPara).toMatch(/NAMES a version fails loudly/);


### PR DESCRIPTION
The AWS Marketplace listing is public as of 7 September 2026, so the channel row
moves from `pending` to `live`:
https://aws.amazon.com/marketplace/pp/prodview-tsahkrgdqpnws (product
`prod-jq7wwg5ifhcfe`, first published version 0.14.1, AMI
`ami-08263251d25dc8ced`, free AMI product in 33 regions).

The status is load-bearing, not documentation: `.github/workflows/aws-ami-build.yml`
reads this row and stands down on every machine-triggered path while it is not
`live`, so this flip is what opens the release path. Nothing fires on its own —
`release-artifacts.yml` does not dispatch the AMI build, and a chained dispatch
still has to be added by hand.

- `distribution/channels.yaml`: status `live`, the listing URL as `links.catalog`,
  and a pin note recording why there is nothing to pin (the listed version lives
  in the AWS Marketplace Management Portal, the way Azure's lives in Partner
  Center).
- `docs/CHANNELS.md` and `src/lib/distribution/channels.generated.ts`: regenerated,
  not hand-edited.
- `deploy/aws/README.md`: the listing URL and the published version.

Before publication the product was validated in Limited state against the
phase-3 checklist on an instance launched from the listing itself: first boot
under 90 seconds with no `did not become ready`, both oneshots finished, health
and login served, credentials retrievable from the console log only, MOTD
carrying no password, sshd refusing password and root login, IMDSv2 required,
digest-pinned image, reboot and stop/start keeping the same credentials while
publishing no second banner, and a second instance generating a different
password.
