### PR TITLE
chore(distribution): move the owned deployment pins to 0.14.1

### DIFF
--- a/.github/workflows/do-packer-build.yml
+++ b/.github/workflows/do-packer-build.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag for snapshot name AND image pin — must exist on ghcr.io/libredb/libredb-studio (e.g. 0.9.59)'
+        description: 'Version tag for snapshot name AND image pin — must exist on ghcr.io/libredb/libredb-studio (e.g. 0.14.1)'
         required: true
-        default: '0.9.59'
+        default: '0.14.1'
 
 permissions:
   contents: read
@@ -38,7 +38,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::version must be semver (e.g. 0.9.59), got: $VERSION"
+            echo "::error::version must be semver (e.g. 0.14.1), got: $VERSION"
             exit 1
           fi
 

--- a/deploy/digitalocean/README.md
+++ b/deploy/digitalocean/README.md
@@ -31,7 +31,7 @@ the pin deliberately, in both places, after reviewing upstream changes.
 ## Build
 
 **GitHub Actions (recommended):** Actions → "DO Packer Build" → Run workflow →
-enter a version (semver, e.g. `0.9.59` — must exist as a tag on
+enter a version (semver, e.g. `0.14.1` — must exist as a tag on
 `ghcr.io/libredb/libredb-studio`). The snapshot ID appears in the job summary.
 Requires the `DIGITALOCEAN_TOKEN` repo secret (read+write PAT).
 
@@ -44,8 +44,8 @@ curl -fsSLo scripts/90-cleanup.sh   "https://raw.githubusercontent.com/digitaloc
 curl -fsSLo scripts/99-img-check.sh "https://raw.githubusercontent.com/digitalocean/marketplace-partners/${MP_SHA}/scripts/99-img-check.sh"
 export DIGITALOCEAN_TOKEN=dop_v1_...
 packer init .
-packer validate -var "version=0.9.59" .
-packer build -var "version=0.9.59" .
+packer validate -var "version=0.14.1" .
+packer build -var "version=0.14.1" .
 ```
 
 ## Critical build rules

--- a/deploy/digitalocean/droplet/template.pkr.hcl
+++ b/deploy/digitalocean/droplet/template.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type        = string
-  description = "LibreDB Studio release tag — image pin + snapshot name (e.g. 0.9.59). Must exist on ghcr.io/libredb/libredb-studio."
+  description = "LibreDB Studio release tag — image pin + snapshot name (e.g. 0.14.1). Must exist on ghcr.io/libredb/libredb-studio."
 }
 
 source "digitalocean" "ubuntu" {

--- a/deploy/railway/PUBLISH.md
+++ b/deploy/railway/PUBLISH.md
@@ -13,7 +13,7 @@ values to enter are in [`template.json`](./template.json).
 
 - In the editor, click **+ New** (top-right), or open the command palette
   (`⌘K` / `Ctrl+K`) → **+ New Service** → **Docker Image**.
-- Image: `ghcr.io/libredb/libredb-studio:0.9.22` (pinned — never `:latest`).
+- Image: `ghcr.io/libredb/libredb-studio:0.14.1` (pinned — never `:latest`).
 - Rename the service to `libredb-studio`.
 
 ## 3. Variables

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -31,7 +31,7 @@ Or browse the Railway template marketplace and search **LibreDB Studio**.
 ## Deploy (manual — works today, before publishing)
 
 Railway dashboard → **New Project**, then in the project view click **+ New → Docker Image** →
-enter `ghcr.io/libredb/libredb-studio:0.9.22`, then configure the service to
+enter `ghcr.io/libredb/libredb-studio:0.14.1`, then configure the service to
 match [`template.json`](./template.json):
 
 - **Networking:** enable a public domain, target port `3000`.

--- a/deploy/railway/template.json
+++ b/deploy/railway/template.json
@@ -8,7 +8,7 @@
       "name": "libredb-studio",
       "icon": "https://raw.githubusercontent.com/libredb/libredb-studio/main/deploy/railway/libredb-studio.png",
       "source": {
-        "image": "ghcr.io/libredb/libredb-studio:0.9.22"
+        "image": "ghcr.io/libredb/libredb-studio:0.14.1"
       },
       "networking": {
         "public": true,

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -454,11 +454,14 @@ channels:
       docs: deploy/dokploy/README.md
     pin:
       strategy: remote_file
-      url: https://raw.githubusercontent.com/Dokploy/templates/main/blueprints/libredb-studio/docker-compose.yml
+      url: https://raw.githubusercontent.com/Dokploy/templates/canary/blueprints/libredb-studio/docker-compose.yml
       extract: 'libredb-studio:(\d+\.\d+\.\d+)'
       note: The blueprint serves 0.9.59, bumped there by Dokploy/templates#1039 (merged 2026-08-03).
         Every bump is an upstream pull request a maintainer has to merge, so this pin drifts behind
-        the release by design and the drift row is the reminder to open the next one.
+        the release by design and the drift row is the reminder to open the next one. That repo's
+        default branch is `canary`, not main, and both of the pull requests merged there for this
+        app (931 and 1039) targeted it, so the pin URL and any bump PR must use `canary`. This URL
+        read `main` until now, which happened to report the same version and so hid the mistake.
 
   - id: cosmos
     name: Cosmos servapp marketplace

--- a/fly.toml
+++ b/fly.toml
@@ -8,7 +8,7 @@ app = 'libredb-studio'
 primary_region = 'ams'
 
 [build]
-  image = 'ghcr.io/libredb/libredb-studio:0.9.59'
+  image = 'ghcr.io/libredb/libredb-studio:0.14.1'
 
 [env]
   NEXT_PUBLIC_AUTH_PROVIDER = 'local'


### PR DESCRIPTION
Every image tag this repository owns was still on an old release while we ship 0.14.1. Users deploy straight from these files, so they were being handed a version we stopped shipping months ago.

| File | Was | Now |
|---|---|---|
| `fly.toml` | 0.9.59 | 0.14.1 |
| `deploy/railway/template.json` | 0.9.22 | 0.14.1 |
| `deploy/railway/README.md` | 0.9.22 | 0.14.1 |
| `deploy/railway/PUBLISH.md` | 0.9.22 | 0.14.1 |
| `deploy/digitalocean/droplet/template.pkr.hcl` | 0.9.59 | 0.14.1 |
| `deploy/digitalocean/README.md` | 0.9.59 | 0.14.1 |
| `.github/workflows/do-packer-build.yml` | 0.9.59 | 0.14.1 |

The three Railway files are exactly the `pin.files` set that `distribution/channels.yaml` lists for the railway-template channel, and `fly.toml` is the whole set for fly-io, so both channels move together as the config requires. The DigitalOcean files and the packer default are the same version string in its remaining places, none of which has a pin guard behind it. The workflow change touches only the `workflow_dispatch` default and the example in two messages; the input stays `required: true`, the semver check is untouched, and nothing runs that workflow except a person pressing Run.

## The dokploy pin was reading the wrong branch

`distribution/channels.yaml` pointed the dokploy pin at `Dokploy/templates` on `main`. That repository default-branches on `canary`, and both pull requests merged there for this app, 931 and 1039, targeted `canary`. Both branches happen to carry the same version today, which is why the wrong branch never showed up as an error. The pin now reads `canary`, and the note says so, because the next bump PR has to target that branch as well.

## Evidence

`node scripts/distribution-check.mjs` before:

```
| DRIFT | railway-template | 2 | 0.9.22 | 0.14.1 | on_demand |
| DRIFT | fly-io | 2 | 0.9.59 | 0.14.1 | on_demand |
```

after:

```
| OK | railway-template | 2 | 0.14.1 | 0.14.1 | on_demand |
| OK | fly-io | 2 | 0.14.1 | 0.14.1 | on_demand |
```

`--strict` is not evidence here and exits 0 either way: `strictFailures()` gates only local_file pins whose SLA is `every_release`, and both of these are `on_demand`. The report rows above are the real check.

The tag resolves on the registry: a manifest request for `ghcr.io/libredb/libredb-studio:0.14.1` returns 200, and an invented tag returns 404 on the same call.

Green locally on a clean clone: `channels:showcase:check`, `readme:check`, `security:check`, `format`, `lint`, `typecheck`, `knip`, `chart:check`, `distribution:check`, `build`, `build:lib`, `attw`, and `bash tests/run-core.sh` reporting all 384 core test files passed.

## Manual step after merge

Merging this does not change what the Railway template page serves. That template lives in the Railway dashboard and is not built from this repository. Someone with access has to open it, set the `libredb-studio` service source image to `ghcr.io/libredb/libredb-studio:0.14.1`, and publish. Until then the dashboard still serves 0.9.22 while `template.json` says 0.14.1. The steps are in `deploy/railway/PUBLISH.md`. Fly needs no such step, since users deploy from `fly.toml` here.

## Not included

`CONTRIBUTING.md` still omits Helm from its prerequisites, which is why `bun run test` fails 11 helm chart test files on a fresh clone until `helm dependency build charts/libredb-studio` is run. That is issue #570 and it is curated for Hacktoberfest, so it is left for whoever claims it.