### PR TITLE
docs(providers): link measured aggregate helper source

### DIFF
--- a/docs/providers/mssql.md
+++ b/docs/providers/mssql.md
@@ -659,8 +659,8 @@ pairing.
 A database that really measures `0` is a **reading** and is kept. `SUM(...)` over no input answers
 one row of `NULL`, which the provider maps to `0`; the tab then formats the `0 B` it was given. If
 the driver returns no row, no expected column, or a non-finite value, the measurement is absent and
-the string stays `N/A`. The shared `measuredNullableAggregate()` boundary preserves those states
-without a falsy test that would erase a genuine zero.
+the string stays `N/A`. The shared `measuredNullableAggregate()` ([`measured-aggregate.ts`](../../src/lib/db/utils/measured-aggregate.ts))
+boundary preserves those states without a falsy test that would erase a genuine zero.
 
 ---
 

--- a/docs/providers/oracle.md
+++ b/docs/providers/oracle.md
@@ -1003,8 +1003,8 @@ A schema that really measures `0` is a **reading** and is kept, and here that ca
 than hypothetical: a freshly created user owns no segment, so `SUM(BYTES)` answers one row of `NULL`,
 which the provider maps to `0`; the tab then formats the `0 B` it was given. If the driver returns no
 row, no expected column, or a non-finite value, the measurement is absent and the string stays `N/A`.
-The shared `measuredNullableAggregate()` boundary preserves those states without a falsy test that
-would erase a genuine zero.
+The shared `measuredNullableAggregate()` ([`measured-aggregate.ts`](../../src/lib/db/utils/measured-aggregate.ts))
+boundary preserves those states without a falsy test that would erase a genuine zero.
 
 ---
 

--- a/tests/unit/provider-docs-monitoring-citations.test.ts
+++ b/tests/unit/provider-docs-monitoring-citations.test.ts
@@ -221,6 +221,17 @@ describe("redis provider doc", () => {
   });
 });
 
+describe("measured aggregate helper docs", () => {
+  test("MSSQL and Oracle pin the helper name to its source file", () => {
+    for (const doc of ["docs/providers/mssql.md", "docs/providers/oracle.md"]) {
+      expect(read(doc)).toContain(
+        "`measuredNullableAggregate()` ([`measured-aggregate.ts`](../../src/lib/db/utils/measured-aggregate.ts))",
+      );
+    }
+    expect(read("src/lib/db/utils/measured-aggregate.ts")).toMatch(/^export function measuredNullableAggregate\(/m);
+  });
+});
+
 describe("provider docs rewritten this round: code cited by name, whole file", () => {
   for (const { doc, source, methods } of NAMED_CITATIONS) {
     test(`${doc} cites no line number anywhere`, () => {


### PR DESCRIPTION
## Description

Fixes #622 by making the shared measured aggregate helper citation navigable and test-backed.

## Type of Change

- [x] Documentation update
- [x] Test addition or update

## Related Issue

Closes #622

## Changes Made

- Link `measuredNullableAggregate()` in the MSSQL and Oracle monitoring docs to its source file.
- Add a citation test that pins the exported function name and both documentation references.
- Keep the citation line-number-free while making a future helper rename or doc drift fail the test.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [ ] All existing tests pass

- `bun test tests/unit/provider-docs-monitoring-citations.test.ts` — 28 pass, 0 fail
- `bun run format` — pass
- `bun run lint` — 0 errors; 135 existing warnings
- `bun run typecheck` — pass
- `bun run knip` — exit 0 (2 existing configuration hints)
- `bun run readme:check` — pass
- `bun run chart:check` — pass
- `bun run channels:showcase:check` — pass
- `bun run security:check` — pass
- `bun run build` — pass
- Mutation probes: renaming the source export or either documentation reference makes the target citation test fail; each file was restored byte-for-byte.

### Test Environment

- **LibreDB Studio Version**: `b39381f` (upstream/main)
- **Browser**: N/A (documentation/unit test)
- **OS**: Windows (Git Bash / native Bun x64)
- **Node.js/Bun Version**: Bun 1.4.2
- **Database Type**: N/A (documentation/unit test)

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The complete `bun run test` and `bun run test:coverage` commands were also run. They remain blocked by pre-existing Windows/runtime assumptions in unrelated tests (path-separator assertions, Unix shell/archive fixtures, native SQLite behavior and provider-factory/auth cascades); the target citation test passes, and this PR changes no product runtime code.
