### PR TITLE
feat(release): submit the operator bundle to both catalogs on every release (#656)

### DIFF
--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -22,7 +22,11 @@ on:
         type: string
 
 concurrency:
-  group: operator-release-${{ github.ref }}
+  # NOT keyed on the ref. Two releases in flight would otherwise race the
+  # submission's "an older submission is still open" guard, which reads the
+  # catalog's default branch and so cannot see a submission opened seconds
+  # earlier by the other run.
+  group: operator-release
   cancel-in-progress: false
 
 env:
@@ -36,6 +40,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      # Read by submit-catalogs. `skip` is what makes a Helm chart tag a no-op
+      # for the whole workflow rather than for this job alone.
+      version: ${{ steps.version.outputs.version }}
+      skip: ${{ steps.version.outputs.skip }}
+      submittable: ${{ steps.version.outputs.submittable }}
+      image: ${{ steps.image.outputs.name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -73,6 +84,17 @@ jobs:
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # The regex above admits a prerelease (0.15.0-rc.1), which is a
+          # legitimate operator image but not a catalog submission: the
+          # community catalogs take bare semver directories. Say so here
+          # rather than letting the submission job fail on it after the image
+          # is already pushed.
+          if printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "submittable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "submittable=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::'${VERSION}' is a prerelease; the operator image is built but no catalog submission is opened."
+          fi
 
       - name: Guard version against the checked-out ref
         # A manual dispatch (typo'd or historical version) or a manually
@@ -137,3 +159,267 @@ jobs:
           push: true
           tags: ${{ steps.image.outputs.name }}:${{ steps.version.outputs.version }}
           platforms: linux/amd64,linux/arm64
+
+  submit-catalogs:
+    name: Submit ${{ matrix.catalog.label }} bundle PR
+    # The community catalogs pull the controller image on a real cluster, so
+    # this cannot start before the image exists and is public (issue #656).
+    needs: build-and-push
+    if: needs.build-and-push.outputs.skip != 'true' && needs.build-and-push.outputs.submittable == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      # One catalog failing must not cancel the other: they are independent
+      # submissions with independent review queues.
+      fail-fast: false
+      matrix:
+        catalog:
+          - label: operatorhub.io
+            upstream: k8s-operatorhub/community-operators
+            fork: cevheri/community-operators
+            release_config: false
+          - label: OpenShift console
+            upstream: redhat-openshift-ecosystem/community-operators-prod
+            fork: cevheri/community-operators-prod
+            release_config: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.4.2"
+
+      - name: Install dependencies
+        uses: ./.github/actions/bun-install
+
+      - name: Resolve the channel switch and the token
+        id: gate
+        env:
+          # Presence only: the secret is never expanded into a shell variable
+          # that could reach a log, and the steps that actually need it take it
+          # individually.
+          TOKEN_PRESENT: ${{ secrets.OPERATOR_CATALOG_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          # distribution/channels.yaml is the switchboard for every optional
+          # release channel; this reads the same flag the winget job reads.
+          CI_ENABLED=$(node scripts/distribution-check.mjs --ci-outputs | sed -n 's/^operatorhub_community=//p')
+          if [ "${CI_ENABLED:-}" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::operatorhub-community update.ci_enabled is '${CI_ENABLED:-<unresolved>}' in distribution/channels.yaml - skipping the catalog submission."
+            exit 0
+          fi
+          if [ "${TOKEN_PRESENT}" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::OPERATOR_CATALOG_TOKEN is not configured - skipping the catalog submission."
+            exit 0
+          fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the controller image is anonymously pullable
+        if: steps.gate.outputs.enabled == 'true'
+        id: image
+        env:
+          IMAGE: ${{ needs.build-and-push.outputs.image }}
+          VERSION: ${{ needs.build-and-push.outputs.version }}
+        run: |
+          set -euo pipefail
+          # The catalog pipelines pull without credentials, so a private
+          # package fails there rather than here, late and confusingly. This
+          # checks it the way they will: an anonymous pull token and the
+          # manifest, with no credentials of our own.
+          #
+          # The manifest is parsed rather than grepped. A single-arch manifest
+          # has no platform objects at all, and grepping for a substring would
+          # read "absent" and "present but formatted differently" the same way.
+          REPO="${IMAGE#ghcr.io/}"
+          TOKEN=$(curl -sf --retry 3 --retry-connrefused "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO}:pull" |
+            node -e 'let raw = ""; process.stdin.on("data", (d) => { raw += d }); process.stdin.on("end", () => { process.stdout.write(JSON.parse(raw).token) })')
+          # No -f on the manifest read. ghcr hands out a pull token to anyone
+          # who asks, even for a package they cannot read, so the failure lands
+          # here - and with -f the step would die on curl's exit 22 before the
+          # message written for exactly this case could print.
+          CODE=$(curl -s --retry 3 --retry-connrefused -o manifest.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+            "https://ghcr.io/v2/${REPO}/manifests/${VERSION}")
+          case "${CODE}" in
+            200) ;;
+            401|403)
+              echo "::error::${IMAGE}:${VERSION} is not anonymously pullable (HTTP ${CODE}). The catalog CI pulls without credentials - make the GHCR package public: github.com/orgs/libredb/packages"
+              exit 1 ;;
+            404)
+              echo "::error::${IMAGE}:${VERSION} has no manifest (HTTP 404) - the tag was never pushed."
+              exit 1 ;;
+            *)
+              echo "::error::ghcr returned HTTP ${CODE} for ${IMAGE}:${VERSION}."
+              exit 1 ;;
+          esac
+          node -e '
+            const index = JSON.parse(require("node:fs").readFileSync("manifest.json", "utf8"))
+            const platforms = (index.manifests ?? []).map((m) => `${m.platform?.os}/${m.platform?.architecture}`)
+            const missing = ["linux/amd64", "linux/arm64"].filter((p) => !platforms.includes(p))
+            if (missing.length > 0) {
+              console.log(`::error::${process.env.IMAGE}:${process.env.VERSION} is missing ${missing.join(", ")}. Found: ${platforms.join(", ") || "no manifest list"}. If the GHCR package is private, make it public before submitting.`)
+              process.exit(1)
+            }
+            console.log(`Image is public and serves ${platforms.join(", ")}.`)
+          '
+          rm -f manifest.json
+
+      - name: Assert the fork and fast-forward its default branch
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.OPERATOR_CATALOG_TOKEN }}
+          FORK: ${{ matrix.catalog.fork }}
+          UPSTREAM: ${{ matrix.catalog.upstream }}
+        run: |
+          set -euo pipefail
+          # Not `gh repo sync --source`: that calls POST /merge-upstream first,
+          # an endpoint which takes neither a source nor a force parameter, so
+          # --source is dead on the success path and a fork pointing at the
+          # WRONG parent would sync from the wrong repository and still exit 0.
+          # The parent is asserted instead, then merge-upstream is called
+          # directly, then the result is asserted.
+          PARENT=$(gh api "repos/${FORK}" --jq .parent.full_name)
+          if [ "${PARENT}" != "${UPSTREAM}" ]; then
+            echo "::error::${FORK} is a fork of '${PARENT}', not of '${UPSTREAM}'. A fork's parent cannot be changed - re-create it from the upstream, or transfer the existing fork."
+            exit 1
+          fi
+          gh api -X POST "repos/${FORK}/merge-upstream" -f branch=main --jq .message
+          # The upstream pipeline rebases the submission branch onto the
+          # catalog's default branch and fails loudly if it cannot, so a fork
+          # whose main carries commits the upstream lacks has to stop us here
+          # rather than upstream.
+          STATUS=$(gh api "repos/${UPSTREAM}/compare/main...${FORK%%/*}:${FORK##*/}:main" --jq .status)
+          case "${STATUS}" in
+            identical|behind) echo "Fork main is ${STATUS} relative to upstream main." ;;
+            *) echo "::error::${FORK} main is '${STATUS}' relative to ${UPSTREAM} main; it carries commits upstream does not have. Reset it before submitting."; exit 1 ;;
+          esac
+
+      - name: Checkout the catalog repository
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          repository: ${{ matrix.catalog.upstream }}
+          ref: main
+          path: catalog
+          persist-credentials: false
+
+      - name: Decide whether to submit, and what this bundle replaces
+        if: steps.gate.outputs.enabled == 'true'
+        id: decide
+        env:
+          # The search API is rate limited hard for anonymous callers, and an
+          # unread search must fail the step rather than default to "submit".
+          GITHUB_TOKEN: ${{ secrets.OPERATOR_CATALOG_TOKEN }}
+        run: |
+          set -euo pipefail
+          node scripts/operator-catalog-submission.mjs decide \
+            --version "${{ needs.build-and-push.outputs.version }}" \
+            --operator-dir catalog/operators/libredb-studio-operator \
+            --repo "${{ matrix.catalog.upstream }}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Report a skip
+        if: steps.gate.outputs.enabled == 'true' && steps.decide.outputs.enabled != 'true'
+        run: |
+          # A warning rather than a notice: every skip here means a release did
+          # not reach a catalog, and one of them (an older submission still
+          # open) mutes every later release until somebody acts on it.
+          echo "::warning::${{ matrix.catalog.upstream }} - ${{ steps.decide.outputs.reason }}"
+
+      - name: Stage the bundle
+        if: steps.decide.outputs.enabled == 'true'
+        env:
+          VERSION: ${{ needs.build-and-push.outputs.version }}
+          IMAGE: ${{ needs.build-and-push.outputs.image }}
+          REPLACES: ${{ steps.decide.outputs.replaces }}
+        run: |
+          set -euo pipefail
+          DEST="catalog/operators/libredb-studio-operator/${VERSION}"
+          CSV="operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml"
+          # The directory is named from the release version while its contents
+          # come from the committed bundle, and nothing upstream of here proves
+          # those agree: the bundle-freshness job only runs when a pull request
+          # touches operator/, so a version bump that skipped `make -C operator
+          # bundle` would submit the previous bundle under the new number.
+          grep -qx "  version: ${VERSION}" "$CSV" || {
+            echo "::error::${CSV} does not declare version ${VERSION}. Run 'make -C operator bundle' and commit the result."
+            exit 1
+          }
+          grep -q "containerImage: ${IMAGE}:${VERSION}$" "$CSV" || {
+            echo "::error::${CSV} does not stamp containerImage ${IMAGE}:${VERSION}. Run 'make -C operator bundle' and commit the result."
+            exit 1
+          }
+          mkdir -p "$DEST"
+          cp -R operator/bundle/. "$DEST/"
+          # spec.replaces is absent from the committed bundle on purpose: its
+          # only correct value names a version in THIS catalog, which this
+          # repository cannot derive. It is injected here, or omitted entirely
+          # on a first submission.
+          if [ -n "${REPLACES}" ]; then
+            node scripts/operator-catalog-submission.mjs set-replaces \
+              --csv "$DEST/manifests/libredb-studio-operator.clusterserviceversion.yaml" \
+              --replaces "${REPLACES}"
+          else
+            echo "First submission in this catalog - no replaces to set."
+          fi
+
+      - name: Write release-config.yaml for the FBC catalog
+        if: steps.decide.outputs.enabled == 'true' && matrix.catalog.release_config
+        env:
+          VERSION: ${{ needs.build-and-push.outputs.version }}
+          REPLACES: ${{ steps.decide.outputs.replaces }}
+        run: |
+          set -euo pipefail
+          # Without this file the release pipeline only prints the manual
+          # instructions instead of opening the rendered-catalog PR itself.
+          # `replaces` and not `skipRange`: with a skipRange alone the rendered
+          # channel keeps two heads and `opm validate` rejects it with
+          # "multiple channel heads found in graph" (measured on
+          # community-operators-prod#11106).
+          CONFIG="catalog/operators/libredb-studio-operator/${VERSION}/release-config.yaml"
+          {
+            echo "---"
+            echo "catalog_templates:"
+            echo "  - template_name: basic.yaml"
+            echo "    channels: [alpha]"
+            if [ -n "${REPLACES}" ]; then
+              echo "    replaces: ${REPLACES}"
+            fi
+          } > "$CONFIG"
+          cat "$CONFIG"
+
+      - name: Open or update the submission PR
+        if: steps.decide.outputs.enabled == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          path: catalog
+          push-to-fork: ${{ matrix.catalog.fork }}
+          token: ${{ secrets.OPERATOR_CATALOG_TOKEN }}
+          base: main
+          branch: libredb-studio-operator-${{ needs.build-and-push.outputs.version }}
+          # Never delete the head branch from here: deleting it closes the PR
+          # and GitHub then refuses to reopen it.
+          delete-branch: false
+          add-paths: operators/libredb-studio-operator
+          # DCO, not GPG: upstream's "signed" requirement is the Developer
+          # Certificate of Origin, and the trailer email must match the author.
+          signoff: true
+          committer: Mehmet Cevheri BOZOGLAN <cevheribozoglan@gmail.com>
+          author: Mehmet Cevheri BOZOGLAN <cevheribozoglan@gmail.com>
+          commit-message: |
+            operator libredb-studio-operator (${{ needs.build-and-push.outputs.version }})
+          title: operator libredb-studio-operator (${{ needs.build-and-push.outputs.version }})
+          body: |
+            Update libredb-studio-operator to ${{ needs.build-and-push.outputs.version }}.
+
+            Release notes: https://github.com/libredb/libredb-studio/releases/tag/${{ needs.build-and-push.outputs.version }}
+            Controller image: `${{ needs.build-and-push.outputs.image }}:${{ needs.build-and-push.outputs.version }}`, public, linux/amd64 and linux/arm64.
+
+            ${{ steps.decide.outputs.reason }}
+
+            Opened by this repository's release workflow.

--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -22,11 +22,18 @@ on:
         type: string
 
 concurrency:
-  # NOT keyed on the ref. Two releases in flight would otherwise race the
-  # submission's "an older submission is still open" guard, which reads the
-  # catalog's default branch and so cannot see a submission opened seconds
-  # earlier by the other run.
-  group: operator-release
+  # Keyed on the ref on purpose, even though a global group would serialize
+  # the submission's "an open submission for another version" guard, which
+  # reads the catalog's default branch and so cannot see a pull request opened
+  # seconds earlier by another run.
+  #
+  # A global group costs more than that race. GitHub keeps only ONE pending
+  # run per group: a third release cancels the second while the first is still
+  # running, `cancel-in-progress: false` or not, and a cancelled run means no
+  # image and no submission for that version, silently. The race it would
+  # prevent is loud instead: two submissions naming the same predecessor fail
+  # the second merge upstream with "multiple channel heads".
+  group: operator-release-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -177,11 +184,11 @@ jobs:
         catalog:
           - label: operatorhub.io
             upstream: k8s-operatorhub/community-operators
-            fork: cevheri/community-operators
+            fork: libredb/community-operators
             release_config: false
           - label: OpenShift console
             upstream: redhat-openshift-ecosystem/community-operators-prod
-            fork: cevheri/community-operators-prod
+            fork: libredb/community-operators-prod
             release_config: true
     steps:
       - name: Checkout code
@@ -321,7 +328,8 @@ jobs:
           node scripts/operator-catalog-submission.mjs decide \
             --version "${{ needs.build-and-push.outputs.version }}" \
             --operator-dir catalog/operators/libredb-studio-operator \
-            --repo "${{ matrix.catalog.upstream }}" | tee -a "$GITHUB_OUTPUT"
+            --repo "${{ matrix.catalog.upstream }}" \
+            --fork "${{ matrix.catalog.fork }}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Report a skip
         if: steps.gate.outputs.enabled == 'true' && steps.decide.outputs.enabled != 'true'

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -675,6 +675,12 @@ channels:
     update:
       method: upstream_pr
       sla: every_release
