### PR TITLE
test(env): match the shape-2 comment to the regex, and give the boundary test a control

### DIFF
--- a/tests/unit/env-documentation.test.ts
+++ b/tests/unit/env-documentation.test.ts
@@ -22,8 +22,11 @@
  *   1. `const X = "NAME"` (exported or not), then `process.env[X]` -- the
  *      per-name aliases in `src/lib/agent/config.ts`;
  *   2. an object field whose value is a bare uppercase string literal, then
- *      `process.env[<expr>.field]` -- the rate-limit bucket table in
- *      `src/lib/api/rate-limit.ts`, read as `process.env[spec.maxVar]`.
+ *      `process.env[<identifier>.field]` -- exactly one bare identifier before
+ *      the `.field`, as in the rate-limit bucket table's `process.env[spec.maxVar]`
+ *      (`src/lib/api/rate-limit.ts`). A deeper receiver -- `process.env[a.b.field]`
+ *      or `process.env[arr[0].field]` -- is not matched; nothing in `src/` is in
+ *      that shape today.
  *
  * What stays out of scope: a name that reaches `process.env[...]` as a function
  * argument or parameter, because resolving it needs a call graph and a regex
@@ -87,7 +90,8 @@ const readNames = (): string[] => {
   // Shape 1: `const X = "NAME"` / `export const X = "NAME"`, then `process.env[X]`.
   const constDeclPattern = new RegExp(`(?:export\\s+)?const\\s+(${IDENT})\\s*=\\s*"(${ENV_NAME})"`, "g");
   const constReadPattern = new RegExp(`process[.]env[?]?\\[(${IDENT})\\]`, "g");
-  // Shape 2: `field: "NAME"`, then `process.env[<expr>.field]` (the bucket table).
+  // Shape 2: `field: "NAME"`, then `process.env[<identifier>.field]` -- one bare
+  // identifier before `.field` (the bucket table); a deeper receiver is not matched.
   const fieldDeclPattern = new RegExp(`(${IDENT})\\s*:\\s*"(${ENV_NAME})"`, "g");
   const fieldReadPattern = new RegExp(`process[.]env[?]?\\[${IDENT}[.](${IDENT})\\]`, "g");
 
@@ -174,6 +178,9 @@ describe("environment variable documentation", () => {
     // graph. When that stops being true, this test is the reminder to widen the
     // extractor rather than a silent gain.
     const names = new Set(readNames());
+    // Control: a negative-only test passes on an empty set, so anchor it to a
+    // name the extractor must always find before trusting the absences below.
+    expect(names.has("JWT_SECRET")).toBe(true);
     for (const name of ["LLM_PROVIDER", "LLM_API_KEY", "LLM_MODEL", "LLM_API_URL", "MY_DB_PASSWORD"]) {
       expect(names.has(name)).toBe(false);
     }


### PR DESCRIPTION

The two optional follow-ups from the #649 review, both surfaced by probing the guard rather than by any defect in it. Quoting the review:

> The header comment says `process.env[<expr>.field]`, but `fieldReadPattern` only accepts a bare identifier between the brackets, so `process.env[a.inner.field]` and `process.env[arr[0].field]` are missed silently. [...] the comment is the guard's contract, so it should say what the regex actually accepts.

> The new boundary test still passes when `readNames()` returns `[]`. [...] the negative test does not carry its own control. One line inside it, `expect(names.has("JWT_SECRET")).toBe(true)`, makes it stand on its own in the file's own idiom.

## Type of Change

- [x] Test addition or update
- [x] Documentation update (in-file comments)

## Related Issue

Follow-up to #649 (no separate issue filed).

## Changes Made

- **Comment matches the regex.** Header and inline comments described shape 2 as `process.env[<expr>.field]`. `fieldReadPattern` accepts only a single bare identifier before `.field`, so `process.env[a.b.field]` and `process.env[arr[0].field]` are not matched. Both comments now say `process.env[<identifier>.field]`, state the "exactly one bare identifier" constraint, and name the deeper shapes that are skipped. Nothing in `src/` is in the deeper shape today, so this is wording only — no behaviour change.
- **Boundary test carries its own control.** `#609 boundary: a name reached through a function argument stays undiscovered` asserted only absences, so it passed on an empty `readNames()`. Added `expect(names.has("JWT_SECRET")).toBe(true)` before the absence checks — the same anchor the file's first test uses — so the negative test is no longer vacuous on its own.

One test file; comments and one assertion; no product code.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass — same ~255 pre-existing environmental failures in `bun test tests/unit` (no `helm`, native-addon ABI mismatch) with and without this change; `8404 pass` unchanged.

Ran locally: `bun run format`, `bun run lint` (0 errors), `bun run typecheck` — all clean. `bun test tests/unit/env-documentation.test.ts` — 8 pass / 0 fail (50 `expect()` calls, +1 from the new control).

**Mutation-checked the control.** Temporarily made `readNames()` `return []`: the boundary test now fails at the new line (`expect(names.has("JWT_SECRET")).toBe(true)` → `Expected: true, Received: false`), where before this change every assertion in it was `.toBe(false)` and passed on the empty set. Reverted after.

### Test Environment
- **LibreDB Studio Version**: `main` @ 1b60ec1e
- **Browser**: n/a (test-only change)
- **OS**: Windows 11
- **Node.js/Bun Version**: Bun 1.4.2
- **Database Type**: n/a

## Screenshots (if applicable)

n/a

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (the guard's header/inline comments)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (#649 is merged)