### PR TITLE
docs(providers): drop dead getPlaceholder mentions

### DIFF
--- a/docs/providers/druid.md
+++ b/docs/providers/druid.md
@@ -124,10 +124,13 @@ the case [`docs/ADDING_A_PROVIDER.md`](../ADDING_A_PROVIDER.md) names ClickHouse
 |---|---|
 | `escapeIdentifier()` | Double-quoted, since `this.type` (`druid`) falls through to the default branch — the same quoting PostgreSQL uses, and correct here: `SELECT "id" FROM "libredb_demo"` parses. Quoting is not optional in generated SQL — see the reserved-word trap in [§5.4](#54-dialect-traps-a-user-will-hit) |
 | `buildLimitClause()` | `LIMIT n` / `LIMIT n OFFSET m`, both accepted by Druid |
-| `getPlaceholder()` | Returns `?`, which is exactly what Druid's positional parameters use ([§3.10](#310-positional-parameters-really-execute)) |
 | `shouldEnableSSL()` | Inherited but **never called**, deliberately. It infers TLS from substrings in the host name, which would silently switch a self-hosted cluster whose hostname merely contains one. TLS here comes from the connection's own `ssl` config only ([§4.3](#43-tls)) |
 | `prepareQuery()` (base) | The shared query limiter; `DruidProvider` calls it first and only overrides the `OFFSET`-with-no-`LIMIT` case |
 | `getLabels()` (base) | Everything but the two entity labels and the slow-query empty state ([§9](#9-capabilities--labels)) |
+
+Not in the list: a placeholder helper. `SQLBaseProvider` no longer has one (#304 removed it).
+Positional `?` still binds via `query(sql, params)`
+([§3.10](#310-positional-parameters-really-execute)).
 
 ### 2.4 Registration & lifecycle
 
@@ -558,7 +561,7 @@ throws on positional ones — Druid takes `?` placeholders with a typed paramete
 -> [["c"],[20]]
 ```
 
-So `query(sql, params)` binds rather than refuses, and `getPlaceholder()` needs no override. The
+So `query(sql, params)` binds rather than refuses. The
 mapping:
 
 | JS value | Druid parameter type | Note |

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -123,9 +123,12 @@ both exports honestly thin (each one names its product and nothing else).
 | `buildLimitClause()` | `LIMIT n`, which this grammar accepts (measured, including after `ORDER BY` / `GROUP BY` / `HAVING`). Its second form, `LIMIT n OFFSET m`, is a **syntax error** here, which is the one thing `prepareQuery()` overrides ([§5.5](#55-the-preparequery-override-there-is-no-second-page)) |
 | `prepareQuery()` (base) | The shared query limiter; called first, then the `OFFSET` case is refused |
 | `escapeIdentifier()` | Inherited and **never called** — this provider builds no SQL of its own, because the schema comes from the mapping rather than from a statement. Its default branch would double-quote, which happens to be right for this product ([§5.4](#54-dialect-traps-a-user-will-hit)) |
-| `getPlaceholder()` | Inherited and never reached: positional parameters are refused outright ([§3.11](#311-positional-parameters-are-refused-not-emulated)) |
 | `measureExecution()` / `trackQuery()` | The measured duration is the only timing in existence — neither the body nor the headers carry one |
 | `shouldEnableSSL()` | Inherited but **never called**. TLS comes from the connection's own `ssl` config only ([§4.3](#43-tls)) |
+
+Not in the list: a placeholder helper. `SQLBaseProvider` no longer has one (#304 removed it).
+Positional parameters are refused outright
+([§3.11](#311-positional-parameters-are-refused-not-emulated)).
 
 ### 2.4 Registration & lifecycle
 

--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -63,7 +63,7 @@ DatabaseProvider (interface) → BaseDatabaseProvider → SQLBaseProvider → MS
 [`sql-base.ts`](../../src/lib/db/providers/sql/sql-base.ts) (see
 [PostgreSQL doc §2.2](./postgres.md#22-what-sqlbaseprovider-provides)) and **overrides**
 `getCapabilities()`, `getLabels()`, `escapeIdentifier()` (bracket quoting), and `prepareQuery()`
-(T-SQL pagination). Bind placeholders are `@p1`, `@p2`, … (`getPlaceholder()` from the base).
+(T-SQL pagination). Bind placeholders are `@p1`, `@p2`, ….
 
 ### Registration
 

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -128,9 +128,12 @@ OpenSearchProvider (search/index.ts:967)         ElasticsearchProvider (search/i
 | `buildLimitClause()` | **Both** forms are correct here: `LIMIT n` and `LIMIT n OFFSET m` (measured, HTTP 200). So the shared limiter is right unmodified and `prepareQuery()` never refuses anything on this product ([§5.5](#55-offset-works-here-which-is-why-paging-does)) |
 | `prepareQuery()` (base) | The shared query limiter, used as inherited |
 | `escapeIdentifier()` | Inherited and **never called** — this provider builds no SQL of its own, because the schema comes from the mapping rather than from a statement. Worth knowing that its default branch would double-quote, which is **wrong for this product** ([§5.4](#54-dialect-traps-a-user-will-hit)); the codebase's own quoter gets it right instead ([`identifier.ts:36`](../../src/lib/sql/identifier.ts)) |
-| `getPlaceholder()` | Inherited and never reached: positional parameters are refused outright ([§3.11](#311-positional-parameters-are-refused-not-emulated)) |
 | `measureExecution()` / `trackQuery()` | The measured duration is the only timing in existence — neither the body nor the headers carry one |
 | `shouldEnableSSL()` | Inherited but **never called**. TLS comes from the connection's own `ssl` config only ([§4.3](#43-tls)) |
+
+Not in the list: a placeholder helper. `SQLBaseProvider` no longer has one (#304 removed it).
+Positional parameters are refused outright
+([§3.11](#311-positional-parameters-are-refused-not-emulated)).
 
 ### 2.4 Registration & lifecycle
 

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -469,7 +469,7 @@ proving each statement had landed:
 `autoCommit: true` on the call is load-bearing, not decoration: `oracledb.autoCommit` defaults to
 `false`, and measured without it the `INSERT` still reported `rowsAffected: 1` while a second
 session saw `COUNT(*) = 0`, and the row was gone for good once the writing connection went back to
-the pool. Bind parameters use Oracle's `:1`-style placeholders (`getPlaceholder()` from the base).
+the pool. Bind parameters use Oracle's `:1`-style placeholders.
 Native errors are normalised through `mapDatabaseError()` (see [§11](#11-error-handling)).
 
 ### 5.2 Query cancellation


### PR DESCRIPTION
## Summary
- Remove dead `getPlaceholder()` mentions from provider docs (`mssql`, `oracle`, `druid`, `elasticsearch`, `opensearch`).
- Keep engine bind facts (`@p1`/`@p2`, `:1`, Druid `?`, ES/OS refuse) and align table notes with `clickhouse.md` after #304.
- Does not touch the same Druid line-number work tracked in #590.

Fixes #640