### PR TITLE
dev: add contributor devcontainer and clarify CI gate

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:5-24-bookworm
+
+# Keep these versions aligned with .github/workflows/ci.yml.
+ARG BUN_VERSION=1.4.2
+ARG HELM_VERSION=4.1.3
+
+USER root
+
+# The standalone Windows archive tests invoke 7z on every development platform.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends p7zip-full \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install --global --allow-scripts=bun bun@${BUN_VERSION}
+
+RUN set -eu; \
+    arch="$(dpkg --print-architecture)"; \
+    archive="helm-v${HELM_VERSION}-linux-${arch}.tar.gz"; \
+    cd /tmp; \
+    curl -fsSLO "https://get.helm.sh/${archive}"; \
+    curl -fsSLO "https://get.helm.sh/${archive}.sha256sum"; \
+    sha256sum --check "${archive}.sha256sum"; \
+    tar -xzf "${archive}"; \
+    install -m 0755 "linux-${arch}/helm" /usr/local/bin/helm; \
+    rm -rf "linux-${arch}" "${archive}" "${archive}.sha256sum"
+
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "LibreDB Studio",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteUser": "node",
+  "mounts": [
+    "source=libredb-studio-${devcontainerId}-node-modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+  ],
+  "forwardPorts": [3000],
+  "postCreateCommand": "sudo chown node:node node_modules && bun install --frozen-lockfile && helm repo add bitnami https://charts.bitnami.com/bitnami --timeout 5m && helm dependency build charts/libredb-studio --skip-refresh"
+}

--- a/.github/curated-issue-footer.md
+++ b/.github/curated-issue-footer.md
@@ -1,0 +1,14 @@
+Curated for Hacktoberfest 2026. Comment to claim the issue before you start so two people do not
+work on the same change. A PR must reference the issue and include tests for executable changes;
+see [CONTRIBUTING.md](https://github.com/libredb/libredb-studio/blob/main/CONTRIBUTING.md).
+Run `bun run test`, never bare `bun test`, so component
+tests use their isolated execution groups. The 100% line-coverage gate must stay green.
+
+**CI is the merge gate.** If you cannot run a command locally, list that command and the reason
+under a `Testing` heading in your PR body; submit the PR, and a maintainer will approve the fork's
+workflow run so CI can verify it. You do not need to withdraw correct work because a local tool
+is unavailable.
+
+If your sandbox can reach the npm registry, `npm install -g bun` is another way to install Bun.
+Helm is only needed for the chart tests in the test suite. The repository's devcontainer provides
+Bun and Helm and installs the JavaScript and chart dependencies automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,13 +45,22 @@ Feature suggestions are welcome! Please provide:
    lines lands with its tests in the same PR. The CI gate is 100% line coverage
    (`scripts/check-coverage.mjs` fails the required `Unit & Integration Tests` job below it), so a
    PR without tests cannot merge no matter how small the change.
-4. **Run the local gate before pushing.** It mirrors the required CI checks:
+4. **Run the checks locally when your environment supports them.** They mirror the required CI checks:
 
    ```bash
    bun run format && bun run lint && bun run typecheck && bun run knip \
      && bun run readme:check && bun run chart:check && bun run channels:showcase:check \
      && bun run security:check && bun run test && bun run build
    ```
+
+   **CI is the merge gate.** If you cannot run a command locally, list that command and the reason
+   under a `Testing` heading in your PR body; submit the PR, and a maintainer will approve the fork's
+   workflow run so CI can verify it. You do not need to withdraw correct work because a local tool
+   is unavailable.
+
+   If your sandbox can reach the npm registry, `npm install -g bun` is another way to install Bun.
+   Helm is only needed for the chart tests in the test suite, not for editing the app or running
+   typecheck. The [devcontainer setup](#devcontainer--codespaces) below provides both tools.
 
    Always `bun run test`, never bare `bun test`: component tests need the isolated execution groups
    the script sets up. `bun run test:coverage && bun run coverage:check` prints the exact uncovered
@@ -139,6 +148,22 @@ complete — completeness cannot be measured in a shallow CI clone, so it stays 
 honest about being one.
 
 ## Development Setup
+
+### Devcontainer / Codespaces
+
+Open the repository in GitHub Codespaces, or use **Dev Containers: Reopen in Container** in VS Code
+with Docker running. [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) provides
+Node.js 24, Bun 1.4.2 and Helm 4.1.3, matching the required Node version and the Bun/Helm versions
+used by CI, plus 7-Zip for the packaging tests. The first creation installs the locked JavaScript
+dependencies and builds the chart's PostgreSQL dependency, so it needs access to the npm registry
+and the chart registries.
+
+JavaScript dependencies live in a container volume, keeping Linux native modules separate from
+any dependencies installed on your host and avoiding slow shared-filesystem installs on Docker Desktop.
+
+Once setup finishes, run the checks from step 4 in the container terminal. Start the app with
+`bun run dev`; the container forwards port 3000. Database containers are optional and are not
+started by this setup.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Description

The contribution guide presents local tooling as a prerequisite for submitting a PR, leaving contributors without Bun or Helm unsure how to get their work verified. Clarify that CI is the merge gate and provide a working devcontainer that installs the contributor toolchain and dependencies automatically.

## Type of Change

- [x] New feature (development environment)
- [x] Documentation update

## Related Issue

Closes #618

## Changes Made

- Preserve the existing check command chain and explain how to report unavailable commands under `Testing`, including maintainer approval of fork workflow runs.
- Store the same guidance in `.github/curated-issue-footer.md` for reuse in curated issues. Include the npm Bun installation option and explain Helm's role in chart tests.
- Add a Node 24 devcontainer with Bun 1.4.2 and Helm 4.1.3, matching CI's tool versions. Helm's downloaded archive is checksum-verified for the container's architecture.
- Include 7-Zip, required by the existing standalone archive tests.
- Install locked JavaScript dependencies and the Helm chart dependency through `postCreateCommand`. Keep `node_modules` in a container-specific volume to avoid host native-module conflicts and Docker Desktop shared-filesystem installation stalls.
- Document Codespaces/Dev Containers setup and forward port 3000.

## Testing

- [x] Built and started the actual configuration with `devcontainer up`; the complete `postCreateCommand` succeeded.
- [x] Inside that Linux arm64 container: `bun run typecheck` and `helm lint charts/libredb-studio --strict` passed.
- [x] Inside the container: all 6 existing standalone archive tests passed with its installed `7z` binary.
- [x] Full host `bun run test`: 14,505 passed, 0 failed; all 34 isolated groups passed.
- [x] Formatting, lint, typecheck, knip, README/chart/showcase/security guards, production build, library build and package type checks passed. Lint reports existing warnings and no errors.
- [x] Checked the devcontainer JSON, documentation links and shared CI-gate wording.

No new unit tests are needed for this docs/config change, as specified in the issue; validation uses the existing suite and a real container start.

### Test Environment

- LibreDB Studio 0.14.1
- Devcontainer: Linux arm64, Node 24.19.0, Bun 1.4.2, Helm 4.1.3
- Host: macOS arm64, Node 24.20.0, Bun 1.4.2, Helm 4.1.3

## Checklist

- [x] Changes follow the repository's code style.
- [x] Self-reviewed the configuration and documentation.
- [x] Both parts of the issue are implemented and verified.
- [x] No product source code, dependency lockfile or chart content changed.

## Additional Notes

The fork's GitHub Actions runs require maintainer approval. All validation listed above was completed locally before submission.
