### PR TITLE
docs(llms): the roster count the pages state, and a guard that derives it

### DIFF
--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -30,7 +30,7 @@ Each model was asked one question per surface, the same wording for every model,
 | Analyze | "Which part of the company costs us the most in salary?" |
 | Plan | "What tables are in this database and how do they relate to each other?" |
 
-Twenty-two models, six surfaces, five runs: **660 runs, and all 660 passed.**
+Twenty-eight models, six surfaces, five runs: **840 runs, and all 840 passed.**
 
 A run passes only when its goal verdict is `answered`. A run that ends `succeeded` having
 answered nothing is a failure here, and the ledger names which bar it missed.
@@ -105,9 +105,9 @@ one, and each page says what its model needed.
 
 ## Driven through the interface as well
 
-The 660 runs above were opened over HTTP. A separate sweep drove ten of the models through the
+The 840 runs above were opened over HTTP. A separate sweep drove ten of the models through the
 product's own rail — log in, pick the sample connection, type the objective, press Start, wait
-for the run to finish on screen — one run per surface: **57 of 60 passed.** Ten, not twenty-two:
+for the run to finish on screen — one run per surface: **57 of 60 passed.** Ten, not twenty-eight:
 that sweep was run when ten models were supported and has not been repeated, and the twelve added
 since are measured over HTTP only. Saying "all of them" would have described a sweep nobody ran.
 

--- a/docs/llms/setup.md
+++ b/docs/llms/setup.md
@@ -7,12 +7,12 @@ are environment variables read at server startup, which is how everything else i
 is configured. It keeps the choice with whoever operates the server rather than turning it into
 a permission to grant, revoke and audit per user.
 
-Twenty-two models are supported — every one of them clears all six agent surfaces five consecutive
+Twenty-eight models are supported — every one of them clears all six agent surfaces five consecutive
 times. They are listed with their measured durations in the [index](README.md).
 
 ## A local model, through Ollama
 
-Twenty-one of the twenty-two run locally, with no key and no traffic leaving the machine.
+Twenty-seven of the twenty-eight run locally, with no key and no traffic leaving the machine.
 
 ```bash
 # macOS
@@ -38,7 +38,7 @@ where is in [`../AGENT_DATA_FLOW.md`](../AGENT_DATA_FLOW.md).
 
 ## A hosted model
 
-One of the twenty-two is hosted, and it is configured the same way with one line more:
+One of the twenty-eight is hosted, and it is configured the same way with one line more:
 
 ```bash
 LLM_PROVIDER=gemini

