### PR TITLE
fix(schema-diff): emit dialect-aware migration DDL

### DIFF
--- a/docs/SCHEMA_DIFF.md
+++ b/docs/SCHEMA_DIFF.md
@@ -11,7 +11,9 @@ index and constraint drops use the unconditional forms, which avoid depending on
 release's support for `IF EXISTS`. A generated migration is not an idempotent script.
 
 Removed foreign keys and indexes precede column changes, so an indexed column can be removed
-and an index name can be reused in the same table diff. Identifier quoting escapes delimiters;
+and an index name can be reused in the same table diff. Changes to an existing index's columns,
+column order or uniqueness replace its old definition; a uniqueness change can fail if existing
+data violates the new constraint. Identifier quoting escapes delimiters;
 line breaks in informational comments are flattened so metadata cannot start a SQL statement.
 
 MongoDB, Redis, LibreDB, Couchbase, Druid, Elasticsearch and OpenSearch receive an explanatory

--- a/docs/SCHEMA_DIFF.md
+++ b/docs/SCHEMA_DIFF.md
@@ -1,0 +1,62 @@
+# Generated migration SQL
+
+`generateMigrationSQL` in `src/lib/schema-diff/migration-generator.ts` converts a schema diff into
+reviewable SQL. Its dialect coverage is pinned by the exhaustive tables in
+`tests/unit/schema-diff/migration-generator.test.ts` and `migration-dialects.test.ts`.
+
+For SQL Server, migrations use `BEGIN TRANSACTION` and `COMMIT`; added columns use `ADD`, and
+index drops include `ON <table>`. Oracle uses `ADD (<definition>)`, places `DEFAULT` before
+`NOT NULL`, and emits no transaction wrapper because DDL commits implicitly. Oracle table,
+index and constraint drops use the unconditional forms, which avoid depending on a particular
+release's support for `IF EXISTS`. A generated migration is not an idempotent script.
+
+Removed foreign keys and indexes precede column changes, so an indexed column can be removed
+and an index name can be reused in the same table diff. Identifier quoting escapes delimiters;
+line breaks in informational comments are flattened so metadata cannot start a SQL statement.
+
+MongoDB, Redis, LibreDB, Couchbase, Druid, Elasticsearch and OpenSearch receive an explanatory
+comment instead of relational table DDL. Trino and ClickHouse refuse foreign-key clauses;
+Trino refuses primary keys too. Trino has no index grammar, and the diff does not retain enough
+ClickHouse index metadata to distinguish and recreate its index kinds, so those index changes
+also produce comments. Existing Cassandra and SQLite-family limitations remain explicit.
+
+Review each migration against its target: a diff does not carry original foreign-key constraint
+names, schema qualifiers, cross-table dependency order, or a general type-conversion strategy.
+Default expressions remain SQL expressions supplied by the diff; they are not parameter values.
+
+## Live regression probe
+
+The optional probe in `tests/live/schema-diff-dialects.ts` creates a fresh SQL Server database or
+Oracle user schema and removes it in `finally`. Use disposable servers on localhost. It checks:
+
+- CREATE, ADD and DROP statements, defaults, NOT NULL and foreign-key enforcement;
+- dropping an indexed foreign-key column and reusing the index name;
+- hostile line breaks and quoting in object names without modifying a sentinel row;
+- transaction rollback on SQL Server and implicit DDL commit on Oracle;
+- negative controls: the previous `ADD COLUMN` and bare `BEGIN` forms must fail.
+
+Run one engine at a time, supplying the password configured on its disposable container:
+
+```sh
+MIGRATION_PROBE_ENGINE=mssql MSSQL_TEST_PORT=11433 MSSQL_TEST_PASSWORD="$PROBE_PASSWORD" \
+  bun tests/live/schema-diff-dialects.ts
+MIGRATION_PROBE_ENGINE=oracle ORACLE_TEST_PORT=11521 ORACLE_TEST_PASSWORD="$PROBE_PASSWORD" \
+  bun tests/live/schema-diff-dialects.ts
+```
+
+The Oracle connection targets `FREEPDB1`. Both probes require credentials allowed to create and
+remove the isolated test database/schema. They are separate from `bun run test`, which needs no
+external database server.
+
+Measured on 2026-09-08 with Oracle AI Database 26ai Free 23.26.1.0.0
+(`gvenzl/oracle-free:23.26.1-slim-faststart`) and the SQL Server 15 ARM64 engine in
+Microsoft Azure SQL Edge Developer 15.0.2000.1574 (`mcr.microsoft.com/azure-sql-edge:1.0.7`).
+The SQL Server 2022 CU17 x86 container could not start under the local Mac's emulation, so the
+live T-SQL measurement uses the ARM engine above; it is not a SQL Server 2022 certification.
+
+Grammar references:
+[SQL Server ALTER TABLE](https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql),
+[SQL Server DROP INDEX](https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-index-transact-sql),
+[Oracle ALTER TABLE](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/ALTER-TABLE.html),
+[Trino SQL statements](https://trino.io/docs/current/sql.html), and
+[ClickHouse index examples](https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/guides/best-practices/skipping-indexes-examples.md).

--- a/src/lib/schema-diff/diff-engine.ts
+++ b/src/lib/schema-diff/diff-engine.ts
@@ -126,13 +126,10 @@ function diffIndexes(sourceIndexes: IndexSchema[], targetIndexes: IndexSchema[])
     if (!targetIdx) continue;
 
     const changes: string[] = [];
-    // Code-point sort (not localeCompare) so this equality check is deterministic
-    // and locale-independent — see columnKey above.
-    const sortedJoin = (cols: string[]) => [...cols].sort().join(",");
-    const sourceColStr = sortedJoin(sourceIdx.columns);
-    const targetColStr = sortedJoin(targetIdx.columns);
-
-    if (sourceColStr !== targetColStr) {
+    // Index columns are ordered: (a, b) and (b, a) have different leading keys.
+    // Serialize the array instead of joining, so commas inside identifiers cannot
+    // make distinct column lists compare equal. Neither input is mutated.
+    if (JSON.stringify(sourceIdx.columns) !== JSON.stringify(targetIdx.columns)) {
       changes.push(`Columns changed: (${sourceIdx.columns.join(", ")}) → (${targetIdx.columns.join(", ")})`);
     }
     if (sourceIdx.unique !== targetIdx.unique) {

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -1,49 +1,14 @@
 /**
- * Migration SQL from a schema diff.
+ * Migration SQL from a schema diff. Dialect-specific DDL is emitted where the
+ * engine supports it; otherwise a comment names the limitation (#284).
  *
- * **Only part of this generator is dialect-aware, and the rest emits one shape for
- * everyone (#284).** Stated here because the difference is invisible from a call
- * site: `generateMigrationSQL(diff, dialect)` takes a dialect either way.
+ * SQL Server uses BEGIN TRANSACTION; Oracle DDL commits implicitly, so it has
+ * no wrapper. Oracle drops omit version-dependent IF EXISTS clauses. The live
+ * regression probe is tests/live/schema-diff-dialects.ts.
  *
- * - Dialect-aware: the modified-column path, which branches per engine and names
- *   the limitation in a comment where an engine has no such statement (#269); the
- *   `ADD` / `DROP` keyword, which CQL spells without `COLUMN`; `CREATE TABLE`,
- *   which is refused outright for Cassandra (see CASSANDRA_NO_CREATE_TABLE); the
- *   transaction wrapper (see NO_TRANSACTION_WRAPPER), which twelve of the
- *   seventeen type ids do without, each for its own named reason; and the foreign-key
- *   statements, which CQL has no grammar for at all and which SQLite's grammar
- *   takes only inside `CREATE TABLE` (see FOREIGN_KEY_ONLY_IN_CREATE_TABLE).
- * - Not yet: MSSQL and Oracle's own transaction-wrapper forms (`BEGIN;` is not
- *   `BEGIN TRANSACTION;`, and Oracle DDL auto-commits regardless of what wraps
- *   it) — both still get today's PostgreSQL-shaped `BEGIN;`/`COMMIT;`, because
- *   settling their real forms wants checking against a live server first, the
- *   way #264 and #265 did, and that measurement is the tracked follow-up to this
- *   fix rather than part of it.
- *
- *   Two more MSSQL/Oracle questions surfaced while checking the rest of this
- *   docstring's claims, and both belong in that same follow-up rather than
- *   being guessed at here: the `ADD COLUMN` keyword — the modified-column path
- *   a few lines below already spells Oracle's own ALTER as `MODIFY (...)`,
- *   with no `COLUMN` keyword in its grammar at all, and MSSQL's documented
- *   `ADD` clause has none either, yet the generic added-column branch hands
- *   both the same literal `ADD COLUMN` every other engine gets; and whether
- *   `DROP TABLE`/`DROP INDEX`/`DROP CONSTRAINT ... IF EXISTS` are valid there
- *   at all — Oracle had no conditional DDL clause before 23ai. Both are
- *   internal inconsistencies or open questions this pass surfaced rather than
- *   fresh guesses, but neither is fixed here.
- *
- *   For every OTHER dialect, `ADD`/`DROP COLUMN` and the index/FK `IF EXISTS`
- *   fallbacks were checked against the same questions and found to already
- *   agree with each one's documented grammar via the existing
- *   Cassandra/SQLite/libSQL/DuckDB/MySQL branches, so nothing there needed
- *   changing in this pass.
- *
- * Cassandra is ahead of MSSQL and Oracle here for a reason worth stating (see
- * NO_TRANSACTION_WRAPPER for the measurement): it is a dialect whose OTHER
- * statements were each measured against a live server too, so its wrapper and FK
- * lines would have been the only unrunnable lines in an otherwise runnable
- * migration. For MSSQL and Oracle they are one problem among several, and the
- * emitted forms still want checking against a live server first.
+ * A diff is not a complete migration plan: source constraint names, schema
+ * qualifiers and cross-table dependency order are not recorded here. Review
+ * the generated SQL before executing it against the target database.
  */
 import type { DatabaseType } from "@/lib/types";
 // The shared quoter, which also escapes an embedded closing quote character — this
@@ -204,21 +169,11 @@ const NO_COLUMN_MODIFICATION: Partial<Record<DatabaseType, { label: string; reas
  * exists; and `clickhouse`'s transaction support is experimental and setting-gated rather
  * than a safe default — this set is what removes it from the wrapper it used to inherit.
  *
- * What none of these nine reasons is: "this generator emits nothing for that id anyway".
- * It has no capability gate - `supportsCreateTable` is read by the schema explorer, not
- * here - so its added-table branch emits a real `CREATE TABLE` for every id except
- * `cassandra` (see CASSANDRA_NO_CREATE_TABLE). The wrapper this set removes was bracketing
- * runnable DDL for these ids, not just comments, which is what makes removing it a fix.
- * `tests/unit/schema-diff/migration-generator.test.ts` drives the coverage table over an
- * added-table diff as well as a modified-table one so that stays measured.
- *
- * `mssql` and `oracle` are deliberately ABSENT from this set — they still get the
- * PostgreSQL-shaped wrapper, UNCHANGED, because their real forms (`BEGIN TRANSACTION;`
- * for MSSQL; whether Oracle needs a wrapper at all, given DDL there auto-commits) want
- * checking against a live server first, the way #264 and #265 were, and remain tracked
- * in the module docstring above as the follow-up this PR does not attempt.
+ * Oracle DDL commits implicitly and BEGIN opens a PL/SQL block, not a transaction.
+ * SQL Server is handled separately with BEGIN TRANSACTION.
  */
 const NO_TRANSACTION_WRAPPER: ReadonlySet<DatabaseType> = new Set<DatabaseType>([
+  "oracle",
   "sqlite",
   "libsql",
   "cassandra",
@@ -233,8 +188,40 @@ const NO_TRANSACTION_WRAPPER: ReadonlySet<DatabaseType> = new Set<DatabaseType>(
   "trino",
 ]);
 
+// These engines cannot apply a relational table diff through SQL. In particular,
+// Couchbase has index/collection DDL, but no CREATE/ALTER TABLE column grammar.
+// The reasons are already documented and tested by the modified-column path.
+const NO_TABLE_DDL: ReadonlySet<DatabaseType> = new Set<DatabaseType>([
+  "mongodb",
+  "redis",
+  "libredb",
+  "couchbase",
+  "druid",
+  "elasticsearch",
+  "opensearch",
+]);
+
+// IndexDiff carries column names/uniqueness, not ClickHouse's index expression,
+// kind and granularity. It also cannot distinguish its synthetic sorting-key rows.
+// Trino has no index or foreign-key grammar (docs/providers/trino.md §3.8).
+const NO_PORTABLE_INDEX_DDL: Partial<Record<DatabaseType, string>> = {
+  clickhouse:
+    "ClickHouse: Cannot generate index DDL. The diff does not record the index kind, expression or granularity; write the index change by hand.",
+  trino: "Trino: Cannot generate index DDL. Indexes belong to the connector's underlying system, not Trino SQL.",
+};
+const NO_FOREIGN_KEYS: Partial<Record<DatabaseType, string>> = {
+  clickhouse: "ClickHouse",
+  trino: "Trino",
+};
+
+// Object names are untrusted metadata. Quoting protects SQL identifiers, but a
+// newline in a -- comment can start an executable statement outside that quote.
+function commentName(name: string): string {
+  return name.replace(/[\r\n\u2028\u2029]/g, " ");
+}
+
 function generateColumnDef(col: ColumnDiff, dialect: DatabaseType): string {
-  const type = col.targetType || col.sourceType || "TEXT";
+  const type = col.targetType || col.sourceType || (dialect === "oracle" ? "VARCHAR2(255)" : "TEXT");
   // A CQL column definition is a name and a type, full stop. Measured on 5.0.9:
   // `name TEXT NOT NULL`, `name TEXT UNIQUE` and `name TEXT DEFAULT 'x'` are each
   // "no viable alternative at input" - none of the three qualifiers exists in the
@@ -243,7 +230,9 @@ function generateColumnDef(col: ColumnDiff, dialect: DatabaseType): string {
   if (dialect === "cassandra") return `${escapeIdentifier(col.columnName, dialect)} ${type}`;
   const nullable = col.targetNullable === false ? " NOT NULL" : "";
   const defaultVal = col.targetDefault ? ` DEFAULT ${col.targetDefault}` : "";
-  return `${escapeIdentifier(col.columnName, dialect)} ${type}${nullable}${defaultVal}`;
+  // Oracle's column grammar puts DEFAULT before inline constraints such as NOT NULL.
+  const modifiers = dialect === "oracle" ? `${defaultVal}${nullable}` : `${nullable}${defaultVal}`;
+  return `${escapeIdentifier(col.columnName, dialect)} ${type}${modifiers}`;
 }
 
 /**
@@ -323,7 +312,7 @@ function generateCreateTable(table: TableDiff, dialect: DatabaseType): string {
 
   // Declined whole, indexes and foreign keys included: there would be no table for them to attach to.
   if (dialect === "cassandra") {
-    return `-- Apache Cassandra: Cannot generate CREATE TABLE for ${id}. ${CASSANDRA_NO_CREATE_TABLE}`;
+    return `-- Apache Cassandra: Cannot generate CREATE TABLE for ${commentName(id)}. ${CASSANDRA_NO_CREATE_TABLE}`;
   }
 
   const colDefs = table.columns.filter((c) => c.action === "added").map((c) => `  ${generateColumnDef(c, dialect)}`);
@@ -338,7 +327,7 @@ function generateCreateTable(table: TableDiff, dialect: DatabaseType): string {
 
   lines.push(`CREATE TABLE ${id} (`);
   lines.push(colDefs.join(",\n"));
-  if (pkCols.length > 0) {
+  if (pkCols.length > 0 && dialect !== "trino") {
     lines.push(`,  PRIMARY KEY (${pkCols.join(", ")})`);
   }
   if (keyIsTableConstraint) {
@@ -360,11 +349,19 @@ function generateCreateTable(table: TableDiff, dialect: DatabaseType): string {
     });
   }
   lines.push(");");
+  if (pkCols.length > 0 && dialect === "trino") {
+    lines.push("-- Trino: Cannot declare a primary key. Trino SQL has no primary-key constraint.");
+  }
 
   // Indexes
   table.indexes
     .filter((i) => i.action === "added")
     .forEach((idx) => {
+      const refusal = NO_PORTABLE_INDEX_DDL[dialect];
+      if (refusal) {
+        lines.push(`-- ${refusal}`);
+        return;
+      }
       const unique = idx.targetUnique ? "UNIQUE " : "";
       const cols = (idx.targetColumns || []).map((c) => escapeIdentifier(c, dialect)).join(", ");
       lines.push(`CREATE ${unique}INDEX ${escapeIdentifier(idx.indexName, dialect)} ON ${id} (${cols});`);
@@ -374,6 +371,11 @@ function generateCreateTable(table: TableDiff, dialect: DatabaseType): string {
   // for everyone else this separate ALTER is the shape that has always been emitted here.
   if (!keyIsTableConstraint) {
     addedForeignKeys.forEach((fk) => {
+      const label = NO_FOREIGN_KEYS[dialect];
+      if (label) {
+        lines.push(`-- ${label}: Cannot add a foreign key. The engine has no foreign-key constraint.`);
+        return;
+      }
       lines.push(
         `ALTER TABLE ${id} ADD CONSTRAINT ${escapeIdentifier(`fk_${table.tableName}_${fk.columnName}`, dialect)} FOREIGN KEY (${escapeIdentifier(fk.columnName, dialect)}) REFERENCES ${escapeIdentifier(fk.targetReferencedTable || "", dialect)}(${escapeIdentifier(fk.targetReferencedColumn || "", dialect)});`,
       );
@@ -384,14 +386,73 @@ function generateCreateTable(table: TableDiff, dialect: DatabaseType): string {
 }
 
 function generateDropTable(table: TableDiff, dialect: DatabaseType): string {
-  return `DROP TABLE IF EXISTS ${escapeIdentifier(table.tableName, dialect)};`;
+  const conditional = dialect === "oracle" ? "" : " IF EXISTS";
+  return `DROP TABLE${conditional} ${escapeIdentifier(table.tableName, dialect)};`;
 }
 
 function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
   const lines: string[] = [];
   const id = escapeIdentifier(table.tableName, dialect);
 
-  lines.push(`-- Alter table: ${table.tableName}`);
+  lines.push(`-- Alter table: ${commentName(table.tableName)}`);
+
+  // Drop recorded dependencies before altering their columns or reusing their names.
+  // Removed foreign keys
+  table.foreignKeys
+    .filter((fk) => fk.action === "removed")
+    .forEach((fk) => {
+      const label = NO_FOREIGN_KEYS[dialect];
+      if (label) {
+        lines.push(`-- ${label}: Cannot drop a foreign key. The engine has no foreign-key constraint.`);
+        return;
+      }
+      const constraintName = escapeIdentifier(`fk_${table.tableName}_${fk.columnName}`, dialect);
+      if (dialect === "mysql") {
+        lines.push(`ALTER TABLE ${id} DROP FOREIGN KEY ${constraintName};`);
+      } else if (dialect === "sqlite") {
+        lines.push(`-- SQLite: Cannot drop foreign key directly. Requires table recreation.`);
+      } else if (dialect === "libsql") {
+        // The generic `DROP CONSTRAINT` branch below is not parseable here, measured on
+        // sqld 0.24.33: `ALTER TABLE t DROP CONSTRAINT fk_x` is "near CONSTRAINT …
+        // syntax error". Same limit as SQLite, named separately so the comment names
+        // the engine the reader connected to.
+        lines.push(`-- libSQL: Cannot drop a foreign key directly. Requires table recreation.`);
+      } else if (dialect === "duckdb") {
+        // The generic branch below is refused here too, measured on v1.5.5: `ALTER
+        // TABLE t DROP CONSTRAINT IF EXISTS fk_x` is "Not implemented Error: No
+        // support for that ALTER TABLE option yet!" - and a `Not implemented` is not
+        // an `IF EXISTS` no-op, so the line would fail a migration rather than skip.
+        lines.push(`-- DuckDB: Cannot drop a foreign key directly. Requires table recreation.`);
+      } else if (dialect === "cassandra") {
+        // `DROP CONSTRAINT IF EXISTS fk_x` is "mismatched input 'IF' expecting EOF"
+        // (measured), and dropping what was never declarable is not a statement.
+        lines.push(`-- Apache Cassandra: Cannot drop a foreign key. CQL never declared one.`);
+      } else if (dialect === "oracle") {
+        lines.push(`ALTER TABLE ${id} DROP CONSTRAINT ${constraintName};`);
+      } else {
+        lines.push(`ALTER TABLE ${id} DROP CONSTRAINT IF EXISTS ${constraintName};`);
+      }
+    });
+
+  // Removed indexes
+  table.indexes
+    .filter((i) => i.action === "removed")
+    .forEach((idx) => {
+      const refusal = NO_PORTABLE_INDEX_DDL[dialect];
+      if (refusal) {
+        lines.push(`-- ${refusal}`);
+        return;
+      }
+      if (dialect === "mysql") {
+        lines.push(`DROP INDEX ${escapeIdentifier(idx.indexName, dialect)} ON ${id};`);
+      } else if (dialect === "mssql") {
+        lines.push(`DROP INDEX IF EXISTS ${escapeIdentifier(idx.indexName, dialect)} ON ${id};`);
+      } else if (dialect === "oracle") {
+        lines.push(`DROP INDEX ${escapeIdentifier(idx.indexName, dialect)};`);
+      } else {
+        lines.push(`DROP INDEX IF EXISTS ${escapeIdentifier(idx.indexName, dialect)};`);
+      }
+    });
 
   // Added columns
   table.columns
@@ -400,8 +461,13 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
       // CQL spells it without the COLUMN keyword, measured on 5.0.9: `ADD COLUMN extra
       // TEXT` is "line 1:42 mismatched input 'TEXT' expecting EOF" while `ADD extra
       // text` succeeds.
-      const keyword = dialect === "cassandra" ? "ADD" : "ADD COLUMN";
-      lines.push(`ALTER TABLE ${id} ${keyword} ${generateColumnDef(col, dialect)};`);
+      const definition = generateColumnDef(col, dialect);
+      if (dialect === "oracle") {
+        lines.push(`ALTER TABLE ${id} ADD (${definition});`);
+      } else {
+        const keyword = dialect === "cassandra" || dialect === "mssql" ? "ADD" : "ADD COLUMN";
+        lines.push(`ALTER TABLE ${id} ${keyword} ${definition};`);
+      }
     });
 
   // Removed columns
@@ -409,7 +475,9 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
     .filter((c) => c.action === "removed")
     .forEach((col) => {
       if (dialect === "sqlite") {
-        lines.push(`-- SQLite: Cannot drop column "${col.columnName}" directly. Requires table recreation.`);
+        lines.push(
+          `-- SQLite: Cannot drop column "${commentName(col.columnName)}" directly. Requires table recreation.`,
+        );
       } else {
         // Same measurement in the other direction: `DROP COLUMN extra` is "mismatched
         // input 'extra' expecting EOF" on CQL, while `DROP extra` succeeds.
@@ -424,7 +492,9 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
     .filter((c) => c.action === "modified")
     .forEach((col) => {
       if (dialect === "sqlite") {
-        lines.push(`-- SQLite: Cannot alter column "${col.columnName}" type directly. Requires table recreation.`);
+        lines.push(
+          `-- SQLite: Cannot alter column "${commentName(col.columnName)}" type directly. Requires table recreation.`,
+        );
       } else if (dialect === "mysql") {
         const type = col.targetType || col.sourceType || "TEXT";
         const nullable = col.targetNullable === false ? " NOT NULL" : " NULL";
@@ -468,12 +538,14 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
             lines.push(`ALTER TABLE ${id} MODIFY COLUMN ${column} REMOVE ${kind};`);
           } else {
             lines.push(
-              `-- ClickHouse: Cannot remove the ${kind} property of column "${col.columnName}". REMOVE accepts DEFAULT, MATERIALIZED or ALIAS only; recreate the column.`,
+              `-- ClickHouse: Cannot remove the ${kind} property of column "${commentName(col.columnName)}". REMOVE accepts DEFAULT, MATERIALIZED or ALIAS only; recreate the column.`,
             );
           }
         }
       } else if (inexpressible) {
-        lines.push(`-- ${inexpressible.label}: Cannot alter column "${col.columnName}". ${inexpressible.reason}`);
+        lines.push(
+          `-- ${inexpressible.label}: Cannot alter column "${commentName(col.columnName)}". ${inexpressible.reason}`,
+        );
       } else {
         // PostgreSQL
         if (col.sourceType !== col.targetType) {
@@ -504,26 +576,25 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
   table.indexes
     .filter((i) => i.action === "added")
     .forEach((idx) => {
+      const refusal = NO_PORTABLE_INDEX_DDL[dialect];
+      if (refusal) {
+        lines.push(`-- ${refusal}`);
+        return;
+      }
       const unique = idx.targetUnique ? "UNIQUE " : "";
       const cols = (idx.targetColumns || []).map((c) => escapeIdentifier(c, dialect)).join(", ");
       lines.push(`CREATE ${unique}INDEX ${escapeIdentifier(idx.indexName, dialect)} ON ${id} (${cols});`);
-    });
-
-  // Removed indexes
-  table.indexes
-    .filter((i) => i.action === "removed")
-    .forEach((idx) => {
-      if (dialect === "mysql") {
-        lines.push(`DROP INDEX ${escapeIdentifier(idx.indexName, dialect)} ON ${id};`);
-      } else {
-        lines.push(`DROP INDEX IF EXISTS ${escapeIdentifier(idx.indexName, dialect)};`);
-      }
     });
 
   // Added foreign keys
   table.foreignKeys
     .filter((fk) => fk.action === "added")
     .forEach((fk) => {
+      const label = NO_FOREIGN_KEYS[dialect];
+      if (label) {
+        lines.push(`-- ${label}: Cannot add a foreign key. The engine has no foreign-key constraint.`);
+        return;
+      }
       const constraintName = escapeIdentifier(`fk_${table.tableName}_${fk.columnName}`, dialect);
       // Cassandra has no foreign key to add: `ADD CONSTRAINT ... FOREIGN KEY` is
       // "mismatched input 'FOREIGN' expecting EOF" (measured on 5.0.9), which is also
@@ -533,7 +604,7 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
       // connection's, so a relational schema's keys arrive with a CQL dialect.
       if (dialect === "cassandra") {
         lines.push(
-          `-- Apache Cassandra: Cannot add a foreign key on ${escapeIdentifier(fk.columnName, dialect)}. The clause is not in CQL's grammar; enforce the relationship in the application.`,
+          `-- Apache Cassandra: Cannot add a foreign key on ${commentName(escapeIdentifier(fk.columnName, dialect))}. The clause is not in CQL's grammar; enforce the relationship in the application.`,
         );
         return;
       }
@@ -548,43 +619,13 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
       const declined = FOREIGN_KEY_ONLY_IN_CREATE_TABLE[dialect];
       if (declined) {
         lines.push(
-          `-- ${declined.label}: Cannot add a foreign key on ${escapeIdentifier(fk.columnName, dialect)}. ${declined.reason}`,
+          `-- ${declined.label}: Cannot add a foreign key on ${commentName(escapeIdentifier(fk.columnName, dialect))}. ${declined.reason}`,
         );
         return;
       }
       lines.push(
         `ALTER TABLE ${id} ADD CONSTRAINT ${constraintName} FOREIGN KEY (${escapeIdentifier(fk.columnName, dialect)}) REFERENCES ${escapeIdentifier(fk.targetReferencedTable || "", dialect)}(${escapeIdentifier(fk.targetReferencedColumn || "", dialect)});`,
       );
-    });
-
-  // Removed foreign keys
-  table.foreignKeys
-    .filter((fk) => fk.action === "removed")
-    .forEach((fk) => {
-      const constraintName = escapeIdentifier(`fk_${table.tableName}_${fk.columnName}`, dialect);
-      if (dialect === "mysql") {
-        lines.push(`ALTER TABLE ${id} DROP FOREIGN KEY ${constraintName};`);
-      } else if (dialect === "sqlite") {
-        lines.push(`-- SQLite: Cannot drop foreign key directly. Requires table recreation.`);
-      } else if (dialect === "libsql") {
-        // The generic `DROP CONSTRAINT` branch below is not parseable here, measured on
-        // sqld 0.24.33: `ALTER TABLE t DROP CONSTRAINT fk_x` is "near CONSTRAINT …
-        // syntax error". Same limit as SQLite, named separately so the comment names
-        // the engine the reader connected to.
-        lines.push(`-- libSQL: Cannot drop a foreign key directly. Requires table recreation.`);
-      } else if (dialect === "duckdb") {
-        // The generic branch below is refused here too, measured on v1.5.5: `ALTER
-        // TABLE t DROP CONSTRAINT IF EXISTS fk_x` is "Not implemented Error: No
-        // support for that ALTER TABLE option yet!" - and a `Not implemented` is not
-        // an `IF EXISTS` no-op, so the line would fail a migration rather than skip.
-        lines.push(`-- DuckDB: Cannot drop a foreign key directly. Requires table recreation.`);
-      } else if (dialect === "cassandra") {
-        // `DROP CONSTRAINT IF EXISTS fk_x` is "mismatched input 'IF' expecting EOF"
-        // (measured), and dropping what was never declarable is not a statement.
-        lines.push(`-- Apache Cassandra: Cannot drop a foreign key. CQL never declared one.`);
-      } else {
-        lines.push(`ALTER TABLE ${id} DROP CONSTRAINT IF EXISTS ${constraintName};`);
-      }
     });
 
   return lines.join("\n");
@@ -603,13 +644,19 @@ export function generateMigrationSQL(diff: SchemaDiff, dialect: DatabaseType): s
   );
   sections.push("");
 
+  if (NO_TABLE_DDL.has(dialect)) {
+    const limitation = NO_COLUMN_MODIFICATION[dialect]!;
+    sections.push(`-- ${limitation.label}: Cannot generate table DDL. ${limitation.reason}`);
+    return sections.join("\n");
+  }
+
   // ONE definition, read twice: the opening and the closing halves of this wrapper used
   // to be two independent conditions, which is a shape that can diverge into a `BEGIN;`
   // with no `COMMIT;`. See NO_TRANSACTION_WRAPPER for why each excluded id is excluded.
   const wrapsInTransaction = !NO_TRANSACTION_WRAPPER.has(dialect);
 
   if (wrapsInTransaction) {
-    sections.push("BEGIN;");
+    sections.push(dialect === "mssql" ? "BEGIN TRANSACTION;" : "BEGIN;");
     sections.push("");
   }
 

--- a/src/lib/schema-diff/migration-generator.ts
+++ b/src/lib/schema-diff/migration-generator.ts
@@ -434,9 +434,10 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
       }
     });
 
-  // Removed indexes
+  // Changed indexes need replacement too. Drop the old definition before column
+  // changes, then recreate it with the target columns and uniqueness below.
   table.indexes
-    .filter((i) => i.action === "removed")
+    .filter((i) => i.action === "removed" || i.action === "modified")
     .forEach((idx) => {
       const refusal = NO_PORTABLE_INDEX_DDL[dialect];
       if (refusal) {
@@ -572,9 +573,9 @@ function generateAlterTable(table: TableDiff, dialect: DatabaseType): string {
       }
     });
 
-  // Added indexes
+  // Added and replaced indexes
   table.indexes
-    .filter((i) => i.action === "added")
+    .filter((i) => i.action === "added" || i.action === "modified")
     .forEach((idx) => {
       const refusal = NO_PORTABLE_INDEX_DDL[dialect];
       if (refusal) {

--- a/tests/live/schema-diff-dialects.ts
+++ b/tests/live/schema-diff-dialects.ts
@@ -1,0 +1,211 @@
+/**
+ * Opt-in live regression for #284. Requires disposable SQL Server and Oracle servers.
+ * Run with Bun; connection variables are documented in docs/SCHEMA_DIFF.md.
+ * Each probe owns a fresh database/schema and removes it in finally.
+ */
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import mssql from "mssql";
+import oracledb from "oracledb";
+import { generateMigrationSQL } from "../../src/lib/schema-diff/migration-generator";
+import type { SchemaDiff, TableDiff } from "../../src/lib/schema-diff/types";
+import { splitStatements } from "../../src/lib/sql/statement-splitter";
+import { resolveSqlGrammar } from "../../src/lib/sql/grammar";
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Set ${name} for the disposable test server.`);
+  return value;
+}
+
+function change(table: Partial<TableDiff>): SchemaDiff {
+  return {
+    hasChanges: true,
+    summary: { added: 1, removed: 1, modified: 1 },
+    tables: [{ action: "modified", tableName: "items", columns: [], indexes: [], foreignKeys: [], ...table }],
+  };
+}
+
+async function probe(
+  dialect: "mssql" | "oracle",
+  run: (sql: string) => Promise<unknown>,
+  scalar: (sql: string) => Promise<unknown>,
+): Promise<void> {
+  const q = (name: string) =>
+    dialect === "mssql" ? `[${name.replaceAll("]", "]]")}]` : `"${name.replaceAll('"', '""')}"`;
+  const generated = async (table: Partial<TableDiff>) => {
+    const sql = generateMigrationSQL(change(table), dialect);
+    for (const statement of splitStatements(sql, resolveSqlGrammar(dialect))) {
+      // oxlint-disable-next-line no-await-in-loop -- DDL depends on earlier statements in the same session.
+      await run(statement.sql.replace(/;\s*$/, ""));
+    }
+    return sql;
+  };
+  await run(`CREATE TABLE ${q("parent")} (${q("id")} INTEGER PRIMARY KEY)`);
+  await run(`INSERT INTO ${q("parent")} VALUES (1)`);
+  await generated({
+    action: "added",
+    columns: [
+      {
+        action: "added",
+        columnName: "id",
+        targetType: "INTEGER",
+        targetNullable: false,
+        targetIsPrimary: true,
+        changes: [],
+      },
+      { action: "added", columnName: "old", targetType: "INTEGER", changes: [] },
+      {
+        action: "added",
+        columnName: "n",
+        targetType: "INTEGER",
+        targetDefault: "42",
+        targetNullable: false,
+        changes: [],
+      },
+    ],
+    indexes: [{ action: "added", indexName: "idx_old", targetColumns: ["old"], changes: [] }],
+    foreignKeys: [
+      {
+        action: "added",
+        columnName: "old",
+        targetReferencedTable: "parent",
+        targetReferencedColumn: "id",
+        changes: [],
+      },
+    ],
+  });
+  await run(`INSERT INTO ${q("items")} (${q("id")}, ${q("old")}) VALUES (1, 1)`);
+  assert.equal(Number(await scalar(`SELECT ${q("n")} FROM ${q("items")}`)), 42);
+  await assert.rejects(() => run(`INSERT INTO ${q("items")} (${q("id")}, ${q("n")}) VALUES (2, NULL)`));
+  await assert.rejects(() => run(`INSERT INTO ${q("items")} (${q("id")}, ${q("old")}) VALUES (3, 99)`));
+
+  // Mutation controls: the old emitted forms must fail against the same live server.
+  await assert.rejects(() => run(`ALTER TABLE ${q("items")} ADD COLUMN ${q("extra")} INTEGER`));
+  await assert.rejects(() => run("BEGIN"));
+  if (dialect === "mssql") {
+    await assert.rejects(() => run(`DROP INDEX IF EXISTS ${q("idx_old")}`));
+    await assert.rejects(() => run(`ALTER TABLE ${q("items")} DROP COLUMN ${q("old")}`));
+  } else {
+    await assert.rejects(() => run(`ALTER TABLE ${q("items")} ADD (${q("extra")} INTEGER NOT NULL DEFAULT 7)`));
+  }
+
+  // Remove an indexed FK column and replace its index name on the newly added column.
+  await generated({
+    columns: [
+      { action: "removed", columnName: "old", changes: [] },
+      {
+        action: "added",
+        columnName: "extra",
+        targetType: "INTEGER",
+        targetDefault: "7",
+        targetNullable: false,
+        changes: [],
+      },
+    ],
+    indexes: [
+      { action: "removed", indexName: "idx_old", changes: [] },
+      { action: "added", indexName: "idx_old", targetColumns: ["extra"], changes: [] },
+    ],
+    foreignKeys: [{ action: "removed", columnName: "old", changes: [] }],
+  });
+  assert.equal(Number(await scalar(`SELECT ${q("extra")} FROM ${q("items")}`)), 7);
+  assert.equal(Number(await scalar(`SELECT COUNT(*) FROM ${q("items")}`)), 1);
+  await assert.rejects(() => run(`SELECT ${q("old")} FROM ${q("items")}`));
+
+  // Newlines and quote delimiters in metadata must stay inside identifiers, never
+  // turn the generator's informational comment into an executable DELETE.
+  const attack = dialect === "mssql" ? 'x"\nDELETE FROM "items";\n--]' : "x\nDELETE FROM items;\n--]";
+  await run(`CREATE TABLE ${q(attack)} (${q("id")} INTEGER)`);
+  await generated({
+    tableName: attack,
+    columns: [{ action: "added", columnName: dialect === "mssql" ? 'n"]' : "n]", targetType: "INTEGER", changes: [] }],
+  });
+  assert.equal(Number(await scalar(`SELECT COUNT(*) FROM ${q("items")}`)), 1);
+  await generated({ tableName: attack, action: "removed" });
+
+  // Transaction semantics, not just parser acceptance.
+  if (dialect === "mssql") {
+    await run("BEGIN TRANSACTION");
+    await run(`CREATE TABLE ${q("rollback_probe")} (${q("id")} INTEGER)`);
+    await run("ROLLBACK");
+    assert.equal(Number(await scalar("SELECT COUNT(*) FROM sys.tables WHERE name = 'rollback_probe'")), 0);
+  } else {
+    await run(`CREATE TABLE ${q("commit_probe")} (${q("id")} INTEGER)`);
+    await run("ROLLBACK");
+    assert.equal(Number(await scalar("SELECT COUNT(*) FROM user_tables WHERE table_name = 'commit_probe'")), 1);
+    await run(`DROP TABLE ${q("commit_probe")}`);
+  }
+  await generated({ action: "removed" });
+  await run(`DROP TABLE ${q("parent")}`);
+  console.log(`${dialect}: live DDL, data/defaults, dependency order, quoted metadata and transaction probes passed`);
+}
+
+const engine = required("MIGRATION_PROBE_ENGINE");
+const suffix = randomBytes(5).toString("hex");
+if (engine === "mssql") {
+  const config = {
+    server: "127.0.0.1",
+    port: Number(required("MSSQL_TEST_PORT")),
+    user: "sa",
+    password: required("MSSQL_TEST_PASSWORD"),
+    options: { trustServerCertificate: true, encrypt: false },
+    // One physical connection: transaction statements must share a session.
+    pool: { min: 1, max: 1 },
+  };
+  const admin = await new mssql.ConnectionPool(config).connect();
+  const database = `migration_probe_${suffix}`;
+  let connection: mssql.ConnectionPool | undefined;
+  try {
+    console.log((await admin.request().query("SELECT @@VERSION AS version")).recordset[0].version);
+    await admin.request().query(`CREATE DATABASE [${database}]`);
+    connection = await new mssql.ConnectionPool({ ...config, database }).connect();
+    const db = connection;
+    await probe(
+      "mssql",
+      (sql) => db.request().batch(sql),
+      async (sql) => Object.values((await db.request().query(sql)).recordset[0])[0],
+    );
+  } finally {
+    await connection?.close();
+    await admin.request().query(`IF DB_ID('${database}') IS NOT NULL DROP DATABASE [${database}]`);
+    await admin.close();
+  }
+} else if (engine === "oracle") {
+  const connectString = `127.0.0.1:${required("ORACLE_TEST_PORT")}/FREEPDB1`;
+  const adminPool = await oracledb.createPool({
+    user: "system",
+    password: required("ORACLE_TEST_PASSWORD"),
+    connectString,
+    poolMin: 0,
+    poolMax: 1,
+  });
+  const admin = await adminPool.getConnection();
+  const user = `PROBE_${suffix.toUpperCase()}`;
+  const password = `Probe${randomBytes(12).toString("hex")}`;
+  let connection: oracledb.Connection | undefined;
+  let pool: oracledb.Pool | undefined;
+  let created = false;
+  try {
+    console.log((await admin.execute("SELECT banner_full FROM v$version")).rows);
+    await admin.execute(`CREATE USER ${user} IDENTIFIED BY "${password}" QUOTA UNLIMITED ON USERS`);
+    created = true;
+    await admin.execute(`GRANT CREATE SESSION, CREATE TABLE TO ${user}`);
+    pool = await oracledb.createPool({ user, password, connectString, poolMin: 0, poolMax: 1 });
+    connection = await pool.getConnection();
+    const db = connection;
+    await probe(
+      "oracle",
+      (sql) => db.execute(sql),
+      async (sql) => ((await db.execute(sql)).rows as unknown[][])[0][0],
+    );
+  } finally {
+    await connection?.close();
+    await pool?.close(0);
+    if (created) await admin.execute(`DROP USER ${user} CASCADE`);
+    await admin.close();
+    await adminPool.close(0);
+  }
+} else {
+  throw new Error("MIGRATION_PROBE_ENGINE must be mssql or oracle");
+}

--- a/tests/live/schema-diff-dialects.ts
+++ b/tests/live/schema-diff-dialects.ts
@@ -104,14 +104,29 @@ async function probe(
       },
     ],
     indexes: [
-      { action: "removed", indexName: "idx_old", changes: [] },
-      { action: "added", indexName: "idx_old", targetColumns: ["extra"], changes: [] },
+      { action: "modified", indexName: "idx_old", sourceColumns: ["old"], targetColumns: ["extra"], changes: [] },
     ],
     foreignKeys: [{ action: "removed", columnName: "old", changes: [] }],
   });
   assert.equal(Number(await scalar(`SELECT ${q("extra")} FROM ${q("items")}`)), 7);
   assert.equal(Number(await scalar(`SELECT COUNT(*) FROM ${q("items")}`)), 1);
   await assert.rejects(() => run(`SELECT ${q("old")} FROM ${q("items")}`));
+
+  // A uniqueness-only diff must replace the index and enforce the new rule.
+  await generated({
+    indexes: [
+      {
+        action: "modified",
+        indexName: "idx_old",
+        sourceColumns: ["extra"],
+        targetColumns: ["extra"],
+        sourceUnique: false,
+        targetUnique: true,
+        changes: [],
+      },
+    ],
+  });
+  await assert.rejects(() => run(`INSERT INTO ${q("items")} (${q("id")}, ${q("extra")}) VALUES (2, 7)`));
 
   // Newlines and quote delimiters in metadata must stay inside identifiers, never
   // turn the generator's informational comment into an executable DELETE.

--- a/tests/unit/schema-diff/index-migration.test.ts
+++ b/tests/unit/schema-diff/index-migration.test.ts
@@ -1,0 +1,87 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { diffSchemas } from "@/lib/schema-diff/diff-engine";
+import { generateMigrationSQL } from "@/lib/schema-diff/migration-generator";
+import type { TableSchema } from "@/lib/types";
+
+function table(columns: string[], indexColumns: string[], unique = false): TableSchema {
+  return {
+    name: "items",
+    columns: columns.map((name) => ({ name, type: "INTEGER", nullable: true, isPrimary: false })),
+    indexes: [{ name: "idx_items", columns: indexColumns, unique }],
+    foreignKeys: [],
+  };
+}
+
+describe("schema comparison through index migration", () => {
+  for (const dialect of ["mssql", "oracle"] as const) {
+    test(`${dialect}: a changed index is dropped before its old column and recreated afterwards`, () => {
+      const diff = diffSchemas([table(["old"], ["old"])], [table(["replacement"], ["replacement"])]);
+      expect(diff.tables[0].indexes[0].action).toBe("modified");
+      const sql = generateMigrationSQL(diff, dialect);
+      expect(sql).toContain("DROP INDEX");
+      expect(sql).toContain("CREATE INDEX");
+      expect(sql.indexOf("DROP INDEX")).toBeLessThan(sql.indexOf("DROP COLUMN"));
+      expect(sql.indexOf("CREATE INDEX")).toBeGreaterThan(sql.indexOf("DROP COLUMN"));
+      if (dialect === "mssql") {
+        expect(sql).toContain("DROP INDEX IF EXISTS [idx_items] ON [items];");
+        expect(sql).toContain("CREATE INDEX [idx_items] ON [items] ([replacement]);");
+      } else {
+        expect(sql).toContain('DROP INDEX "idx_items";');
+        expect(sql).toContain('CREATE INDEX "idx_items" ON "items" ("replacement");');
+      }
+    });
+  }
+
+  test("a composite index's order is a schema change and is applied to SQLite", () => {
+    const source = table(["a", "b"], ["a", "b"]);
+    const target = table(["a", "b"], ["b", "a"]);
+    const diff = diffSchemas([source], [target]);
+    expect(diff.hasChanges).toBe(true);
+    expect(source.indexes[0].columns).toEqual(["a", "b"]);
+    expect(target.indexes[0].columns).toEqual(["b", "a"]);
+    const db = new Database(":memory:");
+    try {
+      db.exec("CREATE TABLE items (a INTEGER, b INTEGER); CREATE INDEX idx_items ON items (a, b)");
+      db.exec(generateMigrationSQL(diff, "sqlite"));
+      expect(
+        db
+          .query<{ name: string }, []>("PRAGMA index_info(idx_items)")
+          .all()
+          .map((row) => row.name),
+      ).toEqual(["b", "a"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("a uniqueness change actually enforces the target constraint", () => {
+    const diff = diffSchemas([table(["a"], ["a"])], [table(["a"], ["a"], true)]);
+    const db = new Database(":memory:");
+    try {
+      db.exec("CREATE TABLE items (a INTEGER); CREATE INDEX idx_items ON items (a); INSERT INTO items VALUES (1)");
+      db.exec(generateMigrationSQL(diff, "sqlite"));
+      expect(() => db.exec("INSERT INTO items VALUES (1)")).toThrow();
+      expect(db.query<{ a: number }, []>("SELECT a FROM items").all()).toEqual([{ a: 1 }]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("commas in column names cannot hide a changed index", () => {
+    const diff = diffSchemas(
+      [table(["a,b", "c", "a", "b,c"], ["a,b", "c"])],
+      [table(["a,b", "c", "a", "b,c"], ["a", "b,c"])],
+    );
+    expect(diff.hasChanges).toBe(true);
+    expect(generateMigrationSQL(diff, "oracle")).toContain('CREATE INDEX "idx_items" ON "items" ("a", "b,c");');
+  });
+
+  for (const dialect of ["clickhouse", "trino"] as const) {
+    test(`${dialect}: a modified index reports its unsupported grammar`, () => {
+      const sql = generateMigrationSQL(diffSchemas([table(["a", "b"], ["a"])], [table(["a", "b"], ["b"])]), dialect);
+      expect(sql).toContain("Cannot generate index DDL");
+      expect(sql).not.toMatch(/^(DROP INDEX|CREATE INDEX)/m);
+    });
+  }
+});

--- a/tests/unit/schema-diff/migration-dialects.test.ts
+++ b/tests/unit/schema-diff/migration-dialects.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "bun:test";
+import { generateMigrationSQL } from "@/lib/schema-diff/migration-generator";
+import type { SchemaDiff, TableDiff } from "@/lib/schema-diff/types";
+import type { DatabaseType } from "@/lib/types";
+
+function diff(table: Partial<TableDiff>): SchemaDiff {
+  return {
+    hasChanges: true,
+    summary: { added: 1, removed: 1, modified: 1 },
+    tables: [{ tableName: "items", action: "modified", columns: [], indexes: [], foreignKeys: [], ...table }],
+  };
+}
+
+// Every canonical id must declare its ADD/DROP grammar; a future provider cannot
+// silently inherit PostgreSQL's statements. Null means there is no table DDL.
+const COLUMN_GRAMMAR: Record<DatabaseType, [string, string] | null> = {
+  postgres: ['ADD COLUMN "extra" integer;', 'DROP COLUMN "old";'],
+  mysql: ["ADD COLUMN `extra` integer;", "DROP COLUMN `old`;"],
+  mssql: ["ADD [extra] integer;", "DROP COLUMN [old];"],
+  oracle: ['ADD ("extra" integer);', 'DROP COLUMN "old";'],
+  sqlite: ['ADD COLUMN "extra" integer;', 'Cannot drop column "old" directly.'],
+  libsql: ['ADD COLUMN "extra" integer;', 'DROP COLUMN "old";'],
+  duckdb: ['ADD COLUMN "extra" integer;', 'DROP COLUMN "old";'],
+  cassandra: ['ADD "extra" integer;', 'DROP "old";'],
+  clickhouse: ['ADD COLUMN "extra" integer;', 'DROP COLUMN "old";'],
+  trino: ['ADD COLUMN "extra" integer;', 'DROP COLUMN "old";'],
+  couchbase: null,
+  druid: null,
+  elasticsearch: null,
+  opensearch: null,
+  mongodb: null,
+  redis: null,
+  libredb: null,
+};
+
+describe("migration dialect regressions (#284)", () => {
+  for (const [id, grammar] of Object.entries(COLUMN_GRAMMAR)) {
+    const dialect = id as DatabaseType;
+    test(`${dialect}: added and removed columns follow the engine grammar`, () => {
+      const sql = generateMigrationSQL(
+        diff({
+          columns: [
+            { action: "added", columnName: "extra", targetType: "integer", changes: [] },
+            { action: "removed", columnName: "old", changes: [] },
+          ],
+        }),
+        dialect,
+      );
+      if (grammar) {
+        for (const fragment of grammar) expect(sql).toContain(fragment);
+      } else {
+        expect(sql).toContain("Cannot generate table DDL");
+        expect(sql.split("\n").filter((line) => line.trim() && !line.startsWith("--"))).toEqual([]);
+      }
+    });
+    if (grammar) continue;
+    for (const action of ["added", "removed", "modified"] as const) {
+      test(`${dialect}: ${action} tables and their indexes/keys never leak SQL DDL`, () => {
+        const sql = generateMigrationSQL(
+          diff({
+            action,
+            columns: [{ action: "added", columnName: "id", targetType: "integer", targetIsPrimary: true, changes: [] }],
+            indexes: [
+              { action: "added", indexName: "i", targetColumns: ["id"], changes: [] },
+              { action: "removed", indexName: "old_i", changes: [] },
+            ],
+            foreignKeys: [
+              {
+                action: "added",
+                columnName: "id",
+                targetReferencedTable: "parent",
+                targetReferencedColumn: "id",
+                changes: [],
+              },
+              { action: "removed", columnName: "old_id", changes: [] },
+            ],
+          }),
+          dialect,
+        );
+        expect(sql).toContain("Cannot generate table DDL");
+        expect(sql.split("\n").filter((line) => line.trim() && !line.startsWith("--"))).toEqual([]);
+      });
+    }
+  }
+
+  test("SQL Server starts a transaction using T-SQL's transaction keyword", () => {
+    const sql = generateMigrationSQL(diff({ action: "removed" }), "mssql");
+    expect(sql).toMatch(/^BEGIN TRANSACTION;$/m);
+    expect(sql).toMatch(/^COMMIT;$/m);
+    expect(sql).not.toMatch(/^BEGIN;$/m);
+  });
+
+  test("Oracle has no transaction wrapper and uses portable DROP forms", () => {
+    const sql = generateMigrationSQL(diff({ action: "removed" }), "oracle");
+    expect(sql).toContain('DROP TABLE "items";');
+    expect(sql).not.toMatch(/^(BEGIN|COMMIT)/m);
+    expect(sql).not.toContain("IF EXISTS");
+  });
+
+  for (const action of ["added", "modified"] as const) {
+    test(`Oracle ${action} table puts DEFAULT before NOT NULL`, () => {
+      const sql = generateMigrationSQL(
+        diff({
+          action,
+          columns: [
+            {
+              action: "added",
+              columnName: 'value"x',
+              targetType: "NUMBER",
+              targetDefault: "42",
+              targetNullable: false,
+              changes: [],
+            },
+          ],
+        }),
+        "oracle",
+      );
+      expect(sql).toContain('"value""x" NUMBER DEFAULT 42 NOT NULL');
+      expect(sql).not.toContain("NOT NULL DEFAULT");
+    });
+  }
+
+  for (const dialect of ["mssql", "oracle"] as const) {
+    test(`${dialect}: drop indexes and foreign keys before their columns`, () => {
+      const sql = generateMigrationSQL(
+        diff({
+          columns: [{ action: "removed", columnName: "old", changes: [] }],
+          indexes: [{ action: "removed", indexName: "idx_old", changes: [] }],
+          foreignKeys: [{ action: "removed", columnName: "old", changes: [] }],
+        }),
+        dialect,
+      );
+      expect(sql.indexOf("DROP INDEX")).toBeLessThan(sql.indexOf("DROP COLUMN"));
+      expect(sql.indexOf("DROP CONSTRAINT")).toBeLessThan(sql.indexOf("DROP COLUMN"));
+      if (dialect === "mssql") {
+        expect(sql).toContain("DROP INDEX IF EXISTS [idx_old] ON [items];");
+        expect(sql).toContain("ALTER TABLE [items] DROP CONSTRAINT IF EXISTS [fk_items_old];");
+      } else {
+        expect(sql).toContain('DROP INDEX "idx_old";');
+        expect(sql).toContain('ALTER TABLE "items" DROP CONSTRAINT "fk_items_old";');
+        expect(sql).not.toContain("IF EXISTS");
+      }
+    });
+  }
+
+  for (const dialect of ["mssql", "oracle", "sqlite", "cassandra"] as const) {
+    test(`${dialect}: object names cannot escape generated comments with a newline`, () => {
+      const attack = "x\r\nDELETE FROM valuable;\n--";
+      const sql = generateMigrationSQL(
+        diff({
+          tableName: attack,
+          columns: [{ action: "modified", columnName: attack, targetType: "integer", changes: [] }],
+        }),
+        dialect,
+      );
+      const outsideIdentifiers = sql.replace(/"(?:[^"]|"")*"|\[(?:[^\]]|\]\])*\]/g, "identifier");
+      expect(outsideIdentifiers).not.toMatch(/^DELETE FROM valuable;$/m);
+      // Identifier newlines inside a quoted SQL span remain legal; only comment text is flattened.
+      expect(sql).toContain("-- Alter table: x  DELETE FROM valuable; --");
+    });
+  }
+});
+
+describe("index and foreign-key fallback refusals", () => {
+  for (const dialect of ["clickhouse", "trino"] as const) {
+    for (const action of ["added", "modified"] as const) {
+      test(`${dialect}: ${action} table keeps columns but refuses unsupported index/FK clauses`, () => {
+        const sql = generateMigrationSQL(
+          diff({
+            action,
+            columns: [{ action: "added", columnName: "id", targetType: "integer", changes: [] }],
+            indexes: [
+              { action: "added", indexName: "idx", targetColumns: ["id"], changes: [] },
+              { action: "removed", indexName: "old_idx", changes: [] },
+            ],
+            foreignKeys: [
+              {
+                action: "added",
+                columnName: "id",
+                targetReferencedTable: "parent",
+                targetReferencedColumn: "id",
+                changes: [],
+              },
+              { action: "removed", columnName: "old_id", changes: [] },
+            ],
+          }),
+          dialect,
+        );
+        expect(sql).toContain('"id" integer');
+        expect(sql).toContain("Cannot generate index DDL");
+        expect(sql).toContain("Cannot add a foreign key");
+        if (action === "modified") expect(sql).toContain("Cannot drop a foreign key");
+        expect(sql).not.toMatch(/^(CREATE (UNIQUE )?INDEX|DROP INDEX|ALTER TABLE .* (ADD|DROP) CONSTRAINT)/m);
+      });
+    }
+  }
+
+  test("Trino primary keys are declined rather than written into CREATE TABLE", () => {
+    const sql = generateMigrationSQL(
+      diff({
+        action: "added",
+        columns: [{ action: "added", columnName: "id", targetType: "integer", targetIsPrimary: true, changes: [] }],
+      }),
+      "trino",
+    );
+    expect(sql).toContain("Cannot declare a primary key");
+    expect(sql).not.toContain("PRIMARY KEY (");
+    expect(sql).toContain('CREATE TABLE "items"');
+  });
+
+  test("Oracle's missing type fallback is valid on both CREATE and ADD paths", () => {
+    for (const action of ["added", "modified"] as const) {
+      const sql = generateMigrationSQL(
+        diff({ action, columns: [{ action: "added", columnName: "x", changes: [] }] }),
+        "oracle",
+      );
+      expect(sql).toContain('"x" VARCHAR2(255)');
+    }
+  });
+});

--- a/tests/unit/schema-diff/migration-generator.test.ts
+++ b/tests/unit/schema-diff/migration-generator.test.ts
@@ -184,17 +184,18 @@ describe("generateMigrationSQL: CREATE TABLE", () => {
     const sql = generateMigrationSQL(makeAddedTableDiff(), "mssql");
     expect(sql).toContain("CREATE TABLE [users]");
     expect(sql).toContain("[id] integer NOT NULL");
-    expect(sql).toContain("BEGIN;");
+    expect(sql).toContain("BEGIN TRANSACTION;");
   });
 
   test("oracle uses double-quoted identifiers", () => {
     const sql = generateMigrationSQL(makeAddedTableDiff(), "oracle");
     expect(sql).toContain('CREATE TABLE "users"');
-    expect(sql).toContain("BEGIN;");
+    expect(sql).not.toContain("BEGIN;");
+    expect(sql).not.toContain("COMMIT;");
   });
 
-  test("unlisted dialect falls back to double-quoted identifiers", () => {
-    const sql = generateMigrationSQL(makeAddedTableDiff(), "mongodb");
+  test("duckdb uses double-quoted identifiers", () => {
+    const sql = generateMigrationSQL(makeAddedTableDiff(), "duckdb");
     expect(sql).toContain('CREATE TABLE "users"');
     expect(sql).toContain('"id" integer NOT NULL');
   });
@@ -939,16 +940,16 @@ describe("generateMigrationSQL: SQLite's grammar declares a foreign key only ins
     mysql: "key-follows-in-an-alter",
     oracle: "key-follows-in-an-alter",
     mssql: "key-follows-in-an-alter",
-    clickhouse: "key-follows-in-an-alter",
-    couchbase: "key-follows-in-an-alter",
-    druid: "key-follows-in-an-alter",
-    trino: "key-follows-in-an-alter",
-    elasticsearch: "key-follows-in-an-alter",
-    opensearch: "key-follows-in-an-alter",
+    clickhouse: "engine-has-no-foreign-key",
+    couchbase: "engine-has-no-foreign-key",
+    druid: "engine-has-no-foreign-key",
+    trino: "engine-has-no-foreign-key",
+    elasticsearch: "engine-has-no-foreign-key",
+    opensearch: "engine-has-no-foreign-key",
     cassandra: "engine-has-no-foreign-key",
-    mongodb: "key-follows-in-an-alter",
-    redis: "key-follows-in-an-alter",
-    libredb: "key-follows-in-an-alter",
+    mongodb: "engine-has-no-foreign-key",
+    redis: "engine-has-no-foreign-key",
+    libredb: "engine-has-no-foreign-key",
   };
 
   for (const [dialectId, entry] of Object.entries(GRAMMAR)) {
@@ -1215,7 +1216,11 @@ describe("generateMigrationSQL: dialects that cannot modify a column", () => {
 
     test(`${dialect}: modified column emits a comment naming the limitation, never PostgreSQL DDL`, () => {
       const sql = generateMigrationSQL(makeModifiedTableDiff(), dialect as DatabaseType);
-      expect(sql).toContain(`-- ${expected.label}: Cannot alter column "name".`);
+      if (["couchbase", "druid", "elasticsearch", "opensearch", "mongodb", "redis", "libredb"].includes(dialect)) {
+        expect(sql).toContain(`-- ${expected.label}: Cannot generate table DDL.`);
+      } else {
+        expect(sql).toContain(`-- ${expected.label}: Cannot alter column "name".`);
+      }
       expect(sql).toContain(expected.reason);
       expect(sql).not.toContain("ALTER COLUMN");
       expect(sql).not.toContain("MODIFY COLUMN");
@@ -1229,60 +1234,40 @@ describe("generateMigrationSQL: dialects that cannot modify a column", () => {
  * `DatabaseType` fails typecheck here until it is classified, so it cannot silently
  * inherit the wrapper meant for PostgreSQL and MySQL (#284).
  *
- * `"wrapped"` — the dialect's DDL is bracketed in `BEGIN;` / `COMMIT;`.
- * `"unwrapped"` — no wrapper reaches the migration text. mssql and oracle are
- * deliberately absent from this table's classification of "unwrapped" — they still
- * read `"wrapped"` here, UNCHANGED from today's behaviour, because the module
- * docstring and the issue itself say their real wrapper forms (`BEGIN TRANSACTION;`
- * for MSSQL; whether Oracle needs one at all, given DDL there auto-commits) want
- * checking against a live server before they are settled, the way #264/#265 were -
- * and this PR does not have one available. Tracked as the named follow-up rather than
- * guessed here.
+ * Each wrapped dialect names its exact opening statement; false means no wrapper.
  */
-const TRANSACTION_WRAPPER_COVERAGE: Record<DatabaseType, "wrapped" | "unwrapped"> = {
-  postgres: "wrapped",
-  mysql: "wrapped",
+const TRANSACTION_WRAPPER_COVERAGE: Record<DatabaseType, "BEGIN;" | "BEGIN TRANSACTION;" | false> = {
+  postgres: "BEGIN;",
+  mysql: "BEGIN;",
   // Measured live via @duckdb/node-api 1.5.5-r.4 (DuckDB v1.5.5, in-process, no server
   // needed): `BEGIN;` opens a real transaction around DDL, so a `CREATE TABLE` issued
   // inside one is undone by `ROLLBACK;` and kept by `COMMIT;`. Both arms are EXECUTED in
   // the "generateMigrationSQL: duckdb" describe block above, which is where that
   // measurement is pinned; this line only classifies it.
-  duckdb: "wrapped",
-  // UNCHANGED — see this table's own doc comment above.
-  mssql: "wrapped",
-  oracle: "wrapped",
-  sqlite: "unwrapped", // runs its own transaction (module docstring)
-  libsql: "unwrapped", // SQLite fork, same reasoning, plus its own Hrana-stream note (module docstring)
-  cassandra: "unwrapped", // CQL has no BEGIN/COMMIT — measured on 5.0.9 (module docstring)
+  duckdb: "BEGIN;",
+  mssql: "BEGIN TRANSACTION;",
+  oracle: false, // DDL commits implicitly; BEGIN starts a PL/SQL block.
+  sqlite: false, // runs its own transaction (module docstring)
+  libsql: false, // SQLite fork, same reasoning, plus its own Hrana-stream note (module docstring)
+  cassandra: false, // CQL has no BEGIN/COMMIT — measured on 5.0.9 (module docstring)
   // The remaining nine each have a recorded reason for having no `BEGIN;` to emit, in this
   // same module (`NO_COLUMN_MODIFICATION`), in `src/lib/sql/grammar.ts` (`NON_SQL_DIALECTS`)
   // or in the provider doc named on the line — this table applies those established facts to
   // the wrapper fallback rather than asserting fresh ones, so none of the nine needs a new
   // live probe. What none of them means is "the wrapper bracketed nothing": see the
   // added-table fixture below.
-  mongodb: "unwrapped", // not SQL text at all (`NON_SQL_DIALECTS`); wrapping non-SQL in SQL statements is wrong regardless of Mongo's own transaction API
-  redis: "unwrapped", // same: command-line grammar, not SQL (`NON_SQL_DIALECTS`)
-  libredb: "unwrapped", // "a JSON command grammar, not SQL DDL" (NO_COLUMN_MODIFICATION's own words)
-  couchbase: "unwrapped", // has transactions, but spells them `BEGIN TRANSACTION` + a txid every later statement must carry — not something a flat file expresses (docs/providers/couchbase.md §13)
-  druid: "unwrapped", // "Druid SQL has no ALTER TABLE" and no transaction concept at all (NO_COLUMN_MODIFICATION)
-  clickhouse: "unwrapped", // ClickHouse's transaction support is experimental and setting-gated, not a safe default; today's code wraps it anyway, which this fixes
-  elasticsearch: "unwrapped", // `BEGIN` is not in the grammar (NO_COLUMN_MODIFICATION's measured statement list; docs/providers/elasticsearch.md §9)
-  opensearch: "unwrapped", // same, measured separately on OpenSearch 3.8.0 (docs/providers/opensearch.md §9)
-  trino: "unwrapped", // connector-dependent at best; no portable BEGIN/COMMIT (NO_COLUMN_MODIFICATION)
+  mongodb: false, // not SQL text at all (`NON_SQL_DIALECTS`); wrapping non-SQL in SQL statements is wrong regardless of Mongo's own transaction API
+  redis: false, // same: command-line grammar, not SQL (`NON_SQL_DIALECTS`)
+  libredb: false, // "a JSON command grammar, not SQL DDL" (NO_COLUMN_MODIFICATION's own words)
+  couchbase: false, // has transactions, but spells them `BEGIN TRANSACTION` + a txid every later statement must carry — not something a flat file expresses (docs/providers/couchbase.md §13)
+  druid: false, // "Druid SQL has no ALTER TABLE" and no transaction concept at all (NO_COLUMN_MODIFICATION)
+  clickhouse: false, // ClickHouse's transaction support is experimental and setting-gated, not a safe default; today's code wraps it anyway, which this fixes
+  elasticsearch: false, // `BEGIN` is not in the grammar (NO_COLUMN_MODIFICATION's measured statement list; docs/providers/elasticsearch.md §9)
+  opensearch: false, // same, measured separately on OpenSearch 3.8.0 (docs/providers/opensearch.md §9)
+  trino: false, // connector-dependent at best; no portable BEGIN/COMMIT (NO_COLUMN_MODIFICATION)
 };
 
-/**
- * Two fixtures, because one of them alone cannot see the thing that matters here.
- *
- * `generateMigrationSQL` reads NO provider capability — not `supportsCreateTable`, not
- * anything else — so its added-table branch emits a real `CREATE TABLE` for every id
- * except `cassandra`, which is the one the generator refuses outright
- * (`CASSANDRA_NO_CREATE_TABLE`). A modified-table diff on an id in
- * `NO_COLUMN_MODIFICATION` really does reduce to comments, so a table driven only by
- * that fixture would let "this dialect never gets DDL, so the wrapper bracketed nothing"
- * stand unchallenged. It is false: the wrapper this set removes was bracketing runnable
- * DDL for those ids too, which is why removing it is a fix rather than a tidy-up.
- */
+// Both creation and modification paths must use the same wrapper policy.
 const WRAPPER_FIXTURES = [
   { label: "a modified table", makeDiff: makeModifiedTableDiff, emitsCreateTable: false },
   { label: "an added table", makeDiff: makeAddedTableDiff, emitsCreateTable: true },
@@ -1291,18 +1276,23 @@ const WRAPPER_FIXTURES = [
 describe("generateMigrationSQL: transaction wrapper by dialect", () => {
   for (const [dialect, expected] of Object.entries(TRANSACTION_WRAPPER_COVERAGE)) {
     for (const fixture of WRAPPER_FIXTURES) {
-      test(`${dialect}: ${expected === "wrapped" ? "wraps DDL in BEGIN;/COMMIT;" : "emits no transaction wrapper"} for ${fixture.label}`, () => {
+      test(`${dialect}: ${expected ? `wraps DDL in ${expected}/COMMIT;` : "emits no transaction wrapper"} for ${fixture.label}`, () => {
         const sql = generateMigrationSQL(fixture.makeDiff(), dialect as DatabaseType);
         // Non-vacuity guard: on the added-table fixture the wrapper assertion below is
         // about text that brackets a real statement, not an empty run of comments.
-        if (fixture.emitsCreateTable && dialect !== "cassandra") {
+        if (
+          fixture.emitsCreateTable &&
+          !["cassandra", "mongodb", "redis", "libredb", "couchbase", "druid", "elasticsearch", "opensearch"].includes(
+            dialect,
+          )
+        ) {
           expect(sql).toMatch(/^CREATE TABLE /m);
         }
-        if (expected === "wrapped") {
-          expect(sql).toContain("BEGIN;");
+        if (expected) {
+          expect(sql).toContain(expected);
           expect(sql).toContain("COMMIT;");
         } else {
-          expect(sql).not.toContain("BEGIN;");
+          expect(sql).not.toMatch(/^BEGIN(?: TRANSACTION)?;$/m);
           expect(sql).not.toContain("COMMIT;");
         }
       });


### PR DESCRIPTION
## Description

Schema diffs still emitted PostgreSQL-shaped SQL for SQL Server and Oracle: bare `BEGIN`, `ADD COLUMN`, and index drops missing SQL Server's table name. Oracle column defaults also followed `NOT NULL`, which its grammar rejects.

This completes those dialect branches, refuses relational table DDL for engines without that grammar, and declines unsupported Trino/ClickHouse index and foreign-key fallbacks. Removed and modified indexes, together with removed foreign keys, now precede their column changes. Changes to an index’s columns, column order or uniqueness rebuild its target definition instead of being silently omitted; array comparison preserves order and distinguishes commas inside column names. Adversarial testing also found and fixed SQL statement injection through newlines in informational comments containing schema object names.

Closes #284.

## Changes Made

- SQL Server `BEGIN TRANSACTION`, `ADD`, and `DROP INDEX … ON …`.
- Oracle `ADD (…)`, `DEFAULT … NOT NULL`, portable unconditional drops, and no transaction wrapper.
- Exhaustive 17-dialect ADD/DROP and transaction regressions; explanatory refusals for unsupported DDL.
- Rebuild modified indexes from real schema-comparison output, preserving target column order and uniqueness.
- Preserve quoted identifiers while flattening line breaks only in generated comments.
- Reproducible opt-in live probes and documented remaining schema-diff limitations.

The branch includes upstream 0.15.0. Its catalog-layout error now retains the original filesystem error cause, correcting upstream lint and formatting failures; all 77 catalog regression tests pass.

## Testing

- Added regression tests first: 40 failures reproduced, followed by 5 additional unsupported index/key failures; all pass with the fixes. Seven additional regressions reproduce modified-index omissions, ignored column order, ambiguous comma-joined identifiers and missing uniqueness enforcement; all pass after the follow-up fix.
- `bun run test`: 14,640 passed, 0 failed; all 34 isolated component groups passed.
- `bun run test:coverage && bun run coverage:check`: 46,232/46,232 source lines, 100%.
- Formatting, lint (135 existing warnings, 0 errors), typecheck, knip, and chart/channel/README/security guards passed.
- Production app build, library build, `attw`, and Go launcher checks passed.
- Live Oracle 26ai Free 23.26.1.0.0 and SQL Server 15 ARM64 (Azure SQL Edge 15.0.2000.1574): CREATE/ADD/DROP, defaults, NOT NULL/FK enforcement, indexed-column removal, modified-index replacement, uniqueness enforcement, index-name reuse, hostile metadata, and transaction semantics passed. Negative controls reject the previous broken forms.

The SQL Server 2022 CU17 image failed to start under this Mac's x86 emulation; the live T-SQL result is from the ARM SQL Server engine above. The probe script can be rerun against SQL Server 2022. The generator still requires human review for original FK names, schema qualifiers, cross-table dependencies, and cross-engine type conversion; those are outside this diff format.