+      # Submission is automated from operator-release.yml (#656). The switch is
+      # here because the submission can be legitimately impossible: the first
+      # listing in a catalog is manual, an earlier submission may still be
+      # unmerged, and OPERATOR_CATALOG_TOKEN may be absent - none of which is a
+      # broken release.
+      ci_enabled: true
     links:
       tracking_issue: https://github.com/libredb/libredb-studio/issues/152
       first_pr: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/10497
@@ -687,7 +693,7 @@ channels:
       urls:
         operatorhub-io: https://api.github.com/repos/k8s-operatorhub/community-operators/contents/operators/libredb-studio-operator
         openshift-console: https://api.github.com/repos/redhat-openshift-ecosystem/community-operators-prod/contents/operators/libredb-studio-operator
-      note: Both catalogs are listed - OpenShift console since 0.9.59 (bundle community-operators-prod#10497
+      note: Submitted automatically by the submit-catalogs job in operator-release.yml (#656); ci_enabled above is its switch. Both catalogs are listed - OpenShift console since 0.9.59 (bundle community-operators-prod#10497
         merged 2026-07-27, FBC catalogs community-operators-prod#10581), operatorhub.io since
         k8s-operatorhub/community-operators#8794 merged 2026-09-08. These are the COMMUNITY catalogs, not the
         Red Hat certified one, so the OpenShift console lists the operator under Community with its
@@ -698,7 +704,7 @@ channels:
         start once the operator controller image is public on GHCR; community-operators-prod is contributed in
         FBC mode (fbc.enabled plus per-OCP-version catalog_mapping in ci.yaml). An FBC release is two upstream
         PRs - bundle first, then the rendered catalogs - and that second PR is only bot-created when the
-        bundle version directory ships a release-config.yaml, so every release must include one.
+        bundle version directory ships a release-config.yaml, which submit-catalogs writes.
 
   # ---- Tier 4: partner and curated catalogs (not self-serve) --------------
 

--- a/docs/CHANNELS.md
+++ b/docs/CHANNELS.md
@@ -62,7 +62,7 @@ Live channels by platform: **Linux 8 · macOS 3 · Windows 4 · Container 5 · K
 | [Docker image (GHCR)](https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio) | Containers | Container | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Docker Hub mirror](https://hub.docker.com/r/libredb/libredb-studio) | Containers | Container | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Helm chart](https://artifacthub.io/packages/helm/libredb-studio/libredb-studio) | Kubernetes & operators | Kubernetes | live | Automated, every release | [HELM_CHART.md](HELM_CHART.md) |
-| [OperatorHub / OpenShift](https://operatorhub.io/operator/libredb-studio-operator) | Kubernetes & operators | Kubernetes | live | Manual, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
+| [OperatorHub / OpenShift](https://operatorhub.io/operator/libredb-studio-operator) | Kubernetes & operators | Kubernetes | live | Automated PR, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Rancher Partner Charts](https://www.suse.com/pcsc/viewVersionPage?versionID=26969) | Kubernetes & operators | Kubernetes | live | Manual, on demand | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [Chocolatey](https://community.chocolatey.org/packages/libredb-studio) | Package managers | Windows | live | Automated, every release | [DISTRIBUTION.md](DISTRIBUTION.md) |
 | [FlatPark (Flatpak)](https://flatpark.org/) | Package managers | Linux | live | Manual, every release | [packaging/flatpark/README.md](../packaging/flatpark/README.md) |

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -448,6 +448,9 @@ A skip that means a release did not reach a catalog is a `::warning::` rather th
 | an open submission for any other version | see below, this one is a hard stop |
 | the release is a prerelease | the catalogs take bare semver directories only |
 
+Three conditions are hard failures rather than skips, because each is a misconfiguration on our side that would otherwise break the channel quietly:
+the controller image is not anonymously pullable, the fork's `parent` is not the upstream, and a GitHub API read fails.
+
 Two things it refuses rather than guesses.
 A GitHub API read that fails stops the job instead of defaulting to "submit", because a decision made on an unread search is how a duplicate or a graph-breaking pull request gets opened.
 And a fork whose `parent` is not the upstream stops the job: `gh repo sync --source` cannot be trusted for that check, since it calls `POST /merge-upstream` first and that endpoint takes neither a source nor a force parameter, so a fork pointing at the wrong parent would sync from the wrong repository and still exit 0.
@@ -474,9 +477,9 @@ Our list is `cevheri` and `yusuf-gundogdu`, so the token must belong to one of t
 Signing is DCO, not GPG.
 `create-pull-request` writes the `Signed-off-by` trailer from its **committer** input, whose default is `github-actions[bot]`, so `committer` and `author` are both set to the same real identity; `sign-commits` stays off, because it recreates commits through the API and discards those identities, leaving a trailer that no longer matches the author.
 
-The forks are currently `cevheri/community-operators` and `cevheri/community-operators-prod`.
-If they move under the `libredb` organization, **transfer** them; do not fork the fork.
-An org fork created from a personal fork records the personal fork as its parent, a parent cannot be changed afterwards, and the only escape ("leave fork network") is permanent and destroys the pull requests.
+The forks are `libredb/community-operators` and `libredb/community-operators-prod`.
+They were **transferred** from the `cevheri` account rather than re-forked, which is the only way that keeps `parent` pointing at the upstream: an org fork created from a personal fork records the personal fork as its parent, a parent cannot be changed afterwards, and the only escape ("leave fork network") is permanent and destroys the pull requests.
+The job asserts that parent on every run for the same reason.
 
 What stays manual: the first listing in each catalog, the merge itself (the hub automerges once its checks pass, prod merges on its own pipeline), and the operatorhub.io index publication, which lags a merge by hours.
 
@@ -1685,14 +1688,16 @@ deliverable (`pin.strategy: local_file` for the version-pinned `fly.toml`; `none
   ([community-operators-prod#10581](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/10581)),
   and operatorhub.io via its bundle PR
   ([k8s-operatorhub/community-operators#8794](https://github.com/k8s-operatorhub/community-operators/pull/8794),
-  merged 2026-09-08). `operatorhub-community` is `live` accordingly. Two things
-  the merge does *not* finish: operatorhub.io serves from its own index build,
-  which lags the merge by hours (`https://operatorhub.io/api/operator?packageName=libredb-studio-operator`
-  is the read that answers for it — it returned "can't find" while a control
-  query for `argocd-operator` returned a full record), and both catalogs still
-  serve **0.9.59**, so every release from here is an upstream bump PR per
-  catalog. Remember `release-config.yaml` in each bundle PR (see
-  [An FBC release is two upstream PRs](#an-fbc-release-is-two-upstream-prs)).
+  merged 2026-09-08). `operatorhub-community` is `live` accordingly.
+  Both catalogs carried only 0.9.59 for weeks after that, which is why the
+  per-release submission is now automated; 0.14.1 was the catch-up, landing as
+  k8s-operatorhub/community-operators#9219 and community-operators-prod#11106.
+  One thing a merge still does not finish: operatorhub.io serves from its own
+  index build, which lags by hours.
+  `https://operatorhub.io/api/operator?packageName=libredb-studio-operator` is
+  the read that answers for it, and it returned "can't find" for hours after
+  #8794 merged while a control query for `argocd-operator` returned a full
+  record.
 - **Snap Store listing screenshots**: the description and icon ship with the snap
   (`snap/snapcraft.yaml`, `public/logo.svg`), but screenshots are a manual upload in the
   Snap Store web UI (https://snapcraft.io/libredb-studio/listing). The snap name is registered

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -398,20 +398,26 @@ carries a `release-config.yaml`**; otherwise the release pipeline just prints
 the manual instructions in its summary comment. 0.9.59 shipped without one, so
 its catalog PR
 ([community-operators-prod#10581](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/10581))
-was rendered and opened by hand. From 0.9.60 on, include this file in the
-bundle PR as `operators/libredb-studio-operator/<version>/release-config.yaml`:
+was rendered and opened by hand. Every submission since carries the file at
+`operators/libredb-studio-operator/<version>/release-config.yaml`, written by
+the `submit-catalogs` job rather than by hand:
 
 ```yaml
 ---
 catalog_templates:
   - template_name: basic.yaml
     channels: [alpha]
-    skipRange: '>=0.0.0 <<version>'
+    replaces: libredb-studio-operator.v<previous version in this catalog>
 ```
 
-`skipRange` here is the FBC half of the update graph; the CSV also carries a
-`spec.replaces` pointer, which is what the operatorhub.io side requires. See
-[The update graph: replaces, plus skipRange](#the-update-graph-replaces-plus-skiprange).
+`replaces` and not `skipRange`. A skipRange contributes no edge to the FBC
+graph, so the rendered channel keeps two heads and `opm validate` rejects the
+catalog with `multiple channel heads found in graph` - measured on
+community-operators-prod#11106, whose `add-bundle-to-fbc-dryrun` failed exactly
+that way before the field was changed. The value is the same derived
+predecessor the CSV's `spec.replaces` carries and is written at submission
+time rather than stored in this repo; see
+[The update graph](#the-update-graph).
 Per the pipeline's own schema
 ([`release-config-schema.json`](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/operatorcert/schemas/release-config-schema.json))
 only `template_name` and `channels` are required; `replaces`, `skips` and
@@ -422,42 +428,100 @@ each *newly added* OpenShift version's catalog) and does not substitute for
 (k8s-operatorhub/community-operators) has no such second step: its
 bundle-directory PR is the whole listing.
 
-### The update graph: replaces, plus skipRange
+### Automated submission
 
-Both catalogs need to know where a new bundle sits relative to the last one.
-Two upstream gates check that, and they do not agree on how it may be expressed, so the bundle carries both fields.
+Both submissions are opened by the `submit-catalogs` job in
+[`.github/workflows/operator-release.yml`](../.github/workflows/operator-release.yml) (issue #656).
+It runs with `needs: build-and-push`, because the catalog pipelines pull the controller image onto a real cluster and it has to exist and be public first.
+The job is a matrix over the two catalogs with `fail-fast: false`: they have independent review queues and one failing must not cancel the other.
 
-- **`spec.replaces`** is the one that is actually required.
-  The k8s-operatorhub deploy jobs build a test catalog with `opm index add --mode replaces`, and the mode is read straight from the submission's `ci.yaml` (`Setting index add mode from 'updateGraph' value to 'replaces'` in the job log).
-  That command reads `spec.replaces` and `spec.skips` only.
-  With neither, it prunes the previous bundle out of the channel and the job fails:
+The submission is switched from `distribution/channels.yaml` like every other optional channel, via `update.ci_enabled` on `operatorhub-community`.
+Every "nothing to do" branch exits 0 and names the condition, so a legitimately impossible submission never paints a release run red.
+A skip that means a release did not reach a catalog is a `::warning::` rather than a `::notice::`, because one of them mutes every later release until somebody acts on it:
 
-  ```
-  add prunes bundle libredb-studio-operator.v0.9.59 ... channel alpha:
-  this may be due to incorrect channel head (...v0.14.1, skips/replaces [])
-  ```
+| Condition | Why it is not a failure |
+|---|---|
+| `update.ci_enabled` is not `true` | the channel is switched off in the inventory |
+| `OPERATOR_CATALOG_TOKEN` absent | a fork has no token, and the workflow still has to run |
+| the operator has no directory in that catalog | a first listing needs review and metadata this path does not carry |
+| the catalog already carries this version | a rerun after a merge |
+| an open submission for any other version | see below, this one is a hard stop |
+| the release is a prerelease | the catalogs take bare semver directories only |
 
-  This is what failed the first 0.14.1 submission.
-  Measured locally against the same command with a local registry and two bundle images:
-  `--mode replaces` with only a skipRange exits 1, with `spec.replaces` exits 0, and `--mode semver` with only a skipRange exits 0.
-- **`olm.skipRange`** (`>=0.0.0 <$(VERSION)`) is kept as well.
-  It lets a cluster jump straight to this version instead of stepping through, it is what the FBC `release-config.yaml` accepts, and it satisfies `check_dangling_bundles` in [operatorcert](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/operatorcert/static_tests/community/bundle.py), which seeds its graph from `_resolve_skip_range` before it looks at the pointers.
+Two things it refuses rather than guesses.
+A GitHub API read that fails stops the job instead of defaulting to "submit", because a decision made on an unread search is how a duplicate or a graph-breaking pull request gets opened.
+And a fork whose `parent` is not the upstream stops the job: `gh repo sync --source` cannot be trusted for that check, since it calls `POST /merge-upstream` first and that endpoint takes neither a source nor a force parameter, so a fork pointing at the wrong parent would sync from the wrong repository and still exit 0.
+The job asserts the parent, calls `merge-upstream` directly, then asserts the fork is `identical` or `behind`.
 
-Note the trap in that pair: the static check passes on a skipRange alone, so **a green `check_dangling_bundles` is not evidence that the submission will build.** The binding gate is the deploy job.
+**Any unmerged submission for another version is a hard stop.**
+The predecessor is derived from the catalog's `main`, so a submission that is open but unmerged is invisible to it.
+Submitting past a pending version points the graph over it, and once both merge the pending bundle is dangling.
+The skip names the blocking version and its pull request number, because a skip that does not say what to go and merge is a mute.
+A version the catalog already carries is never treated as pending, whatever an open pull request does to its directory.
+This is what lost VictoriaMetrics 0.48.2, and their record is the reason to take it seriously: `victoriametrics-bot` landed 45 of 50 submissions on operatorhub.io, and four of the five that did not land are versions the catalog has never carried.
 
-`make -C operator bundle` stamps both fields next to the `containerImage` stamp and greps each one back, because sed exits 0 on zero matches and an unparseable skipRange is *ignored with a log warning* rather than rejected.
-`tests/unit/operator-bundle-update-graph.test.ts` asserts both offline.
+Detection is **path-based, never title-based**.
+The hub rewrites submission titles on open and on every push, inserting markers in a fixed order (`operator [O] [R] [N] [CI] [PK] <name> (<versions>)`) and listing more than one version for a multi-version pull request.
+Our own #8794 was accepted and renamed to `operator [N] [CI] libredb-studio-operator (0.9.59)`.
+So the job searches for open pull requests mentioning the operator and then reads each one's changed files, treating `operators/<operator>/<version>/...` as the submission and ignoring a `ci.yaml` edit or the bot's `catalogs/v4.x/...` follow-up.
+`scripts/operator-catalog-submission.mjs` holds that logic as pure functions, tested in `tests/unit/operator-catalog-submission.test.ts`; the workflow step is a thin caller.
 
-Three details that are load bearing:
+**Identity matters more than the fork does.**
+Upstream's authorization check compares the account that OPENED the pull request against the operator's `ci.yaml` `reviewers` list on the base branch, and nothing reads the fork owner or the commit author: `opp-env.sh` does it case-insensitively for the hub's `authorized-changes` label, and `check_permissions.py` does the same for the prod `approved` label.
+Our list is `cevheri` and `yusuf-gundogdu`, so the token must belong to one of them; a separate bot identity would have to be added upstream first, and every PR would wait for a human label until it was.
+`OPERATOR_CATALOG_TOKEN` is therefore a **classic** PAT with `public_repo` on one of those accounts: a fine-grained token cannot be granted pull-request write on a repository we do not own, and `wingetcreate`'s secret carries the same constraint for the same reason.
 
-- **`CATALOG_REPLACES` in `operator/Makefile` is hand-maintained, and has to be.** Its value is the newest version the catalogs actually serve, which is not derivable from `package.json`: it lags our releases by however many submissions are unmerged, and 0.14.0 was never submitted at all.
-  The `operatorhub-community` row of `bun run distribution:check` is what measures that lag.
-  Bump it when a submission merges upstream.
-  Forgetting is loud rather than silent, because the next submission fails upstream with the same prune error.
-- **The skipRange upper bound is exclusive.** `<=$(VERSION)` would put the bundle inside its own skip range.
-- **Do not switch `updateGraph` to `semver-mode` to avoid the pointer.** It works (measured above) and it would remove the hand-maintained value, since the graph becomes the sorted bundle list.
-  But upstream marks the switch as one-way and forbids `spec.replaces` under it, which would permanently cost us the ability to publish a leaf or out-of-order bundle.
-  The prose docs also call `semver-mode` the default while the implementation defaults to `replaces-mode` (`config.get("updateGraph", "replaces-mode")`), so the mode stays written out explicitly in each submission's `ci.yaml`.
+Signing is DCO, not GPG.
+`create-pull-request` writes the `Signed-off-by` trailer from its **committer** input, whose default is `github-actions[bot]`, so `committer` and `author` are both set to the same real identity; `sign-commits` stays off, because it recreates commits through the API and discards those identities, leaving a trailer that no longer matches the author.
+
+The forks are currently `cevheri/community-operators` and `cevheri/community-operators-prod`.
+If they move under the `libredb` organization, **transfer** them; do not fork the fork.
+An org fork created from a personal fork records the personal fork as its parent, a parent cannot be changed afterwards, and the only escape ("leave fork network") is permanent and destroys the pull requests.
+
+What stays manual: the first listing in each catalog, the merge itself (the hub automerges once its checks pass, prod merges on its own pipeline), and the operatorhub.io index publication, which lags a merge by hours.
+
+### The update graph
+
+Both catalogs need to know where a new bundle sits relative to the last one, or the older bundle becomes a *dangling* bundle and the catalog build fails.
+The graph is expressed in two fields, and only one of them is knowable from this repo.
+
+**`olm.skipRange`, owned by the repo.**
+`make -C operator bundle` stamps `>=0.0.0 <$(VERSION)` into the CSV annotations, next to the `containerImage` stamp, and greps it back.
+"Supersede everything below me" is derivable from `package.json` and stays true however many releases go unsubmitted.
+The upper bound is exclusive on purpose; `<=` would put the bundle inside its own skip range.
+Note the upstream failure mode this stamp-and-verify guards against: an unparseable range is *ignored with a log warning* by `_resolve_skip_range` rather than rejected, so a typo would degrade to no range at all and only surface later as a dangling bundle.
+The range is parsed by `semantic_version.NpmSpec`.
+
+**`spec.replaces`, injected at submission time and deliberately absent here.**
+Its only correct value is the version immediately preceding this one *in the catalog being submitted to*.
+That is external state: it lags our releases by however many submissions are unmerged, and the two catalogs disagree with each other.
+Nothing in this repo can derive it, so nothing in this repo declares it.
+The submission path derives it from the catalog itself and patches it into the bundle copy.
+
+The consequence looks like an omission and is not: **the committed bundle on its own does not pass `opm index add --mode replaces`.**
+Measured, with a local registry and two bundle images:
+
+| `--mode` | bundle | exit |
+|---|---|---|
+| `replaces` | committed bundle, skipRange only | 1, `add prunes bundle libredb-studio-operator.v0.9.59` |
+| `replaces` | with `spec.replaces` injected | 0 |
+| `semver` | committed bundle, skipRange only | 0 |
+
+`tests/unit/operator-bundle-update-graph.test.ts` asserts that absence rather than merely documenting it, because the obvious "fix" is to add a declared value back, and a declared value is correct only by coincidence and stale by default.
+
+Two facts about the gates, both learned the hard way on the first 0.14.1 submission:
+
+- **The binding gate is the deploy job, not the static check.**
+  The k8s-operatorhub deploy jobs (`kiwi`, `lemon`, `orange`) build a test catalog with `opm index add --mode replaces`, and the mode is read straight from the submission's `ci.yaml`: `Setting index add mode from 'updateGraph' value to 'replaces'` in the job log.
+  That command reads `spec.replaces` and `spec.skips` and never `olm.skipRange`.
+- **A green `check_dangling_bundles` proves nothing about that.**
+  The static check in [operatorcert](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/operatorcert/static_tests/community/bundle.py) seeds its graph from `_resolve_skip_range` before it looks at the pointers, so it passes on a skipRange alone; it is also decorated `@skip_fbc`, so it never runs for community-operators-prod.
+  A submission that passes it can still fail to build.
+
+**Do not switch `updateGraph` to `semver-mode` to avoid the pointer.**
+It works, and it would remove the pointer entirely, since the graph becomes the sorted bundle list.
+But upstream marks the switch as one-way and forbids `spec.replaces` under it, which would permanently cost us the ability to publish a leaf or out-of-order bundle.
+Note also that the prose docs call `semver-mode` the default while the implementation defaults to `replaces-mode` (`config.get("updateGraph", "replaces-mode")`), so the mode stays written out explicitly in each submission's `ci.yaml`.
 
 ## npx
 
@@ -1279,6 +1343,7 @@ setups still publish the rest:
 | `DOCKER_HUB_TOKEN` (+ `DOCKER_HUB_USERNAME` and `DOCKER_HUB_ORGANIZATION` variables) | The Docker Hub mirror push. Two variables, not one: `DOCKER_HUB_USERNAME` is the **owner who logs in** (an organization cannot sign in), `DOCKER_HUB_ORGANIZATION` is the **namespace the image is published under**. They were the same value while `libredb` was a user account; converting it to an organization on 2026-09-01 split them | GHCR-only publish |
 | `CHOCO_API_KEY` | The chocolatey job: `choco pack` + `choco push` to `https://push.chocolatey.org/` (API key of the `libredb` community account) | Chocolatey publish skipped; the win32 zip still attaches to the release |
 | — | Every row above whose channel is switchable also needs `update.ci_enabled: true` in [`distribution/channels.yaml`](../distribution/channels.yaml): the secret says CI *can* publish, the flag says it *should*. See [Turning a channel's automation off](#turning-a-channels-automation-off) | Channel skipped with a notice; the release publishes normally |
+| `OPERATOR_CATALOG_TOKEN` | The `submit-catalogs` job in `operator-release.yml`: bundle PRs to `k8s-operatorhub/community-operators` and `redhat-openshift-ecosystem/community-operators-prod`. Classic PAT with `public_repo` on an account in the operator's upstream `ci.yaml` reviewers list, because that login is what upstream authorizes | Catalog submission skipped with a notice |
 | `WINGETCREATE_GITHUB_TOKEN` | The winget job: `wingetcreate update --submit` PRs to `microsoft/winget-pkgs`. Classic PAT with `public_repo` scope — wingetcreate does not support fine-grained PATs | winget submission skipped |
 
 The chocolatey and winget jobs run strictly **after** `publish-release`: both channels download
@@ -1546,14 +1611,16 @@ secret is present.
 
 Three deliberate constraints:
 
-- **Only optional channels may carry the flag:** `docker-hub-mirror`, `homebrew`, `snap`,
-  `winget`, `chocolatey`. The core release path (`github-release`, `docker-ghcr`, `npm`, `helm`)
+- **Only optional channels may carry the flag:** the set is
+  `SWITCHABLE_CHANNEL_IDS` in [`scripts/distribution-check.mjs`](../scripts/distribution-check.mjs),
+  which is the list - it is not restated here, because a copy would go stale
+  the next time a channel joins. The core release path (`github-release`, `docker-ghcr`, `npm`, `helm`)
   and the assets `publish-release` requires (`.deb`/`.rpm`, AppImage, the win32 zip) have no
   switch, because one mistyped `false` there would silently ship a release with no npm package or
   no image. `parseChannels` **rejects** the flag anywhere else, so this is enforced, not just
   documented.
-- **It is required, never defaulted,** on those five: CI behaviour for a channel has to be a
-  stated decision in this file, not an omission.
+- **It is required, never defaulted,** on every channel in that set: CI behaviour for a channel
+  has to be a stated decision in this file, not an omission.
 - **Failure leaves channels off, never the release blocked.** The `channels` job is
   `continue-on-error`; if it cannot run, its outputs are empty, every gate reads "not true", and
   the optional channels skip while the release publishes normally. A forgotten re-enable surfaces
@@ -1602,7 +1669,10 @@ deliverable (`pin.strategy: local_file` for the version-pinned `fly.toml`; `none
 
 ### Manual steps still open
 
-- **Operator first listings — done.** The controller image was the first half:
+- **Operator first listings and per-release submissions: done.**
+  Submissions are automated, see [Automated submission](#automated-submission).
+  What follows is how the first ones landed.
+  The controller image was the first half:
   `ghcr.io/libredb/libredb-studio-operator:0.9.59` was built once by manual
   `workflow_dispatch` from the post-merge `main` commit (the `0.9.59` tag
   carries neither `operator/` nor the workflow file, and GitHub only dispatches

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -38,25 +38,6 @@ IMAGE_TAG_BASE ?= ghcr.io/libredb/libredb-studio-operator
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
-# CATALOG_REPLACES is the newest version the community catalogs actually
-# serve, which is what this bundle supersedes in channel `alpha`. It is NOT
-# derivable from package.json: it lags our releases by however many
-# submissions are still unmerged (0.14.0 was never submitted), and the
-# `operatorhub-community` row of `bun run distribution:check` is what measures
-# that lag.
-#
-# It has to be a real field rather than only a skipRange, because the
-# k8s-operatorhub deploy jobs build their catalog with `opm index add --mode
-# replaces` (the mode is read straight from the submission's ci.yaml) and that
-# command looks at spec.replaces and spec.skips ONLY. With a skipRange alone
-# it prunes the previous bundle out of the channel and fails. Measured against
-# the real command: replaces-mode plus skipRange alone exits 1, replaces-mode
-# plus this pointer exits 0.
-#
-# Bump this when a submission merges upstream. Forgetting is loud rather than
-# silent - the next submission fails upstream with that same prune error.
-CATALOG_REPLACES ?= 0.9.59
-
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
@@ -226,13 +207,13 @@ bundle: kustomize operator-sdk ## Generate bundle manifests and metadata, then v
 	# fail the build, not ship an unstamped CSV.
 	@grep -q 'containerImage: $(IMG)$$' bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml || \
 		{ echo "ERROR: containerImage stamp failed - restore the containerImage annotation in config/manifests/bases"; exit 1; }
-	# Stamp the update-graph range the community catalogs read. k8s-operatorhub
-	# runs this operator in replaces-mode, whose dangling-bundle static check
-	# seeds its graph from olm.skipRange before it looks at spec.replaces - so
-	# this annotation carries the graph and no version of it has to be
-	# remembered by hand: "supersede everything below me" stays true however
-	# many releases go unsubmitted. The upper bound is exclusive on purpose; a
-	# <= would make the bundle skip itself.
+	# Stamp the half of the update graph this repo can know. "Supersede
+	# everything below me" is derivable from $(VERSION) and stays true however
+	# many releases go unsubmitted, so it belongs here. The other half,
+	# spec.replaces, names a version in a specific catalog and is injected at
+	# submission time instead - see docs/DISTRIBUTION.md, "The update graph".
+	# The upper bound is exclusive on purpose; a <= would make the bundle skip
+	# itself.
 	sed -e "s|olm.skipRange: '>=0.0.0 <.*'|olm.skipRange: '>=0.0.0 <$(VERSION)'|" \
 		bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml > bundle/manifests/.csv.tmp
 	mv bundle/manifests/.csv.tmp bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -241,14 +222,6 @@ bundle: kustomize operator-sdk ## Generate bundle manifests and metadata, then v
 	# skipRange" and fail there as a dangling bundle. Verify it landed here.
 	@grep -q "olm.skipRange: '>=0.0.0 <$(VERSION)'$$" bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml || \
 		{ echo "ERROR: olm.skipRange stamp failed - restore the olm.skipRange annotation in config/manifests/bases"; exit 1; }
-	# Stamp the bundle this one replaces in the channel. The base CSV holds a
-	# v0.0.0 placeholder; see CATALOG_REPLACES above for why the value cannot
-	# be derived from $(VERSION).
-	sed -e 's|replaces: libredb-studio-operator.v.*|replaces: libredb-studio-operator.v$(CATALOG_REPLACES)|' \
-		bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml > bundle/manifests/.csv.tmp
-	mv bundle/manifests/.csv.tmp bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
-	@grep -q '^  replaces: libredb-studio-operator.v$(CATALOG_REPLACES)$$' bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml || \
-		{ echo "ERROR: replaces stamp failed - restore the replaces field in config/manifests/bases"; exit 1; }
 	# The operatorframework suite is what the community-operator pipelines run
 	# (operator-pipelines static tests); default validators alone skip the
 	# OperatorHub metadata checks.

--- a/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
     capabilities: Basic Install
     categories: Database, Developer Tools
     containerImage: ghcr.io/libredb/libredb-studio-operator:0.14.1
-    createdAt: "2026-09-08T14:52:40Z"
+    createdAt: "2026-09-08T15:36:12Z"
     description: Open-source web-based SQL IDE for sixteen engines - PostgreSQL, MySQL,
       Oracle, SQL Server, SQLite, DuckDB, MongoDB, Redis, Couchbase, ClickHouse, Apache
       Druid, Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra and libSQL
@@ -375,5 +375,4 @@ spec:
   provider:
     name: LibreDB
     url: https://libredb.org
-  replaces: libredb-studio-operator.v0.9.59
   version: 0.14.1

--- a/operator/config/manifests/bases/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/libredb-studio-operator.clusterserviceversion.yaml
@@ -104,5 +104,4 @@ spec:
   provider:
     name: LibreDB
     url: https://libredb.org
-  replaces: libredb-studio-operator.v0.0.0
   version: 0.0.0

--- a/scripts/distribution-check.mjs
+++ b/scripts/distribution-check.mjs
@@ -139,8 +139,20 @@ const STATUS_ORDER = { live: 0, pending: 1, deprecated: 2 };
  * there would be a way to ship a release with no npm package or no image, and
  * one mistyped `false` would do it silently. parseChannels rejects the flag
  * anywhere else, so that invariant is enforced, not merely documented.
+ *
+ * `operatorhub-community` qualifies on exactly the stated grounds (issue #656):
+ * its submission is an upstream pull request that a human merges, the first
+ * listing in a catalog is manual, and the token it needs may be absent - none
+ * of which should paint a release run red.
  */
-export const SWITCHABLE_CHANNEL_IDS = new Set(["docker-hub-mirror", "homebrew", "snap", "winget", "chocolatey"]);
+export const SWITCHABLE_CHANNEL_IDS = new Set([
+  "docker-hub-mirror",
+  "homebrew",
+  "snap",
+  "winget",
+  "chocolatey",
+  "operatorhub-community",
+]);
 
 /**
  * Probes measure channels whose served state is not one document a single
@@ -686,17 +698,26 @@ export function platformCell(platforms) {
     .join(", ");
 }
 
-/** Who bumps this channel and how fast. A dash for retired channels. */
+/**
+ * Who bumps this channel and how fast. A dash for retired channels.
+ *
+ * Three states, not two. `upstream_pr` with a CI switch means the submission
+ * is opened by our release workflow but merged by somebody else's maintainers
+ * (the community operator catalogs, issue #656) - calling that "Automated"
+ * would promise a landing we do not control, and "Manual" would hide the
+ * automation that exists.
+ */
 export function updateSummary(channel) {
   if (channel.status === "deprecated") {
     return "—";
   }
-  const automation =
-    channel.update.method === "ci_publish"
-      ? channel.update.ci_enabled === false
-        ? "Automated (paused)"
-        : "Automated"
-      : "Manual";
+  const paused = channel.update.ci_enabled === false;
+  let automation = "Manual";
+  if (channel.update.method === "ci_publish") {
+    automation = paused ? "Automated (paused)" : "Automated";
+  } else if (channel.update.method === "upstream_pr" && channel.update.ci_enabled !== undefined) {
+    automation = paused ? "Automated PR (paused)" : "Automated PR";
+  }
   return `${automation}, ${humanizeSla(channel.update.sla).toLowerCase()}`;
 }
 

--- a/scripts/operator-catalog-submission.mjs
+++ b/scripts/operator-catalog-submission.mjs
@@ -92,24 +92,39 @@ export function submittedVersions(paths, operator) {
 }
 
 /**
+ * Whether an open pull request is the one this workflow manages for this
+ * version: our fork, and the branch `create-pull-request` pushes.
+ *
+ * The distinction matters because the version exemption below would otherwise
+ * let a duplicate through the very hole it exists to close. A rerun for our
+ * own version must not block, since the action updates that branch in place -
+ * but a same-version submission from any other branch or fork is a second
+ * pull request for one version, and the action will never touch it.
+ */
+export function isManagedSubmission(head, fork, operator, version) {
+  return head.headRepo === fork && head.headRef === `${operator}-${version}`;
+}
+
+/**
  * Open submissions that must stop this one, each with the pull request that
  * holds it. The predecessor is read from the catalog's default branch, so an
  * unmerged submission is invisible to it: submitting past a pending version
  * would leave that bundle dangling once both merge, which is the failure mode
  * that lost VictoriaMetrics 0.48.2.
  *
- * Our own version is not a blocker - that is the rerun case, where the
- * existing pull request is updated in place. The pull request number IS
- * carried, because a skip that does not say what to go and merge is a mute.
+ * Our own version is only exempt when the pull request is the managed one -
+ * see isManagedSubmission. The pull request number IS carried, because a skip
+ * that does not say what to go and merge is a mute.
  *
- * @param {{number: number, versions: string[]}[]} openSubmissions
+ * @param {{number: number, versions: string[], managed: boolean}[]} openSubmissions
  * @returns {{version: string, number: number}[]}
  */
 export function blockingSubmissions(openSubmissions, version) {
   const blockers = new Map();
   for (const submission of openSubmissions) {
     for (const found of submission.versions) {
-      if (found !== version && !blockers.has(found)) {
+      const exempt = found === version && submission.managed;
+      if (!exempt && !blockers.has(found)) {
         blockers.set(found, submission.number);
       }
     }
@@ -121,7 +136,7 @@ export function blockingSubmissions(openSubmissions, version) {
 
 /**
  * @param {{version: string, operator: string, entries: string[] | null,
- *           openSubmissions: {number: number, versions: string[]}[]}} input
+ *           openSubmissions: {number: number, versions: string[], managed: boolean}[]}} input
  *   `entries` is null when the operator directory is absent upstream.
  * @returns {{enabled: boolean, reason: string, predecessor: string | null}}
  */
@@ -245,7 +260,7 @@ export function readOperatorEntries(operatorDir) {
  * `apiBase` is a parameter so the tests can point both endpoints at a local
  * server and the suite never touches the network.
  */
-export async function readOpenSubmissions({ apiBase, repo, operator, timeoutMs = 15000 }) {
+export async function readOpenSubmissions({ apiBase, repo, operator, fork, version, timeoutMs = 15000 }) {
   const query = encodeURIComponent(`repo:${repo} is:pr is:open ${operator}`);
   const search = await fetchJson(`${apiBase}/search/issues?q=${query}&per_page=100`, timeoutMs);
   if (!Array.isArray(search.items)) {
@@ -260,11 +275,22 @@ export async function readOpenSubmissions({ apiBase, repo, operator, timeoutMs =
     if (!Array.isArray(files)) {
       throw new Error(`pull request ${item.number}: changed files unreadable`);
     }
+    // A second read for the head. The search result does not carry it, and
+    // without it a same-version pull request from another branch or fork
+    // cannot be told apart from our own rerun.
+    const pull = await fetchJson(`${apiBase}/repos/${repo}/pulls/${item.number}`, timeoutMs);
+    const versions = submittedVersions(
+      files.map((file) => file.filename ?? ""),
+      operator,
+    );
     submissions.push({
       number: item.number,
-      versions: submittedVersions(
-        files.map((file) => file.filename ?? ""),
+      versions,
+      managed: isManagedSubmission(
+        { headRepo: pull?.head?.repo?.full_name ?? null, headRef: pull?.head?.ref ?? null },
+        fork,
         operator,
+        version,
       ),
     });
   }
@@ -331,12 +357,14 @@ async function decide(argv) {
   const operatorFlag = argv.indexOf("--operator");
   const operator = operatorFlag === -1 ? "libredb-studio-operator" : flag(argv, "operator");
   const apiBase = flag(argv, "api-base") ?? "https://api.github.com";
+  const fork = flag(argv, "fork");
 
   for (const [name, value] of [
     ["version", version],
     ["operator-dir", operatorDir],
     ["repo", repo],
     ["operator", operator],
+    ["fork", fork],
   ]) {
     if (!value) {
       console.error(`ERROR: --${name} is required`);
@@ -354,7 +382,7 @@ async function decide(argv) {
   // it for an absent operator or an already-listed version keeps those two
   // answers offline and certain.
   const needsSearch = entries !== null && !catalogVersions(entries).includes(version);
-  const openSubmissions = needsSearch ? await readOpenSubmissions({ apiBase, repo, operator }) : [];
+  const openSubmissions = needsSearch ? await readOpenSubmissions({ apiBase, repo, operator, fork, version }) : [];
 
   const decision = submissionDecision({ version, operator, entries, openSubmissions });
   for (const line of submissionOutputs(decision, operator)) {

--- a/scripts/operator-catalog-submission.mjs
+++ b/scripts/operator-catalog-submission.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+/**
+ * Decides whether a release should be submitted to one community operator
+ * catalog, and which bundle it replaces there (issue #656).
+ *
+ * Everything that decides is a pure function below. The CLI at the bottom is a
+ * thin shell: it reads the version directories of a checked-out catalog and
+ * the target repository's open pull requests, then prints GITHUB_OUTPUT lines.
+ * That split is deliberate - the same logic used to live as a `sort -V |
+ * grep -B1` pipeline inside a workflow step, where it could not be tested.
+ *
+ * Why the predecessor cannot come from this repository: `spec.replaces` must
+ * name the version immediately preceding ours *in the catalog being submitted
+ * to*, which lags our releases by however many submissions are unmerged and
+ * differs between the two catalogs. Both upstream gates reject a graph that is
+ * not linked that way, and neither accepts `olm.skipRange` as a substitute:
+ *
+ *   k8s-operatorhub  `opm index add --mode replaces` ->
+ *                    "add prunes bundle ... skips/replaces []"
+ *   community-operators-prod (FBC)  `opm validate` ->
+ *                    "multiple channel heads found in graph"
+ *
+ * Both were measured, the second on community-operators-prod#11106.
+ *
+ * Pure functions are unit tested in tests/unit/operator-catalog-submission.test.ts.
+ */
+
+import fs from "node:fs";
+
+/** Bare `x.y.z` only. Our operator versions are app versions, which carry no prerelease suffix. */
+const SEMVER = /^(\d+)\.(\d+)\.(\d+)$/;
+
+/**
+ * The version directories a catalog holds, ascending. A catalog directory also
+ * holds non-version entries - `ci.yaml` on both catalogs, plus `Makefile` and
+ * `catalog-templates` on the FBC one - so this filters rather than assuming.
+ */
+export function catalogVersions(entries) {
+  return entries.filter((name) => SEMVER.test(name)).sort(compareVersions);
+}
+
+export function compareVersions(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) {
+      return pa[i] - pb[i];
+    }
+  }
+  return 0;
+}
+
+/**
+ * The version immediately below ours in that catalog, or null when ours would
+ * be the lowest (a first submission, where `replaces` must be omitted).
+ *
+ * Note what this is NOT: the highest version the catalog serves. Those answer
+ * the same when we are always ahead, and disagree the moment a higher version
+ * is already listed - where the highest would point the graph forwards.
+ */
+export function predecessorVersion(entries, version) {
+  const below = catalogVersions(entries).filter((v) => compareVersions(v, version) < 0);
+  return below.length === 0 ? null : below[below.length - 1];
+}
+
+/**
+ * The versions a pull request submits, read from its changed paths.
+ *
+ * Paths rather than the title, because the hub rewrites submission titles on
+ * open and on every push, inserting markers ("operator [N] [CI] <name>
+ * (<version>)") and, for a multi-version PR, more than one version inside the
+ * parentheses. A title regex is therefore display text that changes under us;
+ * the changed files are the submission.
+ *
+ * Only `operators/<operator>/<version>/...` counts. A `ci.yaml` edit is not a
+ * submission, and `catalogs/v4.x/<operator>/catalog.yaml` is the FBC bot's
+ * follow-up pull request, not ours.
+ */
+export function submittedVersions(paths, operator) {
+  const prefix = `operators/${operator}/`;
+  const found = new Set();
+  for (const path of paths) {
+    if (!path.startsWith(prefix)) {
+      continue;
+    }
+    const segment = path.slice(prefix.length).split("/")[0];
+    if (SEMVER.test(segment)) {
+      found.add(segment);
+    }
+  }
+  return [...found].sort(compareVersions);
+}
+
+/**
+ * Open submissions that must stop this one, each with the pull request that
+ * holds it. The predecessor is read from the catalog's default branch, so an
+ * unmerged submission is invisible to it: submitting past a pending version
+ * would leave that bundle dangling once both merge, which is the failure mode
+ * that lost VictoriaMetrics 0.48.2.
+ *
+ * Our own version is not a blocker - that is the rerun case, where the
+ * existing pull request is updated in place. The pull request number IS
+ * carried, because a skip that does not say what to go and merge is a mute.
+ *
+ * @param {{number: number, versions: string[]}[]} openSubmissions
+ * @returns {{version: string, number: number}[]}
+ */
+export function blockingSubmissions(openSubmissions, version) {
+  const blockers = new Map();
+  for (const submission of openSubmissions) {
+    for (const found of submission.versions) {
+      if (found !== version && !blockers.has(found)) {
+        blockers.set(found, submission.number);
+      }
+    }
+  }
+  return [...blockers.entries()]
+    .map(([found, number]) => ({ version: found, number }))
+    .sort((a, b) => compareVersions(a.version, b.version));
+}
+
+/**
+ * @param {{version: string, operator: string, entries: string[] | null,
+ *           openSubmissions: {number: number, versions: string[]}[]}} input
+ *   `entries` is null when the operator directory is absent upstream.
+ * @returns {{enabled: boolean, reason: string, predecessor: string | null}}
+ */
+export function submissionDecision({ version, operator, entries, openSubmissions }) {
+  if (entries === null) {
+    return {
+      enabled: false,
+      reason: `${operator} is not listed in this catalog; the first submission is manual`,
+      predecessor: null,
+    };
+  }
+  const listed = catalogVersions(entries);
+  // Already-listed is checked first on purpose: a rerun after a merge must
+  // read as "done", not as "blocked by something still open".
+  if (listed.includes(version)) {
+    return { enabled: false, reason: `the catalog already carries ${version}`, predecessor: null };
+  }
+  // A version below the channel head cannot be linked by a predecessor
+  // pointer: the head keeps no replaces of its own, so both stay heads and
+  // `opm validate` rejects the catalog with "multiple channel heads found in
+  // graph". Linking that is a judgement call, not a derivation.
+  const above = listed.filter((candidate) => compareVersions(candidate, version) > 0);
+  if (above.length > 0) {
+    return {
+      enabled: false,
+      reason: `the catalog already carries ${above.join(", ")}, above ${version}; submitting it would leave two channel heads - link the graph by hand`,
+      predecessor: null,
+    };
+  }
+  // A version the catalog already holds is not a pending submission, whatever
+  // an open pull request does to its directory. Blocking on one of those
+  // would mute every release for as long as that pull request stayed open.
+  const blockers = blockingSubmissions(openSubmissions, version).filter((blocker) => !listed.includes(blocker.version));
+  if (blockers.length > 0) {
+    const named = blockers.map((blocker) => `${blocker.version} (#${blocker.number})`).join(", ");
+    return {
+      enabled: false,
+      reason: `a submission for another version is still open - ${named}; merge it before submitting ${version}`,
+      predecessor: null,
+    };
+  }
+  const predecessor = predecessorVersion(entries, version);
+  return {
+    enabled: true,
+    reason: predecessor
+      ? `${version} is not listed; replaces ${predecessor}`
+      : `${version} is not listed; first submission, no replaces`,
+    predecessor,
+  };
+}
+
+/**
+ * GITHUB_OUTPUT lines, in the shape the release workflow's submit step reads.
+ * `replaces` is the CSV field value, empty when there is no predecessor, so a
+ * downstream step can test for emptiness instead of reimplementing the rule.
+ * A reason is flattened to one line - a newline would end the output entry
+ * early and silently drop the rest.
+ */
+export function submissionOutputs(decision, operator) {
+  return [
+    `enabled=${decision.enabled}`,
+    `reason=${decision.reason.replace(/\s*\n\s*/g, " ")}`,
+    `predecessor=${decision.predecessor ?? ""}`,
+    `replaces=${decision.predecessor ? `${operator}.v${decision.predecessor}` : ""}`,
+  ];
+}
+
+/**
+ * The CSV text with `spec.replaces` set, inserted immediately above
+ * `spec.version` at the same indent.
+ *
+ * A targeted text edit rather than a YAML round trip: the submitted bundle
+ * must be the released bundle plus one line, and re-emitting the document
+ * would reflow quoting, key order and block scalars across a 380-line file,
+ * turning a one-line change into an unreviewable diff.
+ *
+ * The anchor is the two-space `version:` key, i.e. the one directly under
+ * `spec`. A CSV also carries nested `version:` keys under
+ * `customresourcedefinitions.owned`, which are API versions and must not be
+ * touched.
+ */
+export function withReplaces(csvText, replacesName) {
+  const anchor = /^ {2}version: .*$/m;
+  if (!anchor.test(csvText)) {
+    throw new Error("cannot set replaces: the CSV has no spec.version line to anchor on");
+  }
+  const withoutExisting = csvText.replace(/^ {2}replaces: .*\n/m, "");
+  return withoutExisting.replace(anchor, (line) => `  replaces: ${replacesName}\n${line}`);
+}
+
+/**
+ * Directory entries of a checked-out catalog's operator dir, or null when the
+ * operator genuinely has no directory there.
+ *
+ * ONLY a missing path is null. Anything else - a path that is not a directory,
+ * an unreadable one, a changed upstream layout - is thrown, because reporting
+ * it as "not listed, the first submission is manual" would stop submitting
+ * for good while every run stayed green.
+ */
+export function readOperatorEntries(operatorDir) {
+  try {
+    return fs.readdirSync(operatorDir);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Open submissions in the target repository, each with the versions it
+ * touches. Two reads per candidate: the search API finds pull requests that
+ * mention this operator at all, then each one's changed files decide whether
+ * it is really a submission and for which versions.
+ *
+ * The search is deliberately not restricted to titles. A false negative here
+ * is the dangerous direction - it lets a submission be opened past a pending
+ * one - so recall matters more than the extra call.
+ *
+ * `apiBase` is a parameter so the tests can point both endpoints at a local
+ * server and the suite never touches the network.
+ */
+export async function readOpenSubmissions({ apiBase, repo, operator, timeoutMs = 15000 }) {
+  const query = encodeURIComponent(`repo:${repo} is:pr is:open ${operator}`);
+  const search = await fetchJson(`${apiBase}/search/issues?q=${query}&per_page=100`, timeoutMs);
+  if (!Array.isArray(search.items)) {
+    throw new Error("open-submission search returned no items array");
+  }
+  const submissions = [];
+  for (const item of search.items) {
+    // per_page=100 is one page for any real submission: a bundle directory is
+    // about ten files. A pull request larger than that is not one of ours, and
+    // the versions we would miss on page two cannot be ours either.
+    const files = await fetchJson(`${apiBase}/repos/${repo}/pulls/${item.number}/files?per_page=100`, timeoutMs);
+    if (!Array.isArray(files)) {
+      throw new Error(`pull request ${item.number}: changed files unreadable`);
+    }
+    submissions.push({
+      number: item.number,
+      versions: submittedVersions(
+        files.map((file) => file.filename ?? ""),
+        operator,
+      ),
+    });
+  }
+  return submissions;
+}
+
+async function fetchJson(url, timeoutMs) {
+  const headers = { accept: "application/vnd.github+json" };
+  if (process.env.GITHUB_TOKEN) {
+    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  const response = await fetch(url, { headers, signal: AbortSignal.timeout(timeoutMs) });
+  if (!response.ok) {
+    // Never degrade to "submit": a decision made on an unread search is how a
+    // duplicate or a graph-breaking pull request gets opened.
+    throw new Error(`GitHub API read failed (status ${response.status}) for ${url}`);
+  }
+  return response.json();
+}
+
+function flag(argv, name) {
+  const index = argv.indexOf(`--${name}`);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = argv[index + 1];
+  return value === undefined || value.startsWith("--") ? undefined : value;
+}
+
+/**
+ * Two commands rather than one, because the workflow needs two distinct
+ * things: a decision before it touches anything, and a patch applied to the
+ * bundle copy afterwards. Naming them keeps each one's required flags obvious
+ * and makes an unknown command an error instead of a plausible default.
+ */
+export async function main(argv) {
+  const command = argv[0];
+  if (command === "decide") {
+    return decide(argv.slice(1));
+  }
+  if (command === "set-replaces") {
+    return setReplaces(argv.slice(1));
+  }
+  console.error(`ERROR: unknown command '${command ?? ""}' - expected 'decide' or 'set-replaces'`);
+  return 2;
+}
+
+function setReplaces(argv) {
+  const csvPath = flag(argv, "csv");
+  const replacesName = flag(argv, "replaces");
+  if (!csvPath || !replacesName) {
+    console.error("ERROR: set-replaces needs --csv and --replaces");
+    return 2;
+  }
+  fs.writeFileSync(csvPath, withReplaces(fs.readFileSync(csvPath, "utf8"), replacesName));
+  console.log(`set replaces: ${replacesName}`);
+  return 0;
+}
+
+async function decide(argv) {
+  const version = flag(argv, "version");
+  const operatorDir = flag(argv, "operator-dir");
+  const repo = flag(argv, "repo");
+  const operatorFlag = argv.indexOf("--operator");
+  const operator = operatorFlag === -1 ? "libredb-studio-operator" : flag(argv, "operator");
+  const apiBase = flag(argv, "api-base") ?? "https://api.github.com";
+
+  for (const [name, value] of [
+    ["version", version],
+    ["operator-dir", operatorDir],
+    ["repo", repo],
+    ["operator", operator],
+  ]) {
+    if (!value) {
+      console.error(`ERROR: --${name} is required`);
+      return 2;
+    }
+  }
+  if (!SEMVER.test(version)) {
+    console.error(`ERROR: --version must be a bare semver, got '${version}'`);
+    return 2;
+  }
+
+  const entries = readOperatorEntries(operatorDir);
+  // The search only matters when a submission is otherwise possible, and it is
+  // the one step that can fail for reasons outside this repository. Skipping
+  // it for an absent operator or an already-listed version keeps those two
+  // answers offline and certain.
+  const needsSearch = entries !== null && !catalogVersions(entries).includes(version);
+  const openSubmissions = needsSearch ? await readOpenSubmissions({ apiBase, repo, operator }) : [];
+
+  const decision = submissionDecision({ version, operator, entries, openSubmissions });
+  for (const line of submissionOutputs(decision, operator)) {
+    console.log(line);
+  }
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(`ERROR: ${error.message}`);
+      process.exit(1);
+    });
+}

--- a/tests/unit/distribution-check.test.ts
+++ b/tests/unit/distribution-check.test.ts
@@ -645,6 +645,7 @@ describe("update.ci_enabled", () => {
       "chocolatey",
       "docker-hub-mirror",
       "homebrew",
+      "operatorhub-community",
       "snap",
       "winget",
     ]);
@@ -1151,6 +1152,7 @@ describe("CLI (probes against a local registry/store/catalog)", () => {
     update:
       method: upstream_pr
       sla: every_release
+      ci_enabled: true
     pin:
       strategy: probe
       probe: github-dir-max-version
@@ -1322,6 +1324,20 @@ describe("matrix cell helpers", () => {
       "Manual, minor+",
     );
     expect(updateSummary({ status: "deprecated", update: { method: "upstream_pr", sla: "on_demand" } })).toBe("—");
+  });
+
+  test("updateSummary calls an automated upstream PR what it is", () => {
+    // The submission is opened by CI (#656) but merged by the upstream
+    // maintainers, so neither "Automated" nor "Manual" is true on its own.
+    expect(
+      updateSummary({ status: "live", update: { method: "upstream_pr", sla: "every_release", ci_enabled: true } }),
+    ).toBe("Automated PR, every release");
+  });
+
+  test("updateSummary marks a switched-off upstream PR channel as paused too", () => {
+    expect(
+      updateSummary({ status: "live", update: { method: "upstream_pr", sla: "every_release", ci_enabled: false } }),
+    ).toBe("Automated PR (paused), every release");
   });
 
   test("updateSummary marks a switched-off channel as paused", () => {

--- a/tests/unit/operator-bundle-update-graph.test.ts
+++ b/tests/unit/operator-bundle-update-graph.test.ts
@@ -1,35 +1,30 @@
 /**
- * The committed OLM bundle is the submission source for both community
- * operator catalogs, and its place in the update graph is the one part of it
- * that no bundle validator checks.
+ * Where the committed OLM bundle sits in the community catalogs' update graph,
+ * and which half of that graph the repo is allowed to know.
  *
- * k8s-operatorhub/community-operators runs this operator in
- * `updateGraph: replaces-mode`, and its deploy jobs build a catalog with
- * `opm index add --mode replaces` (the mode comes straight from `ci.yaml`).
- * That command reads `spec.replaces` and `spec.skips` ONLY. It does not look
- * at `olm.skipRange`, and without a pointer it prunes the previous bundle out
- * of the channel and fails:
+ * `olm.skipRange` is derivable from package.json, so the repo owns it:
+ * `make -C operator bundle` stamps `>=0.0.0 <$(VERSION)` and greps it back.
+ * An unparseable range is *ignored with a log warning* upstream rather than
+ * rejected, so a typo would silently degrade to no range at all - hence the
+ * exact-string assertion rather than a loose match.
  *
- *   add prunes bundle libredb-studio-operator.v0.9.59 ... channel alpha:
- *   this may be due to incorrect channel head (...v0.14.1, skips/replaces [])
+ * `spec.replaces` is deliberately ABSENT, and that absence is the invariant
+ * this file exists to hold. Its only correct value is the version immediately
+ * preceding this one *in a given catalog*, which is external state: it lags
+ * our releases by however many submissions are unmerged, it differs between
+ * the two catalogs, and nothing in this repo can derive it. Stamping a
+ * declared value here (what `CATALOG_REPLACES` did) makes the committed bundle
+ * correct only by coincidence and stale by default, which is a cost paid on
+ * every release.
  *
- * Measured against the real command with two bundle images and a local
- * registry: replaces-mode with a skipRange alone exits 1, replaces-mode with
- * `spec.replaces` exits 0. `check_dangling_bundles` in operatorcert is more
- * forgiving (it seeds its graph from `_resolve_skip_range`), which is exactly
- * why passing that check is not evidence that a submission will build.
+ * So the field is derived and injected at submission time instead, from the
+ * catalog being submitted to. See docs/DISTRIBUTION.md, "The update graph".
  *
- * So both fields are stamped, and both are asserted here:
- *   - `spec.replaces` names the newest version the catalogs actually serve.
- *     It is NOT derivable from package.json, which is why it lives in
- *     `CATALOG_REPLACES` in operator/Makefile and has to be bumped when a
- *     submission merges upstream. Getting it wrong is loud, not silent: the
- *     same prune failure comes back on the next submission.
- *   - `olm.skipRange` lets a cluster jump straight to this version, and is
- *     what the FBC side accepts in `release-config.yaml`. An unparseable
- *     range is *ignored with a log warning* rather than rejected, so a typo
- *     would silently degrade to no range at all - hence the exact-string
- *     assertion below rather than a loose match.
+ * The consequence is worth stating plainly, because it looks like an omission:
+ * this bundle on its own does NOT pass `opm index add --mode replaces`, which
+ * reads `spec.replaces` and `spec.skips` and never `olm.skipRange`. That is
+ * intended. Adding a `replaces` here to "fix" it reintroduces the stale value,
+ * which is why the absence is asserted rather than merely documented.
  */
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -53,18 +48,7 @@ function csvField(name: string, file: string = CSV): string | undefined {
   return readFileSync(file, "utf8").match(new RegExp(`^  ${name}:\\s*(.+?)\\s*$`, "m"))?.[1];
 }
 
-function compareVersions(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
-  for (let i = 0; i < 3; i++) {
-    if (pa[i] !== pb[i]) {
-      return pa[i] - pb[i];
-    }
-  }
-  return 0;
-}
-
-describe("the generated bundle's place in the catalog update graph", () => {
+describe("the committed bundle's place in the catalog update graph", () => {
   test("the CSV carries an olm.skipRange stamped from package.json", () => {
     expect(annotation(CSV, "olm\\.skipRange")).toBe(`>=0.0.0 <${packageVersion()}`);
   });
@@ -75,27 +59,48 @@ describe("the generated bundle's place in the catalog update graph", () => {
     expect(range).not.toContain(`<=${packageVersion()}`);
   });
 
-  test("the base CSV holds the placeholder the Makefile stamps over", () => {
+  test("the base CSV holds the skipRange placeholder the Makefile stamps over", () => {
     // Mirrors containerImage: the stamp is a sed over a placeholder the base
     // owns, and sed exits 0 on zero matches - so a removed or reformatted
     // placeholder must be a visible failure here, not a silently unstamped CSV.
     expect(annotation(BASE_CSV, "olm\\.skipRange")).toBe(">=0.0.0 <0.0.0");
   });
 
-  test("the CSV names the bundle it replaces", () => {
-    expect(csvField("replaces")).toMatch(/^libredb-studio-operator\.v\d+\.\d+\.\d+$/);
+  test("csvField can see a spec-level key at all, so the absences below mean something", () => {
+    // The control for the three absence assertions that follow. Without it a
+    // typo in the helper, a renamed file or a moved bundle would satisfy all
+    // three by reading nothing.
+    expect(csvField("version")).toBe(packageVersion());
+    expect(csvField("version", BASE_CSV)).toBe("0.0.0");
   });
 
-  test("the replaced version is older than this bundle, and is inside its skip range", () => {
-    // A pointer at or above our own version is not a graph edge, it is a
-    // cycle; and the two fields must agree, or a cluster is told one thing by
-    // the range and another by the pointer.
-    const replaced = csvField("replaces")?.replace("libredb-studio-operator.v", "") ?? "";
-    expect(compareVersions(replaced, packageVersion())).toBeLessThan(0);
-    expect(annotation(CSV, "olm\\.skipRange")).toBe(`>=0.0.0 <${packageVersion()}`);
+  test("the CSV declares no spec.replaces, because its value is not knowable here", () => {
+    expect(csvField("replaces")).toBeUndefined();
   });
 
-  test("the base CSV holds the replaces placeholder the Makefile stamps over", () => {
-    expect(csvField("replaces", BASE_CSV)).toBe("libredb-studio-operator.v0.0.0");
+  test("the base CSV declares no replaces placeholder either", () => {
+    // A placeholder would invite a stamp, and a stamp needs a declared value.
+    expect(csvField("replaces", BASE_CSV)).toBeUndefined();
+  });
+
+  test("nothing in the operator build declares a replaces version to stamp", () => {
+    // The whole point is that no such value exists in the repo. A narrow
+    // pattern would catch only the exact name this bundle used to carry, so
+    // this looks for any assignment or stamp that mentions replaces at all,
+    // under any variable name.
+    const makefile = readFileSync(join(ROOT, "operator/Makefile"), "utf8");
+    const suspicious = makefile
+      .split("\n")
+      .filter((line) => /replaces/i.test(line))
+      .filter((line) => !line.trimStart().startsWith("#"));
+    expect(suspicious).toEqual([]);
+  });
+
+  test("the Makefile still stamps and verifies the half the repo does own", () => {
+    // The counterpart control: proving replaces is gone means nothing if the
+    // skipRange stamp went with it.
+    const makefile = readFileSync(join(ROOT, "operator/Makefile"), "utf8");
+    expect(makefile).toContain("olm.skipRange: '>=0.0.0 <$(VERSION)'");
+    expect(makefile).toMatch(/grep -q "olm\.skipRange/);
   });
 });

--- a/tests/unit/operator-catalog-submission.test.ts
+++ b/tests/unit/operator-catalog-submission.test.ts
@@ -1,0 +1,708 @@
+/**
+ * Unit tests for the operator catalog submission helper
+ * (scripts/operator-catalog-submission.mjs, issue #656).
+ *
+ * The helper answers one question per catalog: should this release be
+ * submitted, and if so which bundle does it replace. Everything that decides
+ * that is a pure function here; the CLI is a thin shell around
+ * `submissionDecision` that reads a checked-out catalog directory and the
+ * target repo's open pull requests.
+ *
+ * The predecessor cannot come from this repo. `spec.replaces` must name the
+ * version immediately preceding ours *in the catalog being submitted to*, and
+ * both upstream gates reject a graph that is not linked that way:
+ * `opm index add --mode replaces` prunes the previous bundle on k8s-operatorhub,
+ * and `opm validate` fails with "multiple channel heads found in graph" on the
+ * FBC side. A skipRange satisfies neither.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  blockingSubmissions,
+  catalogVersions,
+  compareVersions,
+  submittedVersions,
+  predecessorVersion,
+  submissionDecision,
+  submissionOutputs,
+  withReplaces,
+} from "../../scripts/operator-catalog-submission.mjs";
+
+const OPERATOR = "libredb-studio-operator";
+
+describe("catalogVersions", () => {
+  test("keeps semver directories and sorts them ascending", () => {
+    expect(catalogVersions(["0.14.1", "0.9.59", "0.10.0"])).toEqual(["0.9.59", "0.10.0", "0.14.1"]);
+  });
+
+  test("drops the non-version entries a catalog directory also holds", () => {
+    // Real neighbours of the version dirs: ci.yaml on both catalogs, plus
+    // Makefile and catalog-templates on the FBC one.
+    expect(catalogVersions(["ci.yaml", "Makefile", "catalog-templates", "0.9.59"])).toEqual(["0.9.59"]);
+  });
+
+  test("sorts numerically, not lexically", () => {
+    expect(catalogVersions(["0.9.9", "0.10.0", "0.9.59"])).toEqual(["0.9.9", "0.9.59", "0.10.0"]);
+  });
+
+  test("returns an empty list for a catalog that holds no version yet", () => {
+    expect(catalogVersions(["ci.yaml"])).toEqual([]);
+  });
+});
+
+describe("compareVersions", () => {
+  // Every component matters. A comparator that ignores one of them still
+  // sorts most real catalogs correctly, which is why each is asserted
+  // separately: dropping the patch arm would otherwise leave the suite green
+  // and pick the wrong predecessor between two same-minor releases.
+  test("orders by major", () => {
+    expect(compareVersions("1.0.0", "0.9.9")).toBeGreaterThan(0);
+  });
+
+  test("orders by minor when the major is equal", () => {
+    expect(compareVersions("0.10.0", "0.9.59")).toBeGreaterThan(0);
+  });
+
+  test("orders by patch when major and minor are equal", () => {
+    expect(compareVersions("0.14.2", "0.14.1")).toBeGreaterThan(0);
+    expect(compareVersions("0.14.1", "0.14.2")).toBeLessThan(0);
+  });
+
+  test("is zero for equal versions", () => {
+    expect(compareVersions("0.14.1", "0.14.1")).toBe(0);
+  });
+});
+
+describe("predecessorVersion", () => {
+  test("is the version immediately below ours", () => {
+    expect(predecessorVersion(["0.9.59", "0.13.7"], "0.14.1")).toBe("0.13.7");
+  });
+
+  test("skips the versions we never submitted", () => {
+    // 0.14.0 was never submitted anywhere, so 0.14.1 replaces 0.9.59.
+    expect(predecessorVersion(["ci.yaml", "0.9.59"], "0.14.1")).toBe("0.9.59");
+  });
+
+  test("is null on a first submission, where replaces must be omitted", () => {
+    expect(predecessorVersion(["ci.yaml"], "0.14.1")).toBeNull();
+  });
+
+  test("stays the immediate predecessor even when a higher version is already listed", () => {
+    // "the highest version the catalog serves" would answer 0.15.0 here and
+    // point the graph forwards. The immediate predecessor is the only correct
+    // answer, and this is why the catalog listing is sorted rather than maxed.
+    expect(predecessorVersion(["0.9.59", "0.13.7", "0.15.0"], "0.14.1")).toBe("0.13.7");
+  });
+
+  test("ignores our own version when it is already present", () => {
+    expect(predecessorVersion(["0.9.59", "0.14.1"], "0.14.1")).toBe("0.9.59");
+  });
+
+  test("is null when ours is the lowest version in the catalog", () => {
+    expect(predecessorVersion(["0.15.0"], "0.14.1")).toBeNull();
+  });
+
+  test("distinguishes two releases that differ only in patch", () => {
+    expect(predecessorVersion(["0.14.1", "0.14.2", "0.9.59"], "0.14.3")).toBe("0.14.2");
+  });
+});
+
+describe("submittedVersions", () => {
+  test("reads the versions a pull request touches from its changed paths", () => {
+    expect(
+      submittedVersions(
+        [`operators/${OPERATOR}/0.13.7/manifests/x.yaml`, `operators/${OPERATOR}/0.13.7/metadata/annotations.yaml`],
+        OPERATOR,
+      ),
+    ).toEqual(["0.13.7"]);
+  });
+
+  test("ignores paths belonging to another operator", () => {
+    expect(submittedVersions(["operators/camel-k/2.11.0/manifests/x.yaml"], OPERATOR)).toEqual([]);
+  });
+
+  test("ignores our own non-version files, so a ci.yaml edit is not a submission", () => {
+    expect(submittedVersions([`operators/${OPERATOR}/ci.yaml`], OPERATOR)).toEqual([]);
+  });
+
+  test("ignores the rendered FBC catalogs, which are the bot's follow-up PR", () => {
+    expect(submittedVersions([`catalogs/v4.15/${OPERATOR}/catalog.yaml`], OPERATOR)).toEqual([]);
+  });
+
+  test("reports every version a pull request touches, deduplicated and sorted", () => {
+    expect(
+      submittedVersions(
+        [
+          `operators/${OPERATOR}/0.15.0/manifests/x.yaml`,
+          `operators/${OPERATOR}/0.13.7/manifests/x.yaml`,
+          `operators/${OPERATOR}/0.13.7/metadata/y.yaml`,
+        ],
+        OPERATOR,
+      ),
+    ).toEqual(["0.13.7", "0.15.0"]);
+  });
+});
+
+describe("blockingSubmissions", () => {
+  test("an open submission for another version blocks", () => {
+    // The predecessor is read from the catalog's default branch, so an
+    // unmerged submission is invisible to it. Submitting past it would leave
+    // the pending bundle dangling once both merge.
+    expect(blockingSubmissions([{ number: 7, versions: ["0.13.7"] }], "0.14.1")).toEqual([
+      { version: "0.13.7", number: 7 },
+    ]);
+  });
+
+  test("an open submission for our own version does not block", () => {
+    expect(blockingSubmissions([{ number: 7, versions: ["0.14.1"] }], "0.14.1")).toEqual([]);
+  });
+
+  test("a higher pending version blocks too", () => {
+    expect(blockingSubmissions([{ number: 7, versions: ["0.15.0"] }], "0.14.1")).toEqual([
+      { version: "0.15.0", number: 7 },
+    ]);
+  });
+
+  test("a pull request touching no version of ours does not block", () => {
+    expect(blockingSubmissions([{ number: 7, versions: [] }], "0.14.1")).toEqual([]);
+  });
+
+  test("carries the pull request number, so the skip names what to go and merge", () => {
+    expect(blockingSubmissions([{ number: 7, versions: ["0.13.7"] }], "0.14.1")).toEqual([
+      { version: "0.13.7", number: 7 },
+    ]);
+  });
+
+  test("reports each blocking version once, sorted", () => {
+    expect(
+      blockingSubmissions(
+        [
+          { number: 8, versions: ["0.15.0"] },
+          { number: 7, versions: ["0.13.7", "0.15.0"] },
+        ],
+        "0.14.1",
+      ),
+    ).toEqual([
+      { version: "0.13.7", number: 7 },
+      { version: "0.15.0", number: 8 },
+    ]);
+  });
+});
+
+describe("submissionDecision", () => {
+  const base = { version: "0.14.1", operator: OPERATOR, entries: ["ci.yaml", "0.9.59"], openSubmissions: [] };
+
+  test("submits with the derived predecessor when the catalog is behind", () => {
+    expect(submissionDecision(base)).toEqual({
+      enabled: true,
+      reason: "0.14.1 is not listed; replaces 0.9.59",
+      predecessor: "0.9.59",
+    });
+  });
+
+  test("submits with no predecessor on a first listing", () => {
+    expect(submissionDecision({ ...base, entries: ["ci.yaml"] })).toEqual({
+      enabled: true,
+      reason: "0.14.1 is not listed; first submission, no replaces",
+      predecessor: null,
+    });
+  });
+
+  test("skips when the catalog already carries this version", () => {
+    const decision = submissionDecision({ ...base, entries: ["0.9.59", "0.14.1"] });
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toMatch(/already carries 0\.14\.1/);
+    expect(decision.predecessor).toBeNull();
+  });
+
+  test("skips when an earlier submission is still open, naming it and its pull request", () => {
+    const decision = submissionDecision({ ...base, openSubmissions: [{ number: 7, versions: ["0.13.7"] }] });
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toMatch(/still open/);
+    expect(decision.reason).toMatch(/0\.13\.7/);
+    expect(decision.reason).toMatch(/#7/);
+    expect(decision.predecessor).toBeNull();
+  });
+
+  test("does not treat a pull request touching an already-merged version as pending", () => {
+    // Someone else editing operators/<operator>/0.9.59/ is not a submission:
+    // 0.9.59 is in the catalog already. Blocking on it would mute every
+    // release for as long as that pull request stayed open.
+    const decision = submissionDecision({
+      ...base,
+      entries: ["ci.yaml", "0.9.59"],
+      openSubmissions: [{ number: 12345, versions: ["0.9.59"] }],
+    });
+    expect(decision.enabled).toBe(true);
+    expect(decision.predecessor).toBe("0.9.59");
+  });
+
+  test("refuses when the catalog already carries a HIGHER version", () => {
+    // Adding a version below the channel head leaves both unreplaced, which
+    // is the "multiple channel heads" failure. Linking that graph is a
+    // judgement call, so it stops here rather than guessing.
+    const decision = submissionDecision({ ...base, entries: ["0.9.59", "0.15.0"] });
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toMatch(/0\.15\.0/);
+    expect(decision.reason).toMatch(/above/);
+    expect(decision.predecessor).toBeNull();
+  });
+
+  test("skips when the operator is not in the catalog at all, because a first listing is manual", () => {
+    // A null entry list means the operator directory is absent upstream.
+    // Creating a listing needs review and metadata this path does not carry.
+    const decision = submissionDecision({ ...base, entries: null });
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toMatch(/not listed/);
+    expect(decision.reason).toMatch(/manual/);
+  });
+
+  test("checks already-listed before the open-submission block", () => {
+    // A rerun after a merge must read as "done", not as "blocked".
+    const decision = submissionDecision({
+      ...base,
+      entries: ["0.9.59", "0.14.1"],
+      openSubmissions: [{ number: 7, versions: ["0.13.7"] }],
+    });
+    expect(decision.reason).toMatch(/already carries/);
+  });
+});
+
+describe("submissionOutputs", () => {
+  test("emits the shape a workflow step reads, with the predecessor as a CSV name", () => {
+    expect(submissionOutputs({ enabled: true, reason: "go", predecessor: "0.9.59" }, OPERATOR)).toEqual([
+      "enabled=true",
+      "reason=go",
+      "predecessor=0.9.59",
+      `replaces=${OPERATOR}.v0.9.59`,
+    ]);
+  });
+
+  test("emits an empty replaces when there is no predecessor, so the field is omitted downstream", () => {
+    expect(submissionOutputs({ enabled: true, reason: "first", predecessor: null }, OPERATOR)).toEqual([
+      "enabled=true",
+      "reason=first",
+      "predecessor=",
+      "replaces=",
+    ]);
+  });
+
+  test("collapses newlines in a reason, which would otherwise break GITHUB_OUTPUT parsing", () => {
+    const [, reason] = submissionOutputs({ enabled: false, reason: "a\nb", predecessor: null }, OPERATOR);
+    expect(reason).toBe("reason=a b");
+  });
+});
+
+describe("withReplaces", () => {
+  const csv = ["spec:", "  maturity: alpha", "  minKubeVersion: 1.26.0", "  version: 0.14.1"].join("\n") + "\n";
+
+  test("inserts the pointer immediately above the version, at the same indent", () => {
+    expect(withReplaces(csv, `${OPERATOR}.v0.9.59`)).toBe(
+      [
+        "spec:",
+        "  maturity: alpha",
+        "  minKubeVersion: 1.26.0",
+        `  replaces: ${OPERATOR}.v0.9.59`,
+        "  version: 0.14.1",
+      ].join("\n") + "\n",
+    );
+  });
+
+  test("changes nothing else, so the submitted bundle stays the released one plus a line", () => {
+    const patched = withReplaces(csv, `${OPERATOR}.v0.9.59`);
+    expect(patched.split("\n").filter((line: string) => !line.includes("replaces"))).toEqual(csv.split("\n"));
+  });
+
+  test("replaces an existing pointer rather than adding a second one", () => {
+    const already = withReplaces(csv, `${OPERATOR}.v0.9.59`);
+    expect(withReplaces(already, `${OPERATOR}.v0.13.7`)).toBe(withReplaces(csv, `${OPERATOR}.v0.13.7`));
+  });
+
+  test("refuses a CSV with no spec.version to anchor on", () => {
+    // Silently returning the text unchanged would ship an unlinked bundle and
+    // fail upstream instead of here.
+    expect(() => withReplaces("spec:\n  maturity: alpha\n", `${OPERATOR}.v0.9.59`)).toThrow(/spec\.version/);
+  });
+
+  test("patches the real committed CSV, inserting exactly one line", () => {
+    // The unit fixtures cannot prove the anchor survives a 380-line document
+    // with nested version keys, block scalars and quoted strings, so this runs
+    // against the file that is actually submitted.
+    const real = readFileSync(
+      join(import.meta.dir, "../../operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml"),
+      "utf8",
+    );
+    const patched = withReplaces(real, `${OPERATOR}.v0.9.59`);
+    const added = patched.split("\n").filter((line: string) => !real.split("\n").includes(line));
+    expect(added).toEqual([`  replaces: ${OPERATOR}.v0.9.59`]);
+    expect(patched).toMatch(new RegExp(`^  replaces: ${OPERATOR}\\.v0\\.9\\.59\\n  version: `, "m"));
+  });
+
+  test("leaves the nested API versions of the real CSV untouched", () => {
+    const real = readFileSync(
+      join(import.meta.dir, "../../operator/bundle/manifests/libredb-studio-operator.clusterserviceversion.yaml"),
+      "utf8",
+    );
+    // A control: the real document does contain deeper `version:` keys, so the
+    // indent anchor is doing work rather than matching the only candidate.
+    expect(real).toMatch(/^ {4,}version: /m);
+    const patched = withReplaces(real, `${OPERATOR}.v0.9.59`);
+    expect((patched.match(/^ *replaces: /gm) ?? []).length).toBe(1);
+  });
+
+  test("anchors on the spec-level version, not a nested one", () => {
+    const nested =
+      ["spec:", "  customresourcedefinitions:", "    owned:", "    - version: v1alpha1", "  version: 0.14.1"].join(
+        "\n",
+      ) + "\n";
+    const patched = withReplaces(nested, `${OPERATOR}.v0.9.59`);
+    expect(patched).toContain(`  replaces: ${OPERATOR}.v0.9.59\n  version: 0.14.1`);
+    expect(patched).toContain("    - version: v1alpha1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The CLI shell: a real subprocess against a temp catalog checkout and a local
+// server standing in for the search API. No network.
+// ---------------------------------------------------------------------------
+
+describe("CLI", () => {
+  const servers: Array<{ stop: () => void }> = [];
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const server of servers.splice(0)) {
+      server.stop();
+    }
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  /** A checked-out catalog holding the given entries as version directories. */
+  function catalogDir(entries: string[] | null): string {
+    const root = mkdtempSync(join(tmpdir(), "catalog-"));
+    roots.push(root);
+    const dir = join(root, "operators", OPERATOR);
+    if (entries === null) {
+      return dir;
+    }
+    mkdirSync(dir, { recursive: true });
+    for (const entry of entries) {
+      if (entry.endsWith(".yaml")) {
+        writeFileSync(join(dir, entry), "---\n");
+      } else {
+        mkdirSync(join(dir, entry), { recursive: true });
+      }
+    }
+    return dir;
+  }
+
+  /**
+   * A stand-in for the two GitHub endpoints the CLI reads: the issue search
+   * and each candidate pull request's changed files.
+   */
+  function apiServing(prs: Array<{ number: number; files: string[] }>, status = 200): string {
+    const server = Bun.serve({
+      port: 0,
+      fetch: (req) => {
+        if (status !== 200) {
+          return new Response("nope", { status });
+        }
+        const path = new URL(req.url).pathname;
+        if (path === "/search/issues") {
+          return Response.json({ items: prs.map((pr) => ({ number: pr.number, title: "whatever" })) });
+        }
+        const match = path.match(/\/repos\/.+\/pulls\/(\d+)\/files$/);
+        if (match) {
+          const pr = prs.find((candidate) => candidate.number === Number(match[1]));
+          return Response.json((pr?.files ?? []).map((filename) => ({ filename })));
+        }
+        return new Response("unexpected path", { status: 404 });
+      },
+    });
+    servers.push(server);
+    return `http://127.0.0.1:${server.port}`;
+  }
+
+  async function run(args: string[]) {
+    const proc = Bun.spawn(["node", join(import.meta.dir, "../../scripts/operator-catalog-submission.mjs"), ...args], {
+      env: { ...process.env, GITHUB_TOKEN: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("prints the outputs a workflow step reads when a submission is due", async () => {
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--api-base",
+      apiServing([]),
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("enabled=true");
+    expect(result.stdout).toContain("predecessor=0.9.59");
+    expect(result.stdout).toContain(`replaces=${OPERATOR}.v0.9.59`);
+  });
+
+  test("skips an already-listed version without calling the search API at all", async () => {
+    // The stand-in server would 500 if it were reached, so a pass here proves
+    // the offline answer stays offline.
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["0.9.59", "0.14.1"]),
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--api-base",
+      apiServing([], 500),
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("enabled=false");
+    expect(result.stdout).toMatch(/reason=.*already carries 0\.14\.1/);
+  });
+
+  test("skips when the operator has no directory upstream", async () => {
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(null),
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--api-base",
+      apiServing([], 500),
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("enabled=false");
+    expect(result.stdout).toMatch(/reason=.*first submission is manual/);
+  });
+
+  test("skips and names the pending version when an earlier submission is open", async () => {
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--api-base",
+      apiServing([{ number: 7, files: [`operators/${OPERATOR}/0.13.7/manifests/csv.yaml`] }]),
+    ]);
+    expect(result.stdout).toContain("enabled=false");
+    expect(result.stdout).toMatch(/reason=.*still open - 0\.13\.7 \(#7\)/);
+  });
+
+  test("does not block on a pull request that only touches our ci.yaml", async () => {
+    // The search matches on the operator name anywhere, so unrelated pull
+    // requests reach the files check. Blocking on one of those would stall
+    // every release for no reason.
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--api-base",
+      apiServing([{ number: 9, files: [`operators/${OPERATOR}/ci.yaml`] }]),
+    ]);
+    expect(result.stdout).toContain("enabled=true");
+    expect(result.stdout).toContain("predecessor=0.9.59");
+  });
+
+  test("fails loudly when the search API cannot be read", async () => {
+    // A submission decision that depends on an unread search must not default
+    // to "go" - that is how a duplicate or graph-breaking PR gets opened.
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--api-base",
+      apiServing([], 403),
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/GitHub API read failed \(status 403\)/);
+    expect(result.stdout).not.toContain("enabled=true");
+  });
+
+  test("prints exactly the four output lines, so a stray line cannot corrupt GITHUB_OUTPUT", async () => {
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--api-base",
+      apiServing([]),
+    ]);
+    expect(result.stdout.trimEnd().split("\n")).toEqual([
+      "enabled=true",
+      "reason=0.14.1 is not listed; replaces 0.9.59",
+      "predecessor=0.9.59",
+      `replaces=${OPERATOR}.v0.9.59`,
+    ]);
+  });
+
+  test("fails on an unreadable operator directory instead of calling it a first submission", async () => {
+    // An absent directory is a first listing; a path that exists but is not a
+    // directory is a broken invocation or a changed upstream layout, and
+    // reporting that as "first submission is manual" would stop submitting
+    // for good with a green run.
+    const root = mkdtempSync(join(tmpdir(), "notdir-"));
+    roots.push(root);
+    const file = join(root, "operators");
+    writeFileSync(file, "not a directory");
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      file,
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--api-base",
+      apiServing([]),
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/ENOTDIR|not a directory/i);
+  });
+
+  test("fails when the search response is not the expected shape", async () => {
+    const server = Bun.serve({ port: 0, fetch: () => Response.json({ nope: true }) });
+    servers.push(server);
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "a/b",
+      "--api-base",
+      `http://127.0.0.1:${server.port}`,
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/no items array/);
+  });
+
+  test("fails when a pull request's changed files are not a list", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: (req) =>
+        new URL(req.url).pathname === "/search/issues"
+          ? Response.json({ items: [{ number: 4 }] })
+          : Response.json({ message: "Not Found" }),
+    });
+    servers.push(server);
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "a/b",
+      "--api-base",
+      `http://127.0.0.1:${server.port}`,
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/changed files unreadable/);
+  });
+
+  test("refuses an empty --operator rather than building a malformed replaces", async () => {
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator",
+      "",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "a/b",
+    ]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/--operator/);
+  });
+
+  test("set-replaces refuses a missing flag", async () => {
+    const missingReplaces = await run(["set-replaces", "--csv", "/tmp/does-not-matter"]);
+    expect(missingReplaces.exitCode).toBe(2);
+    expect(missingReplaces.stderr).toMatch(/--csv and --replaces/);
+  });
+
+  test("refuses a missing or malformed version instead of guessing", async () => {
+    const dir = catalogDir(["0.9.59"]);
+    const missing = await run(["decide", "--operator-dir", dir, "--repo", "a/b"]);
+    expect(missing.exitCode).toBe(2);
+    expect(missing.stderr).toMatch(/--version is required/);
+
+    const noDir = await run(["decide", "--version", "0.14.1", "--repo", "a/b"]);
+    expect(noDir.exitCode).toBe(2);
+    expect(noDir.stderr).toMatch(/--operator-dir is required/);
+
+    const malformed = await run(["decide", "--version", "v0.14.1", "--operator-dir", dir, "--repo", "a/b"]);
+    expect(malformed.exitCode).toBe(2);
+    expect(malformed.stderr).toMatch(/bare semver/);
+  });
+
+  test("set-replaces writes the pointer into a CSV file in place", async () => {
+    const root = mkdtempSync(join(tmpdir(), "csv-"));
+    roots.push(root);
+    const file = join(root, "csv.yaml");
+    writeFileSync(file, "spec:\n  maturity: alpha\n  version: 0.14.1\n");
+    const result = await run(["set-replaces", "--csv", file, "--replaces", `${OPERATOR}.v0.9.59`]);
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(file, "utf8")).toBe(
+      `spec:\n  maturity: alpha\n  replaces: ${OPERATOR}.v0.9.59\n  version: 0.14.1\n`,
+    );
+  });
+
+  test("set-replaces fails rather than shipping an unlinked bundle", async () => {
+    const root = mkdtempSync(join(tmpdir(), "csv-"));
+    roots.push(root);
+    const file = join(root, "csv.yaml");
+    writeFileSync(file, "spec:\n  maturity: alpha\n");
+    const result = await run(["set-replaces", "--csv", file, "--replaces", `${OPERATOR}.v0.9.59`]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/spec\.version/);
+  });
+
+  test("refuses an unknown command instead of doing something plausible", async () => {
+    const result = await run(["publish"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/unknown command/);
+  });
+
+  test("refuses when the target repo is not given", async () => {
+    const result = await run(["decide", "--version", "0.14.1", "--operator-dir", catalogDir(["0.9.59"])]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/--repo is required/);
+  });
+});

--- a/tests/unit/operator-catalog-submission.test.ts
+++ b/tests/unit/operator-catalog-submission.test.ts
@@ -19,10 +19,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { parse } from "yaml";
 import {
   blockingSubmissions,
   catalogVersions,
   compareVersions,
+  isManagedSubmission,
   submittedVersions,
   predecessorVersion,
   submissionDecision,
@@ -31,6 +33,7 @@ import {
 } from "../../scripts/operator-catalog-submission.mjs";
 
 const OPERATOR = "libredb-studio-operator";
+const FORK = "libredb/community-operators";
 
 describe("catalogVersions", () => {
   test("keeps semver directories and sorts them ascending", () => {
@@ -145,32 +148,76 @@ describe("submittedVersions", () => {
   });
 });
 
+describe("isManagedSubmission", () => {
+  const fork = "libredb/community-operators";
+
+  test("recognises the branch this workflow pushes", () => {
+    expect(isManagedSubmission({ headRepo: fork, headRef: `${OPERATOR}-0.14.1` }, fork, OPERATOR, "0.14.1")).toBe(true);
+  });
+
+  test("rejects the same branch name on a different fork", () => {
+    expect(
+      isManagedSubmission(
+        { headRepo: "someone/community-operators", headRef: `${OPERATOR}-0.14.1` },
+        fork,
+        OPERATOR,
+        "0.14.1",
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects a different branch on our own fork", () => {
+    expect(isManagedSubmission({ headRepo: fork, headRef: "manual-fix" }, fork, OPERATOR, "0.14.1")).toBe(false);
+  });
+
+  test("rejects a branch for another version", () => {
+    expect(isManagedSubmission({ headRepo: fork, headRef: `${OPERATOR}-0.13.7` }, fork, OPERATOR, "0.14.1")).toBe(
+      false,
+    );
+  });
+
+  test("is false when the head is unknown", () => {
+    expect(isManagedSubmission({ headRepo: null, headRef: null }, fork, OPERATOR, "0.14.1")).toBe(false);
+  });
+});
+
 describe("blockingSubmissions", () => {
   test("an open submission for another version blocks", () => {
     // The predecessor is read from the catalog's default branch, so an
     // unmerged submission is invisible to it. Submitting past it would leave
     // the pending bundle dangling once both merge.
-    expect(blockingSubmissions([{ number: 7, versions: ["0.13.7"] }], "0.14.1")).toEqual([
+    expect(blockingSubmissions([{ number: 7, versions: ["0.13.7"], managed: false }], "0.14.1")).toEqual([
       { version: "0.13.7", number: 7 },
     ]);
   });
 
-  test("an open submission for our own version does not block", () => {
-    expect(blockingSubmissions([{ number: 7, versions: ["0.14.1"] }], "0.14.1")).toEqual([]);
+  test("our own managed pull request for this version does not block", () => {
+    // The rerun case: create-pull-request updates that branch in place.
+    expect(blockingSubmissions([{ number: 7, versions: ["0.14.1"], managed: true }], "0.14.1")).toEqual([]);
+  });
+
+  test("somebody else's pull request for this version DOES block", () => {
+    // Same version, different head. create-pull-request only ever updates its
+    // own branch, so proceeding here opens a second submission for one
+    // version - which is the duplicate the version exemption exists to avoid,
+    // arriving through the exemption itself.
+    expect(blockingSubmissions([{ number: 7, versions: ["0.14.1"], managed: false }], "0.14.1")).toEqual([
+      { version: "0.14.1", number: 7 },
+    ]);
   });
 
   test("a higher pending version blocks too", () => {
-    expect(blockingSubmissions([{ number: 7, versions: ["0.15.0"] }], "0.14.1")).toEqual([
+    expect(blockingSubmissions([{ number: 7, versions: ["0.15.0"], managed: false }], "0.14.1")).toEqual([
       { version: "0.15.0", number: 7 },
     ]);
   });
 
   test("a pull request touching no version of ours does not block", () => {
-    expect(blockingSubmissions([{ number: 7, versions: [] }], "0.14.1")).toEqual([]);
+    expect(blockingSubmissions([{ number: 7, versions: [], managed: false }], "0.14.1")).toEqual([]);
   });
 
   test("carries the pull request number, so the skip names what to go and merge", () => {
-    expect(blockingSubmissions([{ number: 7, versions: ["0.13.7"] }], "0.14.1")).toEqual([
+    expect(blockingSubmissions([{ number: 7, versions: ["0.13.7"], managed: false }], "0.14.1")).toEqual([
       { version: "0.13.7", number: 7 },
     ]);
   });
@@ -179,8 +226,8 @@ describe("blockingSubmissions", () => {
     expect(
       blockingSubmissions(
         [
-          { number: 8, versions: ["0.15.0"] },
-          { number: 7, versions: ["0.13.7", "0.15.0"] },
+          { number: 8, versions: ["0.15.0"], managed: false },
+          { number: 7, versions: ["0.13.7", "0.15.0"], managed: false },
         ],
         "0.14.1",
       ),
@@ -218,7 +265,10 @@ describe("submissionDecision", () => {
   });
 
   test("skips when an earlier submission is still open, naming it and its pull request", () => {
-    const decision = submissionDecision({ ...base, openSubmissions: [{ number: 7, versions: ["0.13.7"] }] });
+    const decision = submissionDecision({
+      ...base,
+      openSubmissions: [{ number: 7, versions: ["0.13.7"], managed: false }],
+    });
     expect(decision.enabled).toBe(false);
     expect(decision.reason).toMatch(/still open/);
     expect(decision.reason).toMatch(/0\.13\.7/);
@@ -233,7 +283,7 @@ describe("submissionDecision", () => {
     const decision = submissionDecision({
       ...base,
       entries: ["ci.yaml", "0.9.59"],
-      openSubmissions: [{ number: 12345, versions: ["0.9.59"] }],
+      openSubmissions: [{ number: 12345, versions: ["0.9.59"], managed: false }],
     });
     expect(decision.enabled).toBe(true);
     expect(decision.predecessor).toBe("0.9.59");
@@ -264,7 +314,7 @@ describe("submissionDecision", () => {
     const decision = submissionDecision({
       ...base,
       entries: ["0.9.59", "0.14.1"],
-      openSubmissions: [{ number: 7, versions: ["0.13.7"] }],
+      openSubmissions: [{ number: 7, versions: ["0.13.7"], managed: false }],
     });
     expect(decision.reason).toMatch(/already carries/);
   });
@@ -404,7 +454,10 @@ describe("CLI", () => {
    * A stand-in for the two GitHub endpoints the CLI reads: the issue search
    * and each candidate pull request's changed files.
    */
-  function apiServing(prs: Array<{ number: number; files: string[] }>, status = 200): string {
+  function apiServing(
+    prs: Array<{ number: number; files: string[]; headRepo?: string; headRef?: string }>,
+    status = 200,
+  ): string {
     const server = Bun.serve({
       port: 0,
       fetch: (req) => {
@@ -415,10 +468,17 @@ describe("CLI", () => {
         if (path === "/search/issues") {
           return Response.json({ items: prs.map((pr) => ({ number: pr.number, title: "whatever" })) });
         }
-        const match = path.match(/\/repos\/.+\/pulls\/(\d+)\/files$/);
-        if (match) {
-          const pr = prs.find((candidate) => candidate.number === Number(match[1]));
+        const files = path.match(/\/repos\/.+\/pulls\/(\d+)\/files$/);
+        if (files) {
+          const pr = prs.find((candidate) => candidate.number === Number(files[1]));
           return Response.json((pr?.files ?? []).map((filename) => ({ filename })));
+        }
+        const pull = path.match(/\/repos\/.+\/pulls\/(\d+)$/);
+        if (pull) {
+          const pr = prs.find((candidate) => candidate.number === Number(pull[1]));
+          return Response.json({
+            head: { ref: pr?.headRef ?? "somebody-elses-branch", repo: { full_name: pr?.headRepo ?? "someone/fork" } },
+          });
         }
         return new Response("unexpected path", { status: 404 });
       },
@@ -450,6 +510,8 @@ describe("CLI", () => {
       catalogDir(["ci.yaml", "0.9.59"]),
       "--repo",
       "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
       "--api-base",
       apiServing([]),
     ]);
@@ -470,6 +532,8 @@ describe("CLI", () => {
       catalogDir(["0.9.59", "0.14.1"]),
       "--repo",
       "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
       "--api-base",
       apiServing([], 500),
     ]);
@@ -487,6 +551,8 @@ describe("CLI", () => {
       catalogDir(null),
       "--repo",
       "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
       "--api-base",
       apiServing([], 500),
     ]);
@@ -504,6 +570,8 @@ describe("CLI", () => {
       catalogDir(["ci.yaml", "0.9.59"]),
       "--repo",
       "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
       "--api-base",
       apiServing([{ number: 7, files: [`operators/${OPERATOR}/0.13.7/manifests/csv.yaml`] }]),
     ]);
@@ -523,6 +591,8 @@ describe("CLI", () => {
       catalogDir(["ci.yaml", "0.9.59"]),
       "--repo",
       "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
       "--api-base",
       apiServing([{ number: 9, files: [`operators/${OPERATOR}/ci.yaml`] }]),
     ]);
@@ -541,6 +611,8 @@ describe("CLI", () => {
       catalogDir(["ci.yaml", "0.9.59"]),
       "--repo",
       "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
       "--api-base",
       apiServing([], 403),
     ]);
@@ -558,6 +630,8 @@ describe("CLI", () => {
       catalogDir(["ci.yaml", "0.9.59"]),
       "--repo",
       "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
       "--api-base",
       apiServing([]),
     ]);
@@ -586,11 +660,60 @@ describe("CLI", () => {
       file,
       "--repo",
       "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
       "--api-base",
       apiServing([]),
     ]);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toMatch(/ENOTDIR|not a directory/i);
+  });
+
+  test("a rerun for our own version updates rather than blocks, but a stranger's pull request blocks", async () => {
+    const mine = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
+      "--api-base",
+      apiServing([
+        {
+          number: 7,
+          files: [`operators/${OPERATOR}/0.14.1/manifests/csv.yaml`],
+          headRepo: FORK,
+          headRef: `${OPERATOR}-0.14.1`,
+        },
+      ]),
+    ]);
+    expect(mine.stdout).toContain("enabled=true");
+
+    const theirs = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["ci.yaml", "0.9.59"]),
+      "--repo",
+      "k8s-operatorhub/community-operators",
+      "--fork",
+      FORK,
+      "--api-base",
+      apiServing([
+        {
+          number: 8,
+          files: [`operators/${OPERATOR}/0.14.1/manifests/csv.yaml`],
+          headRepo: "stranger/community-operators",
+          headRef: `${OPERATOR}-0.14.1`,
+        },
+      ]),
+    ]);
+    expect(theirs.stdout).toContain("enabled=false");
+    expect(theirs.stdout).toMatch(/reason=.*0\.14\.1 \(#8\)/);
   });
 
   test("fails when the search response is not the expected shape", async () => {
@@ -604,6 +727,8 @@ describe("CLI", () => {
       catalogDir(["ci.yaml", "0.9.59"]),
       "--repo",
       "a/b",
+      "--fork",
+      FORK,
       "--api-base",
       `http://127.0.0.1:${server.port}`,
     ]);
@@ -628,6 +753,8 @@ describe("CLI", () => {
       catalogDir(["ci.yaml", "0.9.59"]),
       "--repo",
       "a/b",
+      "--fork",
+      FORK,
       "--api-base",
       `http://127.0.0.1:${server.port}`,
     ]);
@@ -646,6 +773,8 @@ describe("CLI", () => {
       catalogDir(["ci.yaml", "0.9.59"]),
       "--repo",
       "a/b",
+      "--fork",
+      FORK,
     ]);
     expect(result.exitCode).toBe(2);
     expect(result.stderr).toMatch(/--operator/);
@@ -659,15 +788,25 @@ describe("CLI", () => {
 
   test("refuses a missing or malformed version instead of guessing", async () => {
     const dir = catalogDir(["0.9.59"]);
-    const missing = await run(["decide", "--operator-dir", dir, "--repo", "a/b"]);
+    const missing = await run(["decide", "--operator-dir", dir, "--repo", "a/b", "--fork", FORK]);
     expect(missing.exitCode).toBe(2);
     expect(missing.stderr).toMatch(/--version is required/);
 
-    const noDir = await run(["decide", "--version", "0.14.1", "--repo", "a/b"]);
+    const noDir = await run(["decide", "--version", "0.14.1", "--repo", "a/b", "--fork", FORK]);
     expect(noDir.exitCode).toBe(2);
     expect(noDir.stderr).toMatch(/--operator-dir is required/);
 
-    const malformed = await run(["decide", "--version", "v0.14.1", "--operator-dir", dir, "--repo", "a/b"]);
+    const malformed = await run([
+      "decide",
+      "--version",
+      "v0.14.1",
+      "--operator-dir",
+      dir,
+      "--repo",
+      "a/b",
+      "--fork",
+      FORK,
+    ]);
     expect(malformed.exitCode).toBe(2);
     expect(malformed.stderr).toMatch(/bare semver/);
   });
@@ -701,8 +840,88 @@ describe("CLI", () => {
   });
 
   test("refuses when the target repo is not given", async () => {
-    const result = await run(["decide", "--version", "0.14.1", "--operator-dir", catalogDir(["0.9.59"])]);
+    const result = await run([
+      "decide",
+      "--version",
+      "0.14.1",
+      "--operator-dir",
+      catalogDir(["0.9.59"]),
+      "--fork",
+      FORK,
+    ]);
     expect(result.exitCode).toBe(2);
     expect(result.stderr).toMatch(/--repo is required/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workflow wiring. The matrix that decides where a submission is pushed is
+// configuration, so nothing else in the suite would notice a typo'd slug or a
+// fork paired with the wrong upstream until a release tried it.
+// ---------------------------------------------------------------------------
+
+describe("the submit-catalogs matrix", () => {
+  const workflow = parse(
+    readFileSync(join(import.meta.dir, "../../.github/workflows/operator-release.yml"), "utf8"),
+  ) as {
+    jobs: Record<
+      string,
+      {
+        needs?: string;
+        if?: string;
+        strategy?: {
+          "fail-fast"?: boolean;
+          matrix?: { catalog?: Array<{ label: string; upstream: string; fork: string; release_config: boolean }> };
+        };
+      }
+    >;
+  };
+  const job = workflow.jobs["submit-catalogs"];
+  const catalogs = job.strategy?.matrix?.catalog ?? [];
+
+  test("covers both community catalogs", () => {
+    expect(catalogs.map((entry) => entry.upstream).sort()).toEqual([
+      "k8s-operatorhub/community-operators",
+      "redhat-openshift-ecosystem/community-operators-prod",
+    ]);
+  });
+
+  test("pairs each upstream with the fork of that same upstream", () => {
+    // A fork paired with the wrong upstream would push a bundle into the other
+    // catalog's fork and open a pull request that cannot merge. The fork name
+    // mirrors the upstream repository name, which is what makes this checkable
+    // without the network.
+    for (const entry of catalogs) {
+      expect(entry.fork).toBe(`libredb/${entry.upstream.split("/")[1]}`);
+    }
+  });
+
+  test("every fork is org-owned, because they were transferred there", () => {
+    for (const entry of catalogs) {
+      expect(entry.fork.startsWith("libredb/")).toBe(true);
+    }
+  });
+
+  test("release-config is written for the FBC catalog only", () => {
+    const withConfig = catalogs.filter((entry) => entry.release_config).map((entry) => entry.upstream);
+    expect(withConfig).toEqual(["redhat-openshift-ecosystem/community-operators-prod"]);
+  });
+
+  test("release_config is a boolean, not a string that would read as truthy", () => {
+    // `release_config: "false"` in YAML is a non-empty string, so the step's
+    // `&& matrix.catalog.release_config` guard would run for both catalogs.
+    for (const entry of catalogs) {
+      expect(typeof entry.release_config).toBe("boolean");
+    }
+  });
+
+  test("one catalog failing does not cancel the other", () => {
+    expect(job.strategy?.["fail-fast"]).toBe(false);
+  });
+
+  test("the job runs only after the controller image is pushed, and only for a submittable version", () => {
+    expect(job.needs).toBe("build-and-push");
+    expect(job.if).toContain("needs.build-and-push.outputs.skip != 'true'");
+    expect(job.if).toContain("needs.build-and-push.outputs.submittable == 'true'");
   });
 });


### PR DESCRIPTION
Closes #656.

Every release now opens its own bundle pull request against both community operator catalogs.
Until today that was two hand-made submissions per release, and the cost was measurable rather than theoretical: both catalogs sat at 0.9.59 while the product reached 0.14.1, so **0.14.0 was never submitted at all**.

## What lands

- `submit-catalogs` in [`.github/workflows/operator-release.yml`](.github/workflows/operator-release.yml), a matrix over the two catalogs with `needs: build-and-push`, because the catalog pipelines pull the controller image onto a real cluster and it has to exist and be public first.
- [`scripts/operator-catalog-submission.mjs`](scripts/operator-catalog-submission.mjs): every decision as a pure function, with the CLI as a thin shell. 50 tests.
- `operatorhub-community` joins `SWITCHABLE_CHANNEL_IDS`, so the submission is switched from `distribution/channels.yaml` like every other optional channel.
- `spec.replaces` is removed from the committed bundle, and its absence is now asserted.

## The design decision, and why it reversed

The pointer's only correct value names the version immediately preceding ours **in the catalog being submitted to**.
That is external state: it lags our releases by however many submissions are unmerged, and the two catalogs disagree with each other.
`CATALOG_REPLACES` in `operator/Makefile` declared it, which made the committed bundle correct only by coincidence and stale by default - a cost paid on every release, and exactly the fourth hand-maintained version string the operator docs say must not exist.

So the value is derived at submission time from the catalog itself and injected into the bundle copy, and nothing in the repo declares it.
The consequence looks like an omission and is not: the committed bundle on its own does not pass `opm index add --mode replaces`.
`tests/unit/operator-bundle-update-graph.test.ts` asserts that absence rather than documenting it, because the obvious "fix" is to add a declared value back.

## What was measured, not assumed

Two upstream gates reject an unlinked graph, and neither accepts `olm.skipRange` as a substitute:

| Gate | Failure with skipRange alone |
|---|---|
| k8s-operatorhub deploy jobs, `opm index add --mode replaces` | `add prunes bundle libredb-studio-operator.v0.9.59 ... skips/replaces []` |
| community-operators-prod FBC, `opm validate` | `multiple channel heads found in graph: v0.14.1, v0.9.59` |

The first was reproduced locally against the same command with a local registry and two bundle images: replaces-mode with a skipRange alone exits 1, with `spec.replaces` exits 0, and `--mode semver` exits 0.
The second is from community-operators-prod#11106's pipeline log.
Note the trap in the pair: `check_dangling_bundles` in operatorcert seeds its graph from `_resolve_skip_range` and so passes on a skipRange alone, and it is decorated `@skip_fbc` so it never runs for the FBC catalog. A green static check is not evidence that a submission will build.

Three more findings that shaped the code:

- **Duplicate detection is path-based, never title-based.** The hub rewrites submission titles on open and on every push, inserting markers in a fixed order and listing more than one version for a multi-version PR; our own #8794 was renamed to `operator [N] [CI] libredb-studio-operator (0.9.59)`. The job reads each candidate PR's changed files instead.
- **`gh repo sync --source` cannot be trusted.** It calls `POST /merge-upstream` first, and that endpoint takes neither a source nor a force parameter, so a fork pointing at the wrong parent would sync from the wrong repository and still exit 0. The job asserts the parent, calls `merge-upstream` directly, then asserts the fork is `identical` or `behind`.
- **Identity, not fork ownership, is what upstream authorizes.** Both catalogs compare the account that opened the PR against the operator's `ci.yaml` reviewers on the base branch; nothing reads the fork owner or the commit author. `OPERATOR_CATALOG_TOKEN` is a classic PAT on a listed account, and `signoff: true` writes the trailer from the **committer** input, so committer and author are both set to the same real identity.

## An older unmerged submission is a hard stop

The predecessor comes from the catalog's `main`, so a submission that is open but unmerged is invisible to it.
Submitting past a pending version points the graph over it, and once both merge the pending bundle is dangling.
That is what lost VictoriaMetrics 0.48.2, and their record is why it is worth a hard stop rather than a warning: `victoriametrics-bot` landed 45 of 50 submissions on operatorhub.io, and four of the five that did not land are versions the catalog has never carried.

## Skips are notices, never failures

Every "nothing to do" branch exits 0 with a `::notice::` naming the condition: channel switched off, token absent, image not anonymously pullable, operator not listed yet (a first listing stays manual), version already listed, older submission still open.
Two things it refuses rather than guesses: a GitHub API read that fails stops the job instead of defaulting to "submit", and a fork with the wrong parent stops it before anything is mutated.

One honesty fix came out of this: `docs/CHANNELS.md` labelled everything that is not `ci_publish` as "Manual". The row now reads "Automated PR", because we open the pull request and somebody else merges it.

## Verification

- `bun run format`, `lint` (0 errors), `typecheck`, `chart:check`, `channels:showcase:check`, `readme:check`, `security:check`, `distribution:matrix --check`, `knip`: clean.
- Tests run per layer: 10968 pass in unit/api/integration, and hooks, security, evals and components all clean. The one red is pre-existing and invisible to CI: gitignored `docs/superpowers/` drafts trip the backlog citation guard.
- `make -C operator bundle` regenerates with no diff beyond `createdAt`, so the required bundle-freshness job stays green.
- The committed bundle was built as an image and run through `opm index add --mode replaces` to confirm it fails, which is the intended state.

## Review

Two workflow fan-outs ran over this before it was opened: a recon pass on the upstream assumptions and a six-lens adversarial review of the diff, each finding verified by a second agent against the real code.
The review confirmed 44 defects and every one is fixed here. The six that mattered most:

- **An unrelated upstream pull request touching an already-merged version directory muted the submission.** `blockingSubmissions` filtered only on "not our version", so any open PR editing `operators/libredb-studio-operator/0.9.59/` would have stopped every release with a green run. A version the catalog already carries is no longer treated as pending.
- **A release below the channel head was allowed through** and would have produced the two-head graph it exists to prevent. It is now refused, because linking that graph is a judgement call rather than a derivation.
- **`readOperatorEntries` swallowed every error**, so a changed upstream layout or a wrong path read as "first submission is manual" and exited 0. Only a missing path means that now; anything else throws.
- **The GHCR check could not print its own diagnostic.** ghcr hands a pull token to anyone who asks, so a private package fails on the manifest read, and `curl -sf` killed the step at exit 22 before the "make it public" message could run. It branches on the status code now, and retries transient failures.
- **Test gaps that let real mutations survive.** `compareVersions` was never compared at patch level, the `withReplaces` anchor was never run against the real 380-line CSV, and the three `spec.replaces` absence guards had no positive control, so a broken helper would have satisfied all of them.
- **A prerelease tag would have reddened the release** after the image was already pushed. The version step now emits `submittable`, and the submission job skips a prerelease instead of failing on it.

Also fixed: the workflow is serialized so two releases cannot race the pending-submission guard, the staged bundle is asserted to be the bundle for this version, a skip that means a release did not reach a catalog is a `::warning::` rather than a `::notice::`, the skip names the blocking pull request number, the token is no longer handed to steps that only do unauthenticated reads, and the docs no longer contradict the code about `skipRange`.