--- a/tests/unit/lib/agent/model-roster-docs.test.ts
+++ b/tests/unit/lib/agent/model-roster-docs.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The roster count in `docs/llms/` is derived from the shipped profiles, not typed beside them.
+ *
+ * This file exists because the count leaked twice. `docs/llms/README.md` moved from twenty-two to
+ * twenty-seven when five models landed, and `setup.md` and `methodology.md` did not: both still
+ * said "Twenty-two models are supported" and "660 runs, and all 660 passed" against a document
+ * holding twenty-seven. Two pull requests and one review passed over it, because nothing anywhere
+ * compared the sentence to the file it describes.
+ *
+ * So the comparison is here, derived on both sides: the count comes from `modelProfiles()` and the
+ * total from `count * RUNS_PER_MODEL`, which is what the protocol those pages describe produces -
+ * six surfaces, five consecutive runs each.
+ *
+ * What is checked is the CLAIM, not every number in the prose. A first attempt asserted only that
+ * each page contained the current word, and it did not bite: reverting `setup.md`'s opening
+ * sentence to "Twenty-two models are supported" left the test green, because two later sentences in
+ * the same file still said "twenty-eight" and `includes` was satisfied by them. A test that passes
+ * for the wrong reason is worse than no test, so each claim is now captured by its own sentence and
+ * compared, and the run total is checked against every other roster size it could have been rather
+ * than against the ones we happen to have had.
+ *
+ * A blanket ban on number-words would be wrong here: these pages legitimately say "twenty-seven"
+ * (the models that run locally), "twenty-one" (the models at the 90-second ceiling), "Ten" (the
+ * browser sweep) and "thirty runs" (one model's own sweep). Those are different counts, correctly
+ * stated, and a guard that failed on them would be deleted within a week.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { modelProfiles } from "@/lib/agent/models";
+
+/** Six surfaces, five consecutive passing runs each - the bar `methodology.md` sets. */
+const RUNS_PER_MODEL = 30;
+
+const read = (page: string): string => readFileSync(join(process.cwd(), "docs", "llms", page), "utf8");
+
+/**
+ * The sentences that state the roster's size, one per page that states it.
+ *
+ * Hand-listed because a sentence cannot be derived; the NUMBER in it is what the test derives. A
+ * page whose phrasing changes fails here loudly rather than silently stopping being checked, which
+ * is the failure mode this file was written after.
+ */
+const CLAIMS: readonly { readonly page: string; readonly pattern: RegExp }[] = [
+  { page: "README.md", pattern: /\*\*([A-Za-z-]+) models are supported\.\*\*/ },
+  { page: "setup.md", pattern: /([A-Za-z-]+) models are supported —/ },
+  { page: "methodology.md", pattern: /([A-Za-z-]+) models, six surfaces, five runs/ },
+];
+
+/** Only these two carry the run total; `setup.md` names the roster without counting its runs. */
+const PAGES_WITH_TOTAL = ["README.md", "methodology.md"] as const;
+
+const WORDS: Readonly<Record<number, string>> = {
+  20: "Twenty",
+  21: "Twenty-one",
+  22: "Twenty-two",
+  23: "Twenty-three",
+  24: "Twenty-four",
+  25: "Twenty-five",
+  26: "Twenty-six",
+  27: "Twenty-seven",
+  28: "Twenty-eight",
+  29: "Twenty-nine",
+  30: "Thirty",
+  31: "Thirty-one",
+  32: "Thirty-two",
+  33: "Thirty-three",
+  34: "Thirty-four",
+  35: "Thirty-five",
+};
+
+describe("the roster count the docs state is the roster the product ships", () => {
+  const count = Object.keys(modelProfiles()).length;
+  const total = count * RUNS_PER_MODEL;
+
+  test("each page's own roster sentence names the current count", () => {
+    const word = WORDS[count];
+    // A roster past the table above fails here rather than skipping: these pages spell the number
+    // out, so growing past it needs the word written before the count can be stated at all.
+    expect({ count, word }).toEqual({ count, word: expect.any(String) });
+    for (const { page, pattern } of CLAIMS) {
+      const found = pattern.exec(read(page))?.[1];
+      expect({ page, found }).toEqual({ page, found: word });
+    }
+  });
+
+  test("no page carries a run total from a different roster", () => {
+    for (const page of PAGES_WITH_TOTAL) {
+      const text = read(page);
+      expect({ page, states: text.includes(`${total} runs`) }).toEqual({ page, states: true });
+      for (let other = 10; other <= 60; other += 1) {
+        if (other === count) continue;
+        const stale = `${other * RUNS_PER_MODEL} runs`;
+        expect({ page, stale, found: text.includes(stale) }).toEqual({ page, stale, found: false });
+      }
+    }
+  });
+});

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -902,7 +902,7 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
         sending prose where an object goes.
 
         The paths were already named. What was gated was the SHAPE: `exampleReportCall` rebuilds a
-        whole call from the run's ledger and sits behind `refusalExamples`, which two of twenty-two
+        whole call from the run's ledger and sits behind `refusalExamples`, which two of twenty-eight
         shipped models carry. Everyone else reads "expected object" and has to guess the object.
 
         So this splits the two, on the rule the column advice was split on: a one-line skeleton is


### PR DESCRIPTION
`docs/llms/setup.md` and `docs/llms/methodology.md` still described a **twenty-two model** roster.
Both were written when that was true, and neither moved when five models landed in #572 and a sixth
in #628. Against a document now holding twenty-eight, the pages read:

| Page | Said |
| --- | --- |
| `setup.md` | "Twenty-two models are supported" |
| `setup.md` | "Twenty-one of the twenty-two run locally" |
| `setup.md` | "One of the twenty-two is hosted" |
| `methodology.md` | "Twenty-two models, six surfaces, five runs: **660 runs, and all 660 passed.**" |
| `methodology.md` | "The 660 runs above were opened over HTTP" |
| `methodology.md` | "Ten, not twenty-two" |
| `tests/unit/lib/agent/tools.test.ts` | "which two of twenty-two shipped models carry" |

**Two pull requests and a review passed over all of it**, and that is the part worth fixing rather
than the seven numbers. Nothing anywhere compared the sentence to the file it describes.

## The guard

`tests/unit/lib/agent/model-roster-docs.test.ts` now does that comparison, derived on both sides:
the count comes from `modelProfiles()` and the total from `count * 30`, which is the protocol those
pages define — six surfaces, five consecutive runs each.

**The first version of it did not bite, and that is recorded in the file.** Asserting only that a
page *contained* the current word left `setup.md` green when its opening sentence was reverted to
twenty-two, because two later sentences in the same file still said twenty-eight and `includes` was
satisfied by them. Each claim is now captured by its own sentence and compared; the run total is
checked against every roster size between ten and sixty rather than against the totals this project
happens to have had.

Both halves were confirmed to bite by reverting the two sentences that actually leaked:

| Mutation | Result |
| --- | --- |
| `setup.md` opening sentence back to "Twenty-two models are supported" | **1 fail** |
| `methodology.md` back to "660 runs, and all 660 passed" | **1 fail** |
| Both restored | 2 pass |

## What it deliberately does not do

A blanket ban on number-words would fail on sentences that are correct. These pages legitimately
say **twenty-seven** (the models that run locally), **twenty-one** (the models at the 90-second
ceiling), **Ten** (the browser sweep) and **thirty runs** (one model's own sweep). A guard that
failed on those would be deleted within a week, so it pins the claims and the total instead.

The claim patterns are hand-listed because a sentence cannot be derived; the number in each is what
the test derives. A page whose phrasing changes fails loudly rather than silently stopping being
checked — which is the failure mode this file was written after.

## Gates

`format` · `lint` · `typecheck` · `knip` · `test` (38 groups, 0 fail) · `build` — all green.
Coverage: **45992/45992 lines, 100.00%**.
