### PR TITLE
feat(deploy): support build-time subpath deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,7 @@ tests
 playwright-report
 test-results
 data-e2e-offline
+data-e2e-base-path
 .loop
 loop
 .claude

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@
 # ============================================
 
 # ============================================
+# BUILD-TIME SUBPATH (Optional)
+# ============================================
+# For /libredb, /tools/libredb or /~/libredb, build your own image/app with this
+# value. It cannot relocate a prebuilt image at runtime. No trailing slash.
+# BASE_PATH=/tools/libredb
+# Details, reverse-proxy rules and OIDC callback URLs: docs/SUBPATH.md
+
+# ============================================
 # SERVER BIND ADDRESS (Optional)
 # ============================================
 # Which address the standalone server listens on. The app never reads it - it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,10 @@ jobs:
           USER_EMAIL: user@libredb.org
           USER_PASSWORD: test-user
 
+      - name: Run subpath deployment E2E
+        # Separate build, after the root-path servers have stopped.
+        run: bun run test:e2e:base-path
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ deploy/digitalocean/droplet/scripts/99-img-check.sh
 /probe-*.yaml
 /probe-results/
 /probe-results*.json
+
+# Isolated data for the production subpath regression suite.
+data-e2e-base-path/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV DOCKER_BUILD=true
 
+# Next.js bakes this prefix into routes and browser bundles. Rebuild to change it.
+ARG BASE_PATH=""
+
 ARG JWT_SECRET_BUILD="build-time-placeholder-secret-32ch"
 ARG ADMIN_PASSWORD_BUILD="build"
 ARG USER_PASSWORD_BUILD="build"

--- a/README.md
+++ b/README.md
@@ -638,6 +638,9 @@ Deploy your own instance of LibreDB Studio with a single click on DigitalOcean, 
 
 ## Deployment (DevOps)
 
+For a reverse-proxy path such as `/tools/libredb`, build with `BASE_PATH` and follow the
+[subpath deployment guide](docs/SUBPATH.md). Prebuilt images use the root path.
+
 > Maintainers: every distribution channel is inventoried in
 > [`distribution/channels.yaml`](distribution/channels.yaml); `bun run distribution:check`
 > reports version drift across all of them (see

--- a/charts/libredb-studio/Chart.yaml
+++ b/charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting sixteen engines - PostgreSQL, MySQL, SQLite, DuckDB, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra and libSQL
 type: application
-version: 0.1.60
+version: 0.1.61
 appVersion: "0.14.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -113,13 +113,7 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "The light theme stops painting dark-tuned accent colour. Warning, success and danger text, the query editor Explain control and the monitoring status rings were drawn in colours chosen against a dark ground and reused unchanged on the light one, where the worst of them sat at 1.46:1 against the surface behind it. Every accent is now a token measured on the ground it is drawn on, and the measurement runs as a test rather than being recorded in a comment"
-    - "Both themes now clear a 4.79:1 contrast floor for accent text, measured per token on every surface it can land on"
-    - "Engine identity colours are separated by measurement instead of by eye, so two engines listed next to each other no longer read as the same colour on either theme"
-    - "The Overview and Health panels answer on the MySQL-wire engines that refused a filter they never needed. SHOW STATUS is now read bare and the wanted rows picked out of the answer, so Apache Doris renders instead of failing outright, and a status variable an engine does not publish reads as absent rather than as a fabricated default"
-    - "A query plan is asked for in the grammar the server actually accepts, measured when the connection opens on both wire families. The Explain panel was sending one MySQL form and one PostgreSQL form to every relative of each, so it showed an empty no-plan state on Materialize, CockroachDB, TiDB, StarRocks, SingleStore, Apache Doris and Databend. All seven now render their own plan"
-    - "LOG_LEVEL is documented in .env.example, and an environment variable the app reads can no longer go undocumented without failing a test"
-    - "Track app release 0.14.1 (appVersion bump; default image tag follows)"
+    - "Prefix default health probes with config.basePath for images built to run under a subpath"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/charts/libredb-studio/README.md
+++ b/charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.60 \
+  --version 0.1.61 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```
@@ -391,6 +391,7 @@ would otherwise lose reachability. One line in the pod log names the address it 
 `config.bindAddress` overrules the resolver when you would rather state it than leave it to the
 image:
 
+| `config.basePath` | Must match `BASE_PATH` baked into your custom image; prefixes default health probes | `""` |
 | `config.bindAddress` | Effect |
 |---|---|
 | `""` (default) | the container resolves it, preferring a verified dual-stack `::` |
@@ -639,3 +640,14 @@ fixed `runAsUser`/`runAsGroup`/`fsGroup` so the SCC can assign valid IDs;
 UIDs: every writable path is a volume mount. Set `force` to always adapt (for
 example when templating manifests offline for an OpenShift cluster) or
 `disabled` to keep the fixed IDs everywhere.
+
+## Deployment under a subpath
+
+Build a custom image with `docker build --build-arg BASE_PATH=/tools/libredb ...`, then set
+`config.basePath: /tools/libredb` and the matching image repository/tag. This prefixes the default
+startup, readiness and liveness probes. It does not change routes in an already-built image.
+Explicit custom probe paths are preserved. Set Ingress paths or HTTPRoute matches to the same
+prefix and preserve it when forwarding; do not strip or rewrite it.
+
+See [subpath deployment](https://github.com/libredb/libredb-studio/blob/main/docs/SUBPATH.md)
+for complete build, reverse-proxy and OIDC examples.

--- a/charts/libredb-studio/templates/_helpers.tpl
+++ b/charts/libredb-studio/templates/_helpers.tpl
@@ -386,3 +386,12 @@ Return the PostgreSQL URL when subchart is enabled
 {{- define "libredb-studio.postgresql.url" -}}
 {{- printf "postgresql://%s:$(POSTGRES_PASSWORD)@%s:5432/%s" .Values.postgresql.auth.username (include "libredb-studio.postgresql.fullname" .) .Values.postgresql.auth.database }}
 {{- end }}
+
+{{/* Prefix only the shipped health path; preserve explicit HTTP/exec/TCP probes. */}}
+{{- define "libredb-studio.probe" -}}
+{{- $probe := deepCopy .probe -}}
+{{- if and $probe.httpGet (eq ($probe.httpGet.path | default "") "/api/db/health") -}}
+{{- $_ := set $probe.httpGet "path" (printf "%s/api/db/health" .basePath) -}}
+{{- end -}}
+{{- toYaml $probe -}}
+{{- end -}}

--- a/charts/libredb-studio/templates/deployment.yaml
+++ b/charts/libredb-studio/templates/deployment.yaml
@@ -270,15 +270,15 @@ spec:
             {{- end }}
           {{- with .Values.startupProbe }}
           startupProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- include "libredb-studio.probe" (dict "probe" . "basePath" ($.Values.config.basePath | default "")) | nindent 12 }}
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- include "libredb-studio.probe" (dict "probe" . "basePath" ($.Values.config.basePath | default "")) | nindent 12 }}
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- include "libredb-studio.probe" (dict "probe" . "basePath" ($.Values.config.basePath | default "")) | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/libredb-studio/values.schema.json
+++ b/charts/libredb-studio/values.schema.json
@@ -124,6 +124,12 @@
     "config": {
       "type": "object",
       "properties": {
+        "basePath": {
+          "type": "string",
+          "description": "Build-time BASE_PATH of the custom image; prefixes default probes, not a runtime app setting",
+          "pattern": "^$|^(/[A-Za-z0-9._~-]+)+$",
+          "not": { "pattern": "(^|/)\\.\\.?(/|$)" }
+        },
         "logLevel": {
           "type": "string",
           "enum": ["debug", "info", "warn", "error"],

--- a/charts/libredb-studio/values.yaml
+++ b/charts/libredb-studio/values.yaml
@@ -92,6 +92,9 @@ secrets:
 authProvider: "local"
 
 config:
+  # -- Must match BASE_PATH baked into a custom image. Prefixes default health probes;
+  # this value cannot change the routes in a prebuilt image. Empty means root.
+  basePath: ""
   # -- Log level
   logLevel: "info"
   # -- Address the container listens on, written to HOSTNAME. Empty is the

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -109,8 +109,9 @@ services:
     #   - ./seed-connections.yaml:/app/config/seed-connections.yaml:ro
 
     # Image runs as node:24.16.0-trixie-slim (no curl/wget) — use Node's built-in fetch.
+    # BASE_PATH must match a custom image built with that prefix (docs/SUBPATH.md).
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/api/db/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000${BASE_PATH:-}/api/db/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        BASE_PATH: ${BASE_PATH:-}
     ports:
       - "3000:3000"
     environment:

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -35,7 +35,7 @@ None of it is a GitHub issue.
 - [Dependencies](#dependencies) — P1–P5 · 5
 - [Documentation](#documentation) — DOC3, DOC4 · 2
 - [Release pipeline](#release-pipeline) — REL1–REL3 · 3
-- [Chart configuration surface](#chart-configuration-surface) — N1, N3 · 2
+- [Chart configuration surface](#chart-configuration-surface) — N1 · 1
 - [Security Phase 1 deferrals](#security-phase-1-deferrals) — H1–H8 · 2
 - [Security Phase 2 deferrals](#security-phase-2-deferrals) — C3–C11 · 7
 - [Security Phase 3 deferrals](#security-phase-3-deferrals) — K4
@@ -987,39 +987,6 @@ Note the naming collision: `route.*` in `values.yaml` means Gateway API as of #3
 
 **Done when:** an OpenShift cluster can be served by the chart alone, with TLS termination selectable,
 and the README says which of the three exposure mechanisms belongs to which platform.
-
-### N3. Subpath deployment is build-time only, which is why #369 is deferred rather than scheduled
-
-[#369](https://github.com/libredb/libredb-studio/issues/369) asks to serve Studio under a path prefix
-on a shared domain — `https://example.com/libredb` next to `https://example.com/grafana`.
-`next.config.ts` sets no `basePath` and no `assetPrefix`, so there is zero support today.
-
-The constraint, recorded so nobody rediscovers it: **Next.js `basePath` is baked at build, not read at
-runtime.** Asset URLs (`/_next/static/...`) are emitted into the HTML and JS at build time and there
-is no supported runtime override. So a `BASE_PATH` env var on the prebuilt image cannot work — the
-feature has to be a build arg and a rebuilt image.
-
-A reverse-proxy `StripPrefix` is not a workaround either. The browser asks for `/libredb/`, the proxy
-strips it, the app answers with HTML referencing `/_next/static/...` at the root, and that follow-up
-request no longer matches the `/libredb` router rule. Grafana can do this at runtime because it is a
-Go server templating its own HTML; a statically built Next.js app is structurally different.
-
-The surface a build-time implementation touches: roughly 40 `fetch('/api/...')` call sites, roughly 15
-`router.push('/...')`, the cookie `path: "/"` in `src/lib/auth.ts` and the OIDC login route, OIDC
-redirect URIs, the `src/proxy.ts` matcher, the Docker healthcheck, the chart's ingress and route
-paths, the npm library surface, the E2E suite and the docs of roughly 27 distribution channels.
-`next/link` and the app-router `router` prefix automatically; `fetch`, middleware redirects and cookie
-paths do not.
-
-Deferred rather than scheduled because the acquisition-relevant PaaS one-click listings hand out
-subdomains, not subpaths, so no shipped channel needs it.
-
-Related sharp edge, same silent-no-op class as #366: `values.yaml` already lets a user set
-`ingress.hosts[].paths[].path` to `/libredb`, the install succeeds, and the app is unreachable.
-
-**Done when:** a `BASE_PATH` build arg produces an image reachable under a path prefix — assets, API
-calls, auth cookie and OIDC redirect included — verified against a real path-routing proxy, or the
-chart refuses a non-root ingress path outright.
 
 ---
 

--- a/docs/SUBPATH.md
+++ b/docs/SUBPATH.md
@@ -1,0 +1,126 @@
+# Deploy Studio under a subpath
+
+Studio can run at `/libredb`, `/tools/libredb`, or `/~/libredb` behind a reverse proxy.
+Set `BASE_PATH` **when building**. Next.js bakes this prefix into routes and browser bundles;
+setting it only on a prebuilt image cannot relocate that image. The published images use `/`.
+
+Use a leading slash and no trailing slash. Empty or `/` selects the root. Path segments may
+contain letters, digits, `.`, `_`, `~`, and `-`; dot segments, encoded paths, query strings,
+fragments, backslashes, and repeated slashes are rejected during the build.
+
+## Build from source
+
+Keep the same value for build and `next start`:
+
+```sh
+export BASE_PATH=/tools/libredb
+bun install --frozen-lockfile
+bun run build
+bun start
+```
+
+With Docker, build a custom image from the source revision containing subpath support:
+
+```sh
+docker build --build-arg BASE_PATH=/tools/libredb -t studio-subpath:local .
+docker run --rm -p 3000:3000 --env-file .env.local studio-subpath:local
+```
+
+The build uses the prefix from the build arg. Supply your normal runtime authentication,
+storage, and LLM settings as usual. `BASE_PATH` is not a replacement for a public origin or
+for `ALLOWED_ORIGINS`; that setting still takes origins such as `https://example.com`.
+
+The source `docker-compose.yml` forwards `BASE_PATH` as a build arg:
+
+```sh
+BASE_PATH=/tools/libredb docker compose up --build
+```
+
+When using `docker-compose.example.yml`, select your custom image and set the same `BASE_PATH`
+in Compose's environment so its health check uses the built path.
+
+## Preserve the prefix at the reverse proxy
+
+Forward `/tools/libredb` and everything below it **with the path intact**. Do not use
+Traefik `StripPrefix`, an Nginx rewrite, or an HTTPRoute `URLRewrite` to remove the prefix.
+For example, an Nginx upstream without a URI suffix preserves the original path:
+
+```nginx
+location ~ ^/tools/libredb(?:/|$) {
+    proxy_pass http://studio:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $http_host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+For Traefik, match ``PathPrefix(`/tools/libredb`)`` and forward to Studio without a strip-prefix
+middleware. Restrict the rule to your intended hostname as usual. Assets, API calls,
+streamed agent responses, and native authentication redirects all use the configured prefix.
+Next's router and `Link` apply it automatically. Studio has no WebSocket endpoint to configure.
+
+## Helm and Gateway API
+
+Build and publish your own image with the prefix first. Then use matching chart values:
+
+```yaml
+image:
+  repository: registry.example.com/studio-subpath
+  tag: my-build
+config:
+  basePath: /tools/libredb
+
+ingress:
+  enabled: true
+  hosts:
+    - host: example.com
+      paths:
+        - path: /tools/libredb
+          pathType: Prefix
+```
+
+`config.basePath` prefixes the chart's default startup, readiness, and liveness health paths.
+It does not set a runtime app environment variable. Explicit custom probe paths, exec probes,
+and TCP probes are preserved. A mismatched image and chart prefix fails readiness.
+
+For a Gateway API deployment, use an HTTPRoute match with the same prefix and your cluster's
+actual Gateway reference:
+
+```yaml
+route:
+  main:
+    enabled: true
+    parentRefs:
+      - name: my-gateway
+    hostnames:
+      - example.com
+    matches:
+      - path:
+          type: PathPrefix
+          value: /tools/libredb
+```
+
+Do not add a rewrite filter. If you use external health checks, request
+`/tools/libredb/api/db/health`.
+
+## Authentication and editor assets
+
+Register the full OIDC callback URL, for example
+`https://example.com/tools/libredb/api/auth/oidc/callback`, and allow the logout return URL
+`https://example.com/tools/libredb/login` at your identity provider. Session and OIDC state
+cookies use `/tools/libredb` as their path, including when they are removed.
+
+The default Monaco asset URL becomes `/tools/libredb/monaco/vs`. An explicit
+`NEXT_PUBLIC_MONACO_VS_PATH` override is used exactly as configured, including an external
+asset origin; do not add the prefix a second time.
+
+For the embedded npm library, the host application's routing remains its responsibility.
+Standalone builds publish the internal `NEXT_PUBLIC_BASE_PATH` value from `BASE_PATH`; it is
+not a separate operator setting.
+
+## Verification
+
+`bun run test:e2e:base-path` builds at `/~/libredb`, starts a local path-preserving proxy that
+returns 404 outside that prefix, and tests login, RBAC, cookie deletion, a real SQLite query, origin checks, OIDC error
+redirects, and self-hosted editor assets in Chromium. Run it after the ordinary E2E suite;
+the two configurations build different versions of `.next`.

--- a/e2e/base-path.spec.ts
+++ b/e2e/base-path.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+
+const prefix = "/~/libredb";
+
+test("production deployment behind a path-preserving reverse proxy", async ({ page, context, request, baseURL }) => {
+  const failedAppRequests: string[] = [];
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  page.on("response", (response) => {
+    if (response.url().startsWith(baseURL!) && response.status() >= 400)
+      failedAppRequests.push(`${response.status()} ${response.url()}`);
+  });
+  await page.route("**/*", (route) => (route.request().url().startsWith(baseURL!) ? route.continue() : route.abort()));
+
+  // The proxy makes escaping the prefix observable instead of letting root URLs work by accident.
+  expect((await request.get("/api/db/health")).status()).toBe(404);
+  expect((await request.get(`${prefix}-other/api/db/health`)).status()).toBe(404);
+  expect((await request.get(`${prefix}/api/db/health`)).status()).toBe(200);
+  expect(
+    (
+      await request.post(`${prefix}/api/db/health`, { headers: { origin: "https://untrusted.example" }, data: {} })
+    ).status(),
+  ).toBe(403);
+  const rootRedirect = await request.get(prefix, { maxRedirects: 0 });
+  expect(new URL(rootRedirect.headers().location, baseURL).href).toBe(`${baseURL}${prefix}/login`);
+  const redirect = await request.get(`${prefix}/admin`, { maxRedirects: 0 });
+  expect(new URL(redirect.headers().location, baseURL).href).toBe(`${baseURL}${prefix}/login`);
+  const oidcError = await request.get(`${prefix}/api/auth/oidc/login`, { maxRedirects: 0 });
+  expect(new URL(oidcError.headers().location, baseURL).href).toBe(`${baseURL}${prefix}/login?error=oidc_config`);
+
+  await page.goto(`${prefix}/login`);
+  await page.locator('input[type="email"]:visible').fill("user@libredb.org");
+  await page.locator('input[type="password"]:visible').fill("test-user");
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect(page).toHaveURL(new RegExp(`${prefix}/?$`));
+  await expect(page.locator(".monaco-editor").first()).toBeVisible({ timeout: 30_000 });
+  const cookie = (await context.cookies()).find((value) => value.name === "auth-token");
+  expect(cookie).toMatchObject({ path: prefix, httpOnly: true, sameSite: "Lax" });
+
+  await page.getByText("Sample (Employees)", { exact: true }).first().click();
+  await page.waitForFunction(
+    () =>
+      ((window as unknown as { monaco?: { editor: { getEditors(): unknown[] } } }).monaco?.editor.getEditors().length ??
+        0) > 0,
+  );
+  await page.evaluate(() => {
+    const monaco = (window as unknown as { monaco: { editor: { getEditors(): { setValue(value: string): void }[] } } })
+      .monaco;
+    monaco.editor.getEditors()[0].setValue("SELECT COUNT(*) AS employee_count FROM employee");
+  });
+  await page.getByRole("button", { name: "RUN", exact: true }).click();
+  await expect(page.getByText("employee_count", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("1000", { exact: true }).first()).toBeVisible();
+
+  const session = await page.evaluate(async (path) => (await fetch(`${path}/api/auth/me`)).json(), prefix);
+  expect(session.user.role).toBe("user");
+  await page.goto(`${prefix}/admin`);
+  await expect(page).toHaveURL(new RegExp(`${prefix}/?$`));
+
+  expect((await request.get(`${prefix}/logo.svg`)).status()).toBe(200);
+  expect((await request.get(`${prefix}/monaco/vs/loader.js`)).status()).toBe(200);
+  expect(failedAppRequests).toEqual([]);
+  expect(pageErrors).toEqual([]);
+
+  const logoutStatus = await page.evaluate(
+    async (path) => (await fetch(`${path}/api/auth/logout`, { method: "POST" })).status,
+    prefix,
+  );
+  expect(logoutStatus).toBe(200);
+  expect((await context.cookies()).some((value) => value.name === "auth-token")).toBe(false);
+  await page.goto(`${prefix}/`);
+  await expect(page).toHaveURL(`${baseURL}${prefix}/login`);
+
+  await page.locator('input[type="email"]:visible').fill("admin@libredb.org");
+  await page.locator('input[type="password"]:visible').fill("test-admin");
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect(page).toHaveURL(`${baseURL}${prefix}/admin/overview`);
+  await expect(page.getByTestId("admin-content-overview")).toBeVisible();
+  // Server redirects, Next links and native quick actions all stay inside the mount.
+  await expect(page.getByRole("link", { name: "Operations", exact: true })).toHaveAttribute(
+    "href",
+    `${prefix}/admin/operations`,
+  );
+  const maintenance = page.getByRole("link", { name: /^Maintenance VACUUM/ });
+  await expect(maintenance).toHaveAttribute("href", `${prefix}/admin/operations`);
+  await maintenance.click();
+  await expect(page).toHaveURL(`${baseURL}${prefix}/admin/operations`);
+  await page.goto(`${prefix}/admin?tab=audit`);
+  await expect(page).toHaveURL(`${baseURL}${prefix}/admin/audit`);
+  expect(failedAppRequests).toEqual([]);
+  expect(pageErrors).toEqual([]);
+  await page.getByRole("button", { name: "Logout", exact: true }).click();
+  await expect(page).toHaveURL(`${baseURL}${prefix}/login`);
+  expect((await context.cookies()).some((value) => value.name === "auth-token")).toBe(false);
+});

--- a/e2e/helpers/base-path-proxy.mjs
+++ b/e2e/helpers/base-path-proxy.mjs
@@ -1,0 +1,28 @@
+// A path-preserving reverse proxy: root-relative mistakes must fail with 404.
+import { createServer, request as upstreamRequest } from "node:http";
+
+const prefix = process.env.E2E_BASE_PATH || "/~/libredb";
+const upstreamPort = Number(process.env.E2E_BASE_PATH_APP_PORT || 3020);
+const port = Number(process.env.E2E_BASE_PATH_PROXY_PORT || 3021);
+createServer((request, response) => {
+  const pathname = new URL(request.url, "http://localhost").pathname;
+  if (pathname !== prefix && !pathname.startsWith(`${prefix}/`)) {
+    response.writeHead(404).end("Outside Studio's path prefix");
+    return;
+  }
+  const upstream = upstreamRequest(
+    {
+      hostname: "127.0.0.1",
+      port: upstreamPort,
+      path: request.url,
+      method: request.method,
+      headers: { ...request.headers, "x-forwarded-host": request.headers.host, "x-forwarded-proto": "http" },
+    },
+    (result) => {
+      response.writeHead(result.statusCode, result.headers);
+      result.pipe(response);
+    },
+  );
+  upstream.on("error", () => response.writeHead(502).end("Upstream unavailable"));
+  request.pipe(upstream);
+}).listen(port, "127.0.0.1");

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import packageJson from "./package.json";
+import { readBasePath } from "./src/lib/config/base-path";
 // Relative, not "@/": Next loads this file before any tsconfig path alias exists for it, and
 // src/lib/security/headers.ts is import-free by design precisely so a next.config can read it.
 import { securityHeaders, type SecurityHeaderOptions } from "./src/lib/security/headers";
@@ -197,9 +198,13 @@ function staticAssetHeaders(): { key: string; value: string }[] {
   return selectStaticAssetHeaders(securityHeaders(), securityHeaders(OPTION_PROBE));
 }
 
+const basePath = readBasePath(process.env.BASE_PATH);
+
 const nextConfig: NextConfig = {
+  basePath,
   env: {
     NEXT_PUBLIC_APP_VERSION: packageJson.version,
+    NEXT_PUBLIC_BASE_PATH: basePath,
   },
   // Use standalone output for Docker/Kubernetes deployments
   // For Vercel, this is automatically handled

--- a/operator/helm-charts/libredb-studio/Chart.yaml
+++ b/operator/helm-charts/libredb-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: libredb-studio
 description: Web-based SQL IDE for cloud-native teams supporting sixteen engines - PostgreSQL, MySQL, SQLite, DuckDB, Oracle, SQL Server, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra and libSQL
 type: application
-version: 0.1.60
+version: 0.1.61
 appVersion: "0.14.1"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/libredb/libredb-studio
@@ -113,13 +113,7 @@ annotations:
     - name: Source
       url: https://github.com/libredb/libredb-studio
   artifacthub.io/changes: |
-    - "The light theme stops painting dark-tuned accent colour. Warning, success and danger text, the query editor Explain control and the monitoring status rings were drawn in colours chosen against a dark ground and reused unchanged on the light one, where the worst of them sat at 1.46:1 against the surface behind it. Every accent is now a token measured on the ground it is drawn on, and the measurement runs as a test rather than being recorded in a comment"
-    - "Both themes now clear a 4.79:1 contrast floor for accent text, measured per token on every surface it can land on"
-    - "Engine identity colours are separated by measurement instead of by eye, so two engines listed next to each other no longer read as the same colour on either theme"
-    - "The Overview and Health panels answer on the MySQL-wire engines that refused a filter they never needed. SHOW STATUS is now read bare and the wanted rows picked out of the answer, so Apache Doris renders instead of failing outright, and a status variable an engine does not publish reads as absent rather than as a fabricated default"
-    - "A query plan is asked for in the grammar the server actually accepts, measured when the connection opens on both wire families. The Explain panel was sending one MySQL form and one PostgreSQL form to every relative of each, so it showed an empty no-plan state on Materialize, CockroachDB, TiDB, StarRocks, SingleStore, Apache Doris and Databend. All seven now render their own plan"
-    - "LOG_LEVEL is documented in .env.example, and an environment variable the app reads can no longer go undocumented without failing a test"
-    - "Track app release 0.14.1 (appVersion bump; default image tag follows)"
+    - "Prefix default health probes with config.basePath for images built to run under a subpath"
 dependencies:
   - name: postgresql
     version: "16.x.x"

--- a/operator/helm-charts/libredb-studio/README.md
+++ b/operator/helm-charts/libredb-studio/README.md
@@ -40,7 +40,7 @@ helm install libredb libredb/libredb-studio \
 
 ```bash
 helm install libredb oci://ghcr.io/libredb/charts/libredb-studio \
-  --version 0.1.60 \
+  --version 0.1.61 \
   --set secrets.jwtSecret=$(openssl rand -base64 32) \
   --set secrets.adminPassword=MyAdmin123
 ```
@@ -391,6 +391,7 @@ would otherwise lose reachability. One line in the pod log names the address it 
 `config.bindAddress` overrules the resolver when you would rather state it than leave it to the
 image:
 
+| `config.basePath` | Must match `BASE_PATH` baked into your custom image; prefixes default health probes | `""` |
 | `config.bindAddress` | Effect |
 |---|---|
 | `""` (default) | the container resolves it, preferring a verified dual-stack `::` |
@@ -639,3 +640,14 @@ fixed `runAsUser`/`runAsGroup`/`fsGroup` so the SCC can assign valid IDs;
 UIDs: every writable path is a volume mount. Set `force` to always adapt (for
 example when templating manifests offline for an OpenShift cluster) or
 `disabled` to keep the fixed IDs everywhere.
+
+## Deployment under a subpath
+
+Build a custom image with `docker build --build-arg BASE_PATH=/tools/libredb ...`, then set
+`config.basePath: /tools/libredb` and the matching image repository/tag. This prefixes the default
+startup, readiness and liveness probes. It does not change routes in an already-built image.
+Explicit custom probe paths are preserved. Set Ingress paths or HTTPRoute matches to the same
+prefix and preserve it when forwarding; do not strip or rewrite it.
+
+See [subpath deployment](https://github.com/libredb/libredb-studio/blob/main/docs/SUBPATH.md)
+for complete build, reverse-proxy and OIDC examples.

--- a/operator/helm-charts/libredb-studio/templates/_helpers.tpl
+++ b/operator/helm-charts/libredb-studio/templates/_helpers.tpl
@@ -386,3 +386,12 @@ Return the PostgreSQL URL when subchart is enabled
 {{- define "libredb-studio.postgresql.url" -}}
 {{- printf "postgresql://%s:$(POSTGRES_PASSWORD)@%s:5432/%s" .Values.postgresql.auth.username (include "libredb-studio.postgresql.fullname" .) .Values.postgresql.auth.database }}
 {{- end }}
+
+{{/* Prefix only the shipped health path; preserve explicit HTTP/exec/TCP probes. */}}
+{{- define "libredb-studio.probe" -}}
+{{- $probe := deepCopy .probe -}}
+{{- if and $probe.httpGet (eq ($probe.httpGet.path | default "") "/api/db/health") -}}
+{{- $_ := set $probe.httpGet "path" (printf "%s/api/db/health" .basePath) -}}
+{{- end -}}
+{{- toYaml $probe -}}
+{{- end -}}

--- a/operator/helm-charts/libredb-studio/templates/deployment.yaml
+++ b/operator/helm-charts/libredb-studio/templates/deployment.yaml
@@ -270,15 +270,15 @@ spec:
             {{- end }}
           {{- with .Values.startupProbe }}
           startupProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- include "libredb-studio.probe" (dict "probe" . "basePath" ($.Values.config.basePath | default "")) | nindent 12 }}
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- include "libredb-studio.probe" (dict "probe" . "basePath" ($.Values.config.basePath | default "")) | nindent 12 }}
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- include "libredb-studio.probe" (dict "probe" . "basePath" ($.Values.config.basePath | default "")) | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/operator/helm-charts/libredb-studio/values.schema.json
+++ b/operator/helm-charts/libredb-studio/values.schema.json
@@ -124,6 +124,12 @@
     "config": {
       "type": "object",
       "properties": {
+        "basePath": {
+          "type": "string",
+          "description": "Build-time BASE_PATH of the custom image; prefixes default probes, not a runtime app setting",
+          "pattern": "^$|^(/[A-Za-z0-9._~-]+)+$",
+          "not": { "pattern": "(^|/)\\.\\.?(/|$)" }
+        },
         "logLevel": {
           "type": "string",
           "enum": ["debug", "info", "warn", "error"],

--- a/operator/helm-charts/libredb-studio/values.yaml
+++ b/operator/helm-charts/libredb-studio/values.yaml
@@ -92,6 +92,9 @@ secrets:
 authProvider: "local"
 
 config:
+  # -- Must match BASE_PATH baked into a custom image. Prefixes default health probes;
+  # this value cannot change the routes in a prebuilt image. Empty means root.
+  basePath: ""
   # -- Log level
   logLevel: "info"
   # -- Address the container listens on, written to HOSTNAME. Empty is the

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     "channels:showcase": "node scripts/generate-channel-showcase.mjs",
     "channels:showcase:check": "node scripts/generate-channel-showcase.mjs --check",
     "readme:check": "node scripts/readme-check.mjs",
-    "security:check": "node scripts/security-check.mjs"
+    "security:check": "node scripts/security-check.mjs",
+    "test:e2e:base-path": "playwright test --config=playwright.base-path.config.ts"
   },
   "//dependencies": "@duckdb/node-api is the one exact pin in this list. Its versions carry a prerelease suffix (1.5.5-r.4 = DuckDB 1.5.5, driver revision 4), and npm and bun treat a caret over a prerelease tag inconsistently - `^1.5.5-r.4` would resolve forward across 1.x in a way neither tool agrees on - so the range is written out. The driver is four packages, not one: @duckdb/node-api -> @duckdb/node-bindings -> a per-platform, per-libc @duckdb/node-bindings-<platform>-<arch>[-musl] holding duckdb.node next to the ~70 MB libduckdb.so it links against. None of the four declares a scripts block or a binding.gyp, so no trustedDependencies entry is needed. Bumping it is a provider change, not a routine bump (see docs/providers/duckdb.md and the tri-sync rule in CLAUDE.md).",
   "dependencies": {

--- a/playwright.base-path.config.ts
+++ b/playwright.base-path.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const prefix = "/~/libredb";
+const appPort = Number(process.env.E2E_BASE_PATH_APP_PORT || 3020);
+const proxyPort = Number(process.env.E2E_BASE_PATH_PROXY_PORT || 3021);
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /base-path\.spec\.ts/,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  timeout: 60_000,
+  reporter: "list",
+  use: { ...devices["Desktop Chrome"], baseURL: `http://127.0.0.1:${proxyPort}`, trace: "retain-on-failure" },
+  webServer: [
+    {
+      // Run after the ordinary suite: this rebuilds .next with a different prefix.
+      command: "bun run build && bun start",
+      url: `http://127.0.0.1:${appPort}${prefix}/api/db/health`,
+      timeout: 180_000,
+      reuseExistingServer: false,
+      env: {
+        BASE_PATH: prefix,
+        PORT: String(appPort),
+        HOSTNAME: "127.0.0.1",
+        JWT_SECRET: "test-jwt-secret-for-e2e-tests-32ch",
+        ADMIN_EMAIL: "admin@libredb.org",
+        ADMIN_PASSWORD: "test-admin",
+        USER_EMAIL: "user@libredb.org",
+        USER_PASSWORD: "test-user",
+        STORAGE_SQLITE_PATH: "./data-e2e-base-path/libredb-storage.db",
+        NEXT_TELEMETRY_DISABLED: "1",
+      },
+    },
+    {
+      command: "node e2e/helpers/base-path-proxy.mjs",
+      url: `http://127.0.0.1:${proxyPort}${prefix}/api/db/health`,
+      timeout: 180_000,
+      reuseExistingServer: false,
+      env: {
+        E2E_BASE_PATH: prefix,
+        E2E_BASE_PATH_APP_PORT: String(appPort),
+        E2E_BASE_PATH_PROXY_PORT: String(proxyPort),
+      },
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
       // offline-editor.spec.ts runs under "chromium-offline-editor" below, against its own server.
-      testIgnore: /offline-editor\.spec\.ts/,
+      testIgnore: /(?:offline-editor|base-path)\.spec\.ts/,
     },
     {
       // Every other spec in this suite signs in as the same shared user@libredb.org account

--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withBasePath } from "@/lib/config/base-path";
 import { useEffect } from "react";
 
 export default function AdminError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
@@ -24,7 +25,7 @@ export default function AdminError({ error, reset }: { error: Error & { digest?:
           </button>
           <button
             onClick={() => {
-              window.location.href = "/";
+              window.location.href = withBasePath("/");
             }}
             className="px-5 py-2.5 border border-edge hover:border-edge-hover text-fg-secondary rounded-lg text-sm font-medium transition-colors"
           >

--- a/src/app/admin/overview/page.tsx
+++ b/src/app/admin/overview/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useEffect, useState } from "react";
 import { OverviewTab, type AdminUser } from "@/components/admin/tabs/OverviewTab";
 
@@ -7,7 +8,7 @@ export default function AdminOverviewPage() {
   const [user, setUser] = useState<AdminUser | null>(null);
 
   useEffect(() => {
-    fetch("/api/auth/me")
+    appFetch("/api/auth/me")
       .then((res) => res.json())
       .then((data) => {
         if (data.authenticated && data.user) {

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from "@/lib/config/base-path";
 import { getSession, logout } from "@/lib/auth";
 import { buildLogoutUrl, getPublicOrigin } from "@/lib/oidc";
 import { NextRequest, NextResponse } from "next/server";
@@ -42,7 +43,7 @@ export async function POST(request: NextRequest) {
     const authProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER || "local";
     if (authProvider === "oidc") {
       const origin = getPublicOrigin(request);
-      const returnTo = `${origin}/login`;
+      const returnTo = `${origin}${withBasePath("/login")}`;
       const oidcLogoutUrl = await buildLogoutUrl(returnTo);
 
       if (oidcLogoutUrl) {

--- a/src/app/api/auth/oidc/callback/route.ts
+++ b/src/app/api/auth/oidc/callback/route.ts
@@ -1,3 +1,4 @@
+import { getBasePath, withBasePath } from "@/lib/config/base-path";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { login } from "@/lib/auth";
@@ -45,7 +46,7 @@ export async function GET(request: Request) {
 
     if (!stateCookie) {
       auditFailure("oidc_state_missing", ip);
-      return NextResponse.redirect(`${origin}/login?error=oidc_state_missing`);
+      return NextResponse.redirect(`${origin}${withBasePath("/login")}?error=oidc_state_missing`);
     }
 
     // Decrypt and validate state
@@ -57,9 +58,9 @@ export async function GET(request: Request) {
         route: ROUTE,
         error: decryptError instanceof Error ? decryptError.message : "Unknown",
       });
-      cookieStore.delete("oidc-state");
+      cookieStore.delete({ name: "oidc-state", path: getBasePath() || "/" });
       auditFailure("oidc_state_invalid", ip);
-      return NextResponse.redirect(`${origin}/login?error=oidc_state_invalid`);
+      return NextResponse.redirect(`${origin}${withBasePath("/login")}?error=oidc_state_invalid`);
     }
 
     // Exchange code for tokens
@@ -75,7 +76,7 @@ export async function GET(request: Request) {
     if (!claims) {
       logger.warn("OIDC callback: no claims returned from token exchange", { route: "oidc/callback" });
       auditFailure("oidc_no_claims", ip);
-      return NextResponse.redirect(`${origin}/login?error=oidc_no_claims`);
+      return NextResponse.redirect(`${origin}${withBasePath("/login")}?error=oidc_no_claims`);
     }
 
     // Map role from claims
@@ -86,7 +87,7 @@ export async function GET(request: Request) {
     await login(role, username);
 
     // Clean up state cookie
-    cookieStore.delete("oidc-state");
+    cookieStore.delete({ name: "oidc-state", path: getBasePath() || "/" });
 
     // Isolated in its own try/catch, separate from login() above: a real session already exists by
     // this point, so a failure to record it must never turn a successful login into a recorded (or
@@ -105,7 +106,7 @@ export async function GET(request: Request) {
     }
 
     // Redirect based on role
-    return NextResponse.redirect(`${origin}${role === "admin" ? "/admin" : "/"}`);
+    return NextResponse.redirect(`${origin}${withBasePath(role === "admin" ? "/admin" : "/")}`);
   } catch (error) {
     logger.error("OIDC callback error", error, { route: ROUTE });
     // Typed, not message substring matching: `error instanceof Error && error.message.includes(
@@ -118,6 +119,6 @@ export async function GET(request: Request) {
     // configured but the server's auth secret isn't" with one type check.
     const errorCode = error instanceof AuthConfigError ? "oidc_config" : "oidc_failed";
     auditFailure(errorCode, ip);
-    return NextResponse.redirect(`${origin}/login?error=${errorCode}`);
+    return NextResponse.redirect(`${origin}${withBasePath("/login")}?error=${errorCode}`);
   }
 }

--- a/src/app/api/auth/oidc/login/route.ts
+++ b/src/app/api/auth/oidc/login/route.ts
@@ -1,3 +1,4 @@
+import { getBasePath, withBasePath } from "@/lib/config/base-path";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getOIDCConfig, discoverProvider, generateAuthUrl, encryptState, getPublicOrigin } from "@/lib/oidc";
@@ -10,7 +11,7 @@ export async function GET(request: Request) {
     const config = await discoverProvider(oidcConfig);
 
     const origin = getPublicOrigin(request);
-    const redirectUri = `${origin}/api/auth/oidc/callback`;
+    const redirectUri = `${origin}${withBasePath("/api/auth/oidc/callback")}`;
 
     const { url, state } = await generateAuthUrl(config, redirectUri, oidcConfig.scope);
 
@@ -24,13 +25,13 @@ export async function GET(request: Request) {
       secure: await shouldMarkCookieSecure(),
       sameSite: "lax",
       maxAge: 300, // 5 minutes
-      path: "/",
+      path: getBasePath() || "/",
     });
 
     return NextResponse.redirect(url.toString());
   } catch (error) {
     logger.error("OIDC login error", error, { route: "GET /api/auth/oidc/login" });
     const origin = getPublicOrigin(request);
-    return NextResponse.redirect(`${origin}/login?error=oidc_config`);
+    return NextResponse.redirect(`${origin}${withBasePath("/login")}?error=oidc_config`);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from "@/lib/config/base-path";
 import { GeistMono } from "geist/font/mono";
 // Self-hosted Geist (the `geist` package wraps next/font/local around the woff2
 // files it ships). next/font/google would fetch fonts.googleapis.com at BUILD
@@ -16,11 +17,11 @@ export const metadata: Metadata = {
   description: "Manage PostgreSQL, MySQL, MongoDB, and Redis in one web-based interface.",
   icons: {
     icon: [
-      { url: "/favicon.ico?v=2", sizes: "any" },
-      { url: "/logo.svg?v=2", type: "image/svg+xml" },
+      { url: withBasePath("/favicon.ico?v=2"), sizes: "any" },
+      { url: withBasePath("/logo.svg?v=2"), type: "image/svg+xml" },
     ],
-    shortcut: "/favicon.ico?v=2",
-    apple: "/favicon-32x32.png?v=2",
+    shortcut: withBasePath("/favicon.ico?v=2"),
+    apple: withBasePath("/favicon-32x32.png?v=2"),
   },
 };
 

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch, withBasePath } from "@/lib/config/base-path";
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -40,7 +41,7 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
 
     setIsLoading(true);
     try {
-      const response = await fetch("/api/auth/login", {
+      const response = await appFetch("/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
@@ -237,7 +238,7 @@ function LoginFormInner({ authProvider }: { authProvider: string }) {
                     className="w-full h-11 text-base font-medium shadow-lg shadow-primary/20 active:scale-[0.98] transition-all gap-2"
                     onClick={() => {
                       setIsLoading(true);
-                      window.location.href = "/api/auth/oidc/login";
+                      window.location.href = withBasePath("/api/auth/oidc/login");
                     }}
                     disabled={isLoading}
                   >

--- a/src/components/DataProfiler.tsx
+++ b/src/components/DataProfiler.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useEffect, useMemo } from "react";
 import { LoaderCircle, ChartColumn, X, Hash, CircleAlert, Sparkles, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -81,7 +82,7 @@ export function DataProfiler({
         setAiSummary(result);
       } else {
         // Default: existing fetch behavior
-        const response = await fetch("/api/ai/describe-schema", {
+        const response = await appFetch("/api/ai/describe-schema", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -128,7 +129,7 @@ export function DataProfiler({
       } else {
         // Default: existing fetch behavior
         const columns = tableSchema.columns?.map((c) => c.name) || [];
-        const response = await fetch("/api/db/profile", {
+        const response = await appFetch("/api/db/profile", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           // The seed id for a managed connection: the browser's copy has had its

--- a/src/components/DatabaseDocs.tsx
+++ b/src/components/DatabaseDocs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import React, { useState } from "react";
 import { FileText, LoaderCircle, Search, Sparkles, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -59,7 +60,7 @@ export function DatabaseDocs({ schema, schemaContext, databaseType }: DatabaseDo
         }
       }
 
-      const response = await fetch("/api/ai/describe-schema", {
+      const response = await appFetch("/api/ai/describe-schema", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/components/QuerySafetyDialog.tsx
+++ b/src/components/QuerySafetyDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import React, { useState, useEffect, useMemo } from "react";
 import { ShieldAlert, ShieldCheck, TriangleAlert, LoaderCircle, Play, X } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -157,7 +158,7 @@ export function QuerySafetyDialog({
         setAnalysis(result);
       } else {
         // Default: existing fetch behavior
-        const response = await fetch("/api/ai/query-safety", {
+        const response = await appFetch("/api/ai/query-safety", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ query, schemaContext: filteredSchema, databaseType }),

--- a/src/components/SchemaDiff.tsx
+++ b/src/components/SchemaDiff.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import React, { useState, useMemo, useCallback } from "react";
 import {
   GitCompare,
@@ -102,7 +103,7 @@ export function SchemaDiff({ schema, connection }: SchemaDiffProps) {
 
       setFetchingRemote(true);
       try {
-        const res = await fetch("/api/db/schema-snapshot", {
+        const res = await appFetch("/api/db/schema-snapshot", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import React, { useState, useEffect, useRef } from "react";
 import { Sidebar, ConnectionsList } from "@/components/sidebar";
 import { MobileNav } from "@/components/MobileNav";
@@ -397,7 +398,7 @@ export default function Studio() {
 
   const handleDeleteConnection = (id: string) => {
     // Clean up server-side provider cache and close connections/tunnels
-    fetch("/api/db/disconnect", {
+    appFetch("/api/db/disconnect", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ connectionId: id }),

--- a/src/components/VisualExplain.tsx
+++ b/src/components/VisualExplain.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import React, { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import {
   Zap,
@@ -489,7 +490,7 @@ function AIExplainTab({
     abortControllerRef.current = abortController;
 
     try {
-      const response = await fetch("/api/ai/explain", {
+      const response = await appFetch("/api/ai/explain", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
@@ -27,7 +28,7 @@ export default function AdminDashboard({ children }: AdminDashboardProps) {
   const activeSection = adminSectionFromPathname(pathname);
 
   const handleLogout = async () => {
-    await fetch("/api/auth/logout", { method: "POST" });
+    await appFetch("/api/auth/logout", { method: "POST" });
     toast.success("Logged out successfully");
     router.push("/login");
     router.refresh();

--- a/src/components/admin/tabs/AuditTab.tsx
+++ b/src/components/admin/tabs/AuditTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useEffect, useMemo, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -78,7 +79,7 @@ async function loadAuditEvents(type: string): Promise<AuditEvent[]> {
   try {
     const params = new URLSearchParams({ limit: "200" });
     if (type !== "all") params.set("type", type);
-    const res = await fetch(`/api/admin/audit?${params}`);
+    const res = await appFetch(`/api/admin/audit?${params}`);
     const data = await res.json();
     return data.events || [];
   } catch {

--- a/src/components/admin/tabs/OverviewTab.tsx
+++ b/src/components/admin/tabs/OverviewTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch, withBasePath } from "@/lib/config/base-path";
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -205,7 +206,7 @@ export function OverviewTab({ user }: OverviewTabProps) {
 
   // Fetch audit events for activity feed
   useEffect(() => {
-    fetch("/api/admin/audit?limit=10")
+    appFetch("/api/admin/audit?limit=10")
       .then((r) => r.json())
       .then((d) => setAuditEvents(d.events || []))
       .catch(() => {});
@@ -232,7 +233,7 @@ export function OverviewTab({ user }: OverviewTabProps) {
     async function load() {
       setFleetLoading(true);
       try {
-        const res = await fetch("/api/admin/fleet-health", {
+        const res = await appFetch("/api/admin/fleet-health", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ connections: targets }),
@@ -710,7 +711,7 @@ function FleetHealthSection({
             return (
               <motion.a
                 key={item.connectionId}
-                href="/admin/monitoring"
+                href={withBasePath("/admin/monitoring")}
                 variants={itemVariants}
                 whileHover={{ scale: 1.02, y: -2 }}
                 className={`group relative rounded-xl border-2 ${colors.border} bg-panel p-4 transition-all duration-200 hover:bg-fill ${colors.glow} cursor-pointer block overflow-hidden`}
@@ -1078,7 +1079,7 @@ function QuickActionsSection() {
         {actions.map((action) => (
           <motion.a
             key={action.label}
-            href={action.href}
+            href={withBasePath(action.href)}
             whileHover={{ scale: 1.02, y: -4 }}
             className={`group relative rounded-xl border border-hairline ${action.borderColor} bg-panel p-5 transition-all duration-200 cursor-pointer block overflow-hidden hover:shadow-[0_0_30px_rgba(59,130,246,0.06)]`}
           >

--- a/src/components/agent/AgentRail.tsx
+++ b/src/components/agent/AgentRail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Bot, ChevronDown, ChevronRight, LoaderCircle, PencilLine, Play, Square, TriangleAlert, X } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
@@ -1277,7 +1278,7 @@ export function AgentRail({
    */
   const classifyObjective = async (text: string): Promise<AgentWorkflowClassification> => {
     try {
-      const res = await fetch("/api/agent/classify", {
+      const res = await appFetch("/api/agent/classify", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ objective: text }),

--- a/src/components/agent/use-agent-artifact.ts
+++ b/src/components/agent/use-agent-artifact.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useCallback, useRef, useState } from "react";
 import type { AgentChartSpec } from "@/lib/agent/types";
 import type { ExplainFormat } from "@/lib/db/types";
@@ -69,7 +70,7 @@ export function useAgentArtifact(options: AgentArtifactOptions): AgentArtifactHo
     const ask = latestAsk.current + 1;
     latestAsk.current = ask;
     try {
-      const res = await fetch(
+      const res = await appFetch(
         `/api/agent/runs/${encodeURIComponent(runId)}/artifacts/${encodeURIComponent(correlationId)}`,
       );
       const body = (await res.json().catch(() => ({}))) as { error?: unknown };

--- a/src/components/agent/use-agent-run.ts
+++ b/src/components/agent/use-agent-run.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { isAgentModelCapability } from "@/lib/agent/capability-labels";
 // Type-only, so nothing of the probe — or of the AI SDK it runs — reaches this bundle.
@@ -443,7 +444,7 @@ export function useAgentRun(): AgentRunFollower {
   );
 
   const follow = useCallback(async (id: string, signal: AbortSignal): Promise<void> => {
-    const res = await fetch(`/api/agent/runs/${encodeURIComponent(id)}/stream`, { signal });
+    const res = await appFetch(`/api/agent/runs/${encodeURIComponent(id)}/stream`, { signal });
     if (!res.ok) {
       const body = (await res.json().catch(() => ({}))) as StartResponse;
       throw new Error(
@@ -499,7 +500,7 @@ export function useAgentRun(): AgentRunFollower {
       let openedRunId: string;
       let openedThread: AgentThreadContext | null = null;
       try {
-        const res = await fetch("/api/agent/runs", {
+        const res = await appFetch("/api/agent/runs", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(input),
@@ -578,7 +579,7 @@ export function useAgentRun(): AgentRunFollower {
       // controller: aborting is how this component stops following a run, and a
       // stop request is the opposite — the run is expected to keep reporting until
       // its loop reaches a checkpoint.
-      const res = await fetch(`/api/agent/runs/${encodeURIComponent(runId)}`, {
+      const res = await appFetch(`/api/agent/runs/${encodeURIComponent(runId)}`, {
         method: "DELETE",
         signal: abortRef.current?.signal,
       });

--- a/src/components/monitoring/tabs/PoolTab.tsx
+++ b/src/components/monitoring/tabs/PoolTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import React, { useState, useEffect, useCallback } from "react";
 import { Server, Activity, Clock, LoaderCircle, RefreshCw } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -39,7 +40,7 @@ export function PoolTab({ connection }: PoolTabProps) {
     if (connection === null || requestKey === null) return;
     let ignore = false;
 
-    fetch("/api/db/pool-stats", {
+    appFetch("/api/db/pool-stats", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       // The seed id, not the object: a managed connection arrives here with its

--- a/src/hooks/use-agent-capability.ts
+++ b/src/hooks/use-agent-capability.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useEffect, useState } from "react";
 import { logger } from "@/lib/logger";
 
@@ -33,7 +34,7 @@ export function useAgentCapability(): boolean {
 
     async function probe(): Promise<void> {
       try {
-        const res = await fetch("/api/agent/config");
+        const res = await appFetch("/api/agent/config");
         if (cancelled) return;
         if (!res.ok) return;
         const body = (await res.json()) as { enabled?: unknown };

--- a/src/hooks/use-all-connections.ts
+++ b/src/hooks/use-all-connections.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useEffect } from "react";
 import type { DatabaseConnection } from "@/lib/types";
 import { storage } from "@/lib/storage";
@@ -23,7 +24,7 @@ export function useAllConnections() {
       const dismissed = new Set(storage.getDismissedSeeds());
 
       try {
-        const res = await fetch("/api/connections/managed");
+        const res = await appFetch("/api/connections/managed");
         if (res.ok) {
           const { connections: managedConns } = await res.json();
           if (managedConns?.length > 0 && !cancelled) {

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/hooks/use-toast";
@@ -17,7 +18,7 @@ export function useAuth() {
   useEffect(() => {
     const fetchUser = async () => {
       try {
-        const res = await fetch("/api/auth/me");
+        const res = await appFetch("/api/auth/me");
         if (res.ok) {
           const data = await res.json();
           setUser(data.user);
@@ -36,7 +37,7 @@ export function useAuth() {
 
   const handleLogout = useCallback(async () => {
     try {
-      const res = await fetch("/api/auth/logout", { method: "POST" });
+      const res = await appFetch("/api/auth/logout", { method: "POST" });
       const data = await res.json();
       toast({ title: "Logged out", description: "You have been successfully logged out." });
 

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useCallback } from "react";
 import {
   DatabaseConnection,
@@ -403,7 +404,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       // Platform adapter: use callback instead of fetch
       if (onTestConnection) return await onTestConnection(conn);
 
-      const response = await fetch("/api/db/test-connection", {
+      const response = await appFetch("/api/db/test-connection", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(conn),

--- a/src/hooks/use-connection-manager.ts
+++ b/src/hooks/use-connection-manager.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import type { DatabaseConnection, TableSchema, TableRelations } from "@/lib/types";
 import { useToast } from "@/hooks/use-toast";
@@ -62,7 +63,7 @@ export function useConnectionManager(storageReady = false) {
 
       // Phase 1 — structural list (blocks; this is what the explorer needs)
       try {
-        const response = await fetch(...init("/api/db/schema/list"));
+        const response = await appFetch(...init("/api/db/schema/list"));
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}));
           throw new Error(errorData.error || "Failed to fetch schema");
@@ -84,7 +85,7 @@ export function useConnectionManager(storageReady = false) {
 
       // Phase 2 — relationships + indexes (best-effort; never breaks the list)
       try {
-        const relRes = await fetch(...init("/api/db/schema/relations"));
+        const relRes = await appFetch(...init("/api/db/schema/relations"));
         if (!relRes.ok) {
           const errorData = await relRes.json().catch(() => ({}));
           throw new Error(errorData.error || "Failed to fetch schema relations");
@@ -167,7 +168,7 @@ export function useConnectionManager(storageReady = false) {
       pendingSeeds: string[];
       failed: boolean;
     }> => {
-      const managedRes = await fetch("/api/connections/managed");
+      const managedRes = await appFetch("/api/connections/managed");
       // A non-OK response is a transient failure, NOT "nothing pending" — the
       // poll below must keep retrying (bounded by its attempt budget) instead
       // of treating it as an authoritative empty pendingSeeds.
@@ -297,7 +298,7 @@ export function useConnectionManager(storageReady = false) {
     if (!activeConnection) return;
     const checkHealth = async () => {
       try {
-        const res = await fetch("/api/db/health", {
+        const res = await appFetch("/api/db/health", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(buildConnectionPayload(activeConnection)),

--- a/src/hooks/use-monitoring-data.ts
+++ b/src/hooks/use-monitoring-data.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { DatabaseConnection } from "@/lib/types";
 import { buildConnectionPayload } from "./use-connection-payload";
@@ -113,7 +114,7 @@ export function useMonitoringData(
     setError(null);
 
     try {
-      const res = await fetch("/api/db/monitoring", {
+      const res = await appFetch("/api/db/monitoring", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -217,7 +218,7 @@ export function useMonitoringData(
       if (!currentConnection) return false;
 
       try {
-        const res = await fetch("/api/db/maintenance", {
+        const res = await appFetch("/api/db/maintenance", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -254,7 +255,7 @@ export function useMonitoringData(
       if (!currentConnection) return false;
 
       try {
-        const res = await fetch("/api/db/maintenance", {
+        const res = await appFetch("/api/db/maintenance", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({

--- a/src/hooks/use-provider-metadata.ts
+++ b/src/hooks/use-provider-metadata.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useEffect, useRef } from "react";
 import type { DatabaseConnection } from "@/lib/types";
 import type { ProviderCapabilities, ProviderLabels } from "@/lib/db/types";
@@ -52,7 +53,7 @@ export function useProviderMetadata(connection: DatabaseConnection | null): {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10000);
 
-    fetch("/api/db/provider-meta", {
+    appFetch("/api/db/provider-meta", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       // `buildConnectionPayload`, not the connection object: a managed (seed)

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useEffect, useCallback, useRef, type Dispatch, type SetStateAction, type RefObject } from "react";
 import type { DatabaseConnection, QueryTab } from "@/lib/types";
 import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
@@ -320,7 +321,7 @@ export function useQueryExecution({
 
       try {
         if (isPlaygroundRun) {
-          const beginRes = await fetch("/api/db/transaction", {
+          const beginRes = await appFetch("/api/db/transaction", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ ...buildConnectionPayload(activeConnection), action: "begin" }),
@@ -368,7 +369,7 @@ export function useQueryExecution({
           : useMultiQuery
             ? "/api/db/multi-query"
             : "/api/db/query";
-        const mainQueryPromise = fetch(queryEndpoint, {
+        const mainQueryPromise = appFetch(queryEndpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -405,7 +406,7 @@ export function useQueryExecution({
           // the statement, and every strategy answers it the same way. The
           // statement the engine sees is built on the server (#574).
           if (explainStrategy.buildSql(queryToExecute, "estimate") !== null) {
-            explainPromise = fetch("/api/db/query", {
+            explainPromise = appFetch("/api/db/query", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
@@ -577,7 +578,7 @@ export function useQueryExecution({
         // Playground mode: auto-rollback after getting results
         if (isPlaygroundRun) {
           try {
-            await fetch("/api/db/transaction", {
+            await appFetch("/api/db/transaction", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ ...buildConnectionPayload(activeConnection), action: "rollback" }),
@@ -612,7 +613,7 @@ export function useQueryExecution({
         // Playground mode: rollback on error too
         if (isPlaygroundRun) {
           try {
-            await fetch("/api/db/transaction", {
+            await appFetch("/api/db/transaction", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ ...buildConnectionPayload(activeConnection), action: "rollback" }),
@@ -707,7 +708,7 @@ export function useQueryExecution({
 
       const startTime = Date.now();
       try {
-        const response = await fetch(`/api/agent/runs/${encodeURIComponent(runId)}/handover`, { method: "POST" });
+        const response = await appFetch(`/api/agent/runs/${encodeURIComponent(runId)}/handover`, { method: "POST" });
         const payload = await response.json();
         if (!response.ok) {
           throw new Error(payload.error || "The hand-over could not be run");
@@ -779,7 +780,7 @@ export function useQueryExecution({
       // it does not stop the statement the engine is still executing.
       if (activeConnection) {
         try {
-          await fetch("/api/db/cancel", {
+          await appFetch("/api/db/cancel", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({

--- a/src/hooks/use-storage-sync.ts
+++ b/src/hooks/use-storage-sync.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
   storage,
@@ -78,7 +79,7 @@ export function useStorageSync(): StorageSyncState {
     /** Resolves to whether the collection actually reached the server. */
     const pushToServer = async (collection: string, data: unknown): Promise<boolean> => {
       try {
-        const res = await fetch(`/api/storage/${collection}`, {
+        const res = await appFetch(`/api/storage/${collection}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ data }),
@@ -159,7 +160,7 @@ export function useStorageSync(): StorageSyncState {
   const pullFromServer = useCallback(async () => {
     setIsSyncing(true);
     try {
-      const res = await fetch("/api/storage");
+      const res = await appFetch("/api/storage");
       if (!res.ok) return;
       const data = (await res.json()) as Partial<StorageData>;
 
@@ -220,7 +221,7 @@ export function useStorageSync(): StorageSyncState {
         return;
       }
 
-      const res = await fetch("/api/storage/migrate", {
+      const res = await appFetch("/api/storage/migrate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(allData),
@@ -255,7 +256,7 @@ export function useStorageSync(): StorageSyncState {
 
     async function init() {
       try {
-        const res = await fetch("/api/storage/config");
+        const res = await appFetch("/api/storage/config");
         if (!res.ok || cancelled) return;
         const config = (await res.json()) as StorageConfigResponse;
 

--- a/src/hooks/use-transaction-control.ts
+++ b/src/hooks/use-transaction-control.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { appFetch } from "@/lib/config/base-path";
 import { useState, useCallback } from "react";
 import type { DatabaseConnection } from "@/lib/types";
 import { useToast } from "@/hooks/use-toast";
@@ -19,7 +20,7 @@ export function useTransactionControl({ activeConnection }: UseTransactionContro
       if (!activeConnection) return;
 
       try {
-        const res = await fetch("/api/db/transaction", {
+        const res = await appFetch("/api/db/transaction", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import { getBasePath } from "@/lib/config/base-path";
 import { SignJWT, jwtVerify } from "jose";
 import { cookies, headers } from "next/headers";
 import { logger } from "@/lib/logger";
@@ -157,11 +158,11 @@ export async function login(role: Role, username?: string) {
     // - are covered by the Origin check in src/proxy.ts (src/lib/api/origin-check.ts).
     sameSite: "lax",
     maxAge: 60 * 60 * 24, // 1 day
-    path: "/",
+    path: getBasePath() || "/",
   });
 }
 
 export async function logout() {
   const cookieStore = await cookies();
-  cookieStore.delete("auth-token");
+  cookieStore.delete({ name: "auth-token", path: getBasePath() || "/" });
 }

--- a/src/lib/config/base-path.ts
+++ b/src/lib/config/base-path.ts
@@ -1,0 +1,26 @@
+/** Validate the build-time deployment prefix before Next.js bakes it into routes. */
+export function readBasePath(value = ""): string {
+  if (value === "" || value === "/") return "";
+  if (!/^(\/[A-Za-z0-9._~-]+)+$/.test(value) || value.split("/").some((part) => part === "." || part === "..")) {
+    throw new Error(
+      "BASE_PATH must be empty or an absolute path such as /tools/libredb, without a trailing slash, dot segments, encoding, query or fragment.",
+    );
+  }
+  return value;
+}
+
+// next.config.ts supplies this value at build time. Reading BASE_PATH here would
+// allow runtime configuration to disagree with the already-built client router.
+export function getBasePath(): string {
+  return process.env.NEXT_PUBLIC_BASE_PATH || "";
+}
+
+/** For fetch, native browser navigation and public assets; Next's router/Link prefix themselves. */
+export function withBasePath(path: string): string {
+  return path.startsWith("/") && !path.startsWith("//") ? `${getBasePath()}${path}` : path;
+}
+
+/** Preserve fetch's arguments and cancellation while applying the application's prefix. */
+export function appFetch(path: string, ...init: [RequestInit?]): Promise<Response> {
+  return fetch(withBasePath(path), ...init);
+}

--- a/src/lib/editor/monaco-loader.ts
+++ b/src/lib/editor/monaco-loader.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from "@/lib/config/base-path";
 import { loader } from "@monaco-editor/react";
 
 /**
@@ -21,7 +22,7 @@ interface MonacoLoaderLike {
  */
 export function resolveMonacoVsPath(override: string | undefined): string {
   const trimmed = override?.trim();
-  if (!trimmed) return DEFAULT_MONACO_VS_PATH;
+  if (!trimmed) return withBasePath(DEFAULT_MONACO_VS_PATH);
   return trimmed.replace(/\/+$/, "");
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from "@/lib/config/base-path";
 import { NextRequest, NextResponse } from "next/server";
 import { jwtVerify } from "jose";
 import { AGENT_DRIVE_HEADER, AGENT_DRIVE_PATH, verifyAgentDriveToken } from "@/lib/agent/drive-token";
@@ -31,6 +32,8 @@ const ORIGIN_MISMATCH_BODY = {
 };
 
 export async function proxy(request: NextRequest) {
+  // NextURL removes the configured basePath before exposing pathname; Next also
+  // prefixes config.matcher at build time. Keep authorization checks app-relative.
   const { pathname } = request.nextUrl;
   const isStaticAsset = /\.[a-z0-9]+$/i.test(pathname);
 
@@ -84,7 +87,9 @@ export async function proxy(request: NextRequest) {
         const { payload } = await jwtVerify(token, jwtSecret());
         const role = payload.role as string;
         // Redirect authenticated users based on their role
-        return withSecurityHeaders(NextResponse.redirect(new URL(role === "admin" ? "/admin" : "/", request.url)));
+        return withSecurityHeaders(
+          NextResponse.redirect(new URL(withBasePath(role === "admin" ? "/admin" : "/"), request.url)),
+        );
       } catch {
         // Invalid token, allow access to login page
         logger.debug("Invalid token on login page, allowing access", { route: "proxy" });
@@ -122,7 +127,7 @@ export async function proxy(request: NextRequest) {
   }
 
   if (!token) {
-    return withSecurityHeaders(NextResponse.redirect(new URL("/login", request.url)));
+    return withSecurityHeaders(NextResponse.redirect(new URL(withBasePath("/login"), request.url)));
   }
 
   try {
@@ -156,13 +161,13 @@ export async function proxy(request: NextRequest) {
           logger.error("Failed to record insufficient_role audit event", auditError, { route: "proxy" });
         }
       }
-      return withSecurityHeaders(NextResponse.redirect(new URL("/", request.url)));
+      return withSecurityHeaders(NextResponse.redirect(new URL(withBasePath("/"), request.url)));
     }
 
     return withSecurityHeaders(NextResponse.next());
   } catch {
     logger.warn("JWT verification failed, redirecting to login", { route: "proxy" });
-    return withSecurityHeaders(NextResponse.redirect(new URL("/login", request.url)));
+    return withSecurityHeaders(NextResponse.redirect(new URL(withBasePath("/login"), request.url)));
   }
 }
 
@@ -200,5 +205,8 @@ export const config = {
      * carry the CSP or HSTS.
      */
     "/((?!api/storage/config|_next/static|_next/image|.*\\..*).*)",
+    // The catch-all requires a slash after basePath. Next compiles this explicit
+    // root matcher to also cover the bare mount path (for example /tools/libredb).
+    "/",
   ],
 };

--- a/tests/api/auth/logout.test.ts
+++ b/tests/api/auth/logout.test.ts
@@ -1,3 +1,4 @@
+import { withBasePathEnv } from "../../helpers/base-path";
 import { describe, test, expect, mock, spyOn, beforeEach, afterEach } from "bun:test";
 import { parseResponseJSON } from "../../helpers/mock-next";
 
@@ -151,5 +152,19 @@ describe("POST /api/auth/logout (oidc)", () => {
     await POST(makeRequest() as never);
 
     expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+  test("OIDC logout returns to login under the build's prefix", async () => {
+    const previous = process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = "oidc";
+    try {
+      await withBasePathEnv("/tools/libredb", async () => {
+        mockBuildLogoutUrl.mockClear();
+        await POST(new Request("https://studio.example/tools/libredb/api/auth/logout", { method: "POST" }) as never);
+        expect(mockBuildLogoutUrl).toHaveBeenCalledWith("https://studio.example/tools/libredb/login");
+      });
+    } finally {
+      if (previous === undefined) delete process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+      else process.env.NEXT_PUBLIC_AUTH_PROVIDER = previous;
+    }
   });
 });

--- a/tests/api/auth/oidc-callback.test.ts
+++ b/tests/api/auth/oidc-callback.test.ts
@@ -1,3 +1,4 @@
+import { withBasePathEnv } from "../../helpers/base-path";
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 
 // ─── Mock dependencies ─────────────────────────────────────────────────────
@@ -25,7 +26,8 @@ const defaultClaims = {
   preferred_username: "testuser",
 };
 
-const mockExchangeCode = mock(async () => ({ ...defaultClaims }) as Record<string, unknown> | null);
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mockExchangeCode = mock(async (..._args: unknown[]) => ({ ...defaultClaims }) as Record<string, unknown> | null);
 
 const mockMapOIDCRole = mock(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -125,7 +127,7 @@ describe("GET /api/auth/oidc/callback", () => {
     const req = new Request("http://localhost:3000/api/auth/oidc/callback?code=auth-code&state=test-state");
     await GET(req);
 
-    expect(mockCookieStore.delete).toHaveBeenCalledWith("oidc-state");
+    expect(mockCookieStore.delete).toHaveBeenCalledWith({ name: "oidc-state", path: "/" });
   });
 
   test("redirects to /login?error=oidc_state_missing when no cookie", async () => {
@@ -148,7 +150,7 @@ describe("GET /api/auth/oidc/callback", () => {
 
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("error=oidc_state_invalid");
-    expect(mockCookieStore.delete).toHaveBeenCalledWith("oidc-state");
+    expect(mockCookieStore.delete).toHaveBeenCalledWith({ name: "oidc-state", path: "/" });
   });
 
   test("redirects to /login?error=oidc_no_claims when no claims", async () => {
@@ -193,5 +195,32 @@ describe("GET /api/auth/oidc/callback", () => {
       "roles",
       ["admin"],
     );
+  });
+  test("OIDC callback preserves the mount through exchange, redirect and state cleanup", async () => {
+    await withBasePathEnv("/tools/libredb", async () => {
+      mockCookieGet.mockReturnValue({ value: "encrypted-state-cookie" });
+      mockDecryptState.mockResolvedValue({ code_verifier: "v", state: "s", nonce: "n" });
+      mockGetOIDCConfig.mockImplementation(() => ({
+        issuer: "https://example.auth0.com",
+        clientId: "id",
+        clientSecret: "secret",
+        scope: "openid",
+        roleClaim: "roles",
+        adminRoles: ["admin"],
+      }));
+      mockExchangeCode.mockResolvedValue({ ...defaultClaims });
+      mockExchangeCode.mockClear();
+      mockMapOIDCRole.mockReturnValue("user");
+      mockCookieStore.delete.mockClear();
+      const url = "https://studio.example/tools/libredb/api/auth/oidc/callback?code=c&state=s";
+      const response = await GET(new Request(url));
+      expect(mockExchangeCode.mock.calls[0]?.[1]?.toString()).toBe(url);
+      expect(response.headers.get("location")).toBe("https://studio.example/tools/libredb/");
+      expect(mockCookieStore.delete).toHaveBeenCalledWith({ name: "oidc-state", path: "/tools/libredb" });
+      mockCookieGet.mockReturnValue(undefined);
+      expect((await GET(new Request(url))).headers.get("location")).toBe(
+        "https://studio.example/tools/libredb/login?error=oidc_state_missing",
+      );
+    });
   });
 });

--- a/tests/api/auth/oidc-login.test.ts
+++ b/tests/api/auth/oidc-login.test.ts
@@ -1,3 +1,4 @@
+import { withBasePathEnv } from "../../helpers/base-path";
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 
 // ─── Mock dependencies ─────────────────────────────────────────────────────
@@ -145,5 +146,14 @@ describe("GET /api/auth/oidc/login", () => {
     expect(res.status).toBe(307);
     const location = res.headers.get("location");
     expect(location).toContain("/login?error=oidc_config");
+  });
+  test("OIDC authorization and state cookie share the prefixed callback path", async () => {
+    await withBasePathEnv("/~/libredb", async () => {
+      mockGenerateAuthUrl.mockClear();
+      mockCookieSet.mockClear();
+      await GET(new Request("https://studio.example/~/libredb/api/auth/oidc/login"));
+      expect(mockGenerateAuthUrl.mock.calls[0][1]).toBe("https://studio.example/~/libredb/api/auth/oidc/callback");
+      expect(mockCookieSet.mock.calls[0][2]).toMatchObject({ path: "/~/libredb", sameSite: "lax", httpOnly: true });
+    });
   });
 });

--- a/tests/api/proxy.test.ts
+++ b/tests/api/proxy.test.ts
@@ -1,3 +1,4 @@
+import { withBasePathEnv } from "../helpers/base-path";
 import { describe, test, expect, spyOn } from "bun:test";
 import { readFileSync } from "node:fs";
 import { NextRequest } from "next/server";
@@ -328,6 +329,41 @@ describe("proxy", () => {
 
         expect(isRedirect(await proxy(req))).toBe(true);
       }
+    });
+  });
+});
+
+describe("proxy under a nested basePath", () => {
+  for (const [path, role, destination] of [
+    ["/admin", undefined, "/login"],
+    ["/login", "admin", "/admin"],
+    ["/login", "user", "/"],
+    ["/admin", "user", "/"],
+    ["/", "expired", "/login"],
+  ] as const) {
+    test(`${path} (${role ?? "anonymous"}) redirects inside the mount`, async () => {
+      await withBasePathEnv("/~/libredb", async () => {
+        const token = role ? await createToken(role, role === "expired" ? "-1h" : "1h") : undefined;
+        const request = new NextRequest(`http://localhost:3000/~/libredb${path}`, {
+          headers: token ? { cookie: `auth-token=${token}` } : {},
+          nextConfig: { basePath: "/~/libredb" },
+        });
+        expect(request.nextUrl.pathname).toBe(path);
+        expect((await proxy(request)).headers.get("location")).toBe(`http://localhost:3000/~/libredb${destination}`);
+      });
+    });
+  }
+  test("prefixed health is public and prefixed API writes still reject hostile origins", async () => {
+    await withBasePathEnv("/tools/libredb", async () => {
+      const url = "http://localhost:3000/tools/libredb/api/db/health";
+      const options = { nextConfig: { basePath: "/tools/libredb" } };
+      expect((await proxy(new NextRequest(url, options))).status).toBe(200);
+      const request = new NextRequest(url, {
+        ...options,
+        method: "POST",
+        headers: { host: "localhost:3000", origin: "https://evil.example" },
+      });
+      expect((await proxy(request)).status).toBe(403);
     });
   });
 });

--- a/tests/components/admin/OverviewTab.test.tsx
+++ b/tests/components/admin/OverviewTab.test.tsx
@@ -1,3 +1,4 @@
+import { withBasePathEnv } from "../../helpers/base-path";
 import "../../setup-dom";
 import "../../helpers/mock-sonner";
 import "../../helpers/mock-navigation";
@@ -140,6 +141,28 @@ describe("OverviewTab", () => {
 
   afterEach(() => {
     restoreGlobalFetch();
+  });
+
+  test("fleet cards keep native anchor navigation inside the mount", async () => {
+    await withBasePathEnv("/tools/libredb", async () => {
+      const { container } = render(<OverviewTab user={{ username: "admin", role: "admin" }} />);
+      await waitFor(() => {
+        const link = Array.from(container.querySelectorAll("[href]")).find((element) =>
+          element.textContent?.includes("PG Dev"),
+        );
+        expect(link?.getAttribute("href")).toBe("/tools/libredb/admin/monitoring");
+        for (const [label, path] of [
+          ["Maintenance", "/admin/operations"],
+          ["Security & Masking", "/admin/security"],
+          ["Real-time Monitoring", "/admin/monitoring"],
+        ]) {
+          const action = Array.from(container.querySelectorAll("[href]")).find((element) =>
+            element.textContent?.includes(label),
+          );
+          expect(action?.getAttribute("href")).toBe(`/tools/libredb${path}`);
+        }
+      });
+    });
   });
 
   test("renders when user provided", async () => {

--- a/tests/helpers/base-path.ts
+++ b/tests/helpers/base-path.ts
@@ -1,0 +1,11 @@
+/** Keep build-config simulations local to one test, including rejected requests. */
+export async function withBasePathEnv(prefix: string, action: () => unknown | Promise<unknown>): Promise<void> {
+  const previous = process.env.NEXT_PUBLIC_BASE_PATH;
+  process.env.NEXT_PUBLIC_BASE_PATH = prefix;
+  try {
+    await action();
+  } finally {
+    if (previous === undefined) delete process.env.NEXT_PUBLIC_BASE_PATH;
+    else process.env.NEXT_PUBLIC_BASE_PATH = previous;
+  }
+}

--- a/tests/hooks/use-auth.test.ts
+++ b/tests/hooks/use-auth.test.ts
@@ -1,3 +1,4 @@
+import { withBasePathEnv } from "../helpers/base-path";
 import "../setup-dom";
 import { mockToastSuccess, mockToastError } from "../helpers/mock-sonner";
 import { mockRouterPush, mockRouterRefresh } from "../helpers/mock-navigation";
@@ -372,5 +373,24 @@ describe("useAuth", () => {
 
     // The fetch didn't throw, so logout path should succeed
     expect(mockRouterPush).toHaveBeenCalledWith("/login");
+  });
+  test("auth hook sends requests under basePath and leaves Next router navigation logical", async () => {
+    await withBasePathEnv("/~/libredb", async () => {
+      const fetchMock = mockGlobalFetch({
+        "/~/libredb/api/auth/me": { json: { user: { role: "user" } } },
+        "/~/libredb/api/auth/logout": { json: { success: true } },
+      });
+      const { result, unmount } = renderHook(() => useAuth());
+      try {
+        await waitFor(() => expect(result.current.user).toEqual({ role: "user" }));
+        expect(fetchMock).toHaveBeenCalledWith("/~/libredb/api/auth/me");
+        await act(async () => result.current.handleLogout());
+        expect(fetchMock).toHaveBeenCalledWith("/~/libredb/api/auth/logout", { method: "POST" });
+        expect(mockRouterPush).toHaveBeenCalledWith("/login");
+      } finally {
+        unmount();
+        restoreGlobalFetch();
+      }
+    });
   });
 });

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -384,6 +384,7 @@ describe("routes that reach a provider require a session", () => {
     "@/lib/auth": "session cookie minting and reading",
     "@/lib/auth-compare": "constant-time credential comparison",
     "@/lib/auth-errors": "the auth failure taxonomy",
+    "@/lib/config/base-path": "prefixes redirect URLs and cookie paths; these routes use no fetch or provider",
     "@/lib/local-auth": "the local email/password credential store",
     "@/lib/logger": "structured logging",
     "@/lib/oidc": "the OIDC discovery and PKCE exchange",

--- a/tests/unit/config/base-path.test.ts
+++ b/tests/unit/config/base-path.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { readBasePath, getBasePath, withBasePath, appFetch } from "@/lib/config/base-path";
+
+const originalBase = process.env.NEXT_PUBLIC_BASE_PATH;
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  if (originalBase === undefined) delete process.env.NEXT_PUBLIC_BASE_PATH;
+  else process.env.NEXT_PUBLIC_BASE_PATH = originalBase;
+  globalThis.fetch = originalFetch;
+});
+
+describe("build-time base path", () => {
+  test("root stays the default", () => {
+    expect(readBasePath()).toBe("");
+    expect(readBasePath("")).toBe("");
+    expect(readBasePath("/")).toBe("");
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    expect(getBasePath()).toBe("");
+    expect(withBasePath("/api/db/query")).toBe("/api/db/query");
+  });
+
+  for (const prefix of ["/libredb", "/tools/libredb", "/~/libredb", "/v1.2/studio-beta"]) {
+    test(`preserves ${prefix} on APIs, assets, and browser redirects`, () => {
+      expect(readBasePath(prefix)).toBe(prefix);
+      process.env.NEXT_PUBLIC_BASE_PATH = prefix;
+      expect(getBasePath()).toBe(prefix);
+      expect(withBasePath("/api/agent/runs/x/stream?after=1")).toBe(`${prefix}/api/agent/runs/x/stream?after=1`);
+      expect(withBasePath("/logo.svg?v=2")).toBe(`${prefix}/logo.svg?v=2`);
+      expect(withBasePath("/login?error=oidc_failed")).toBe(`${prefix}/login?error=oidc_failed`);
+      expect(withBasePath("/")).toBe(`${prefix}/`);
+    });
+  }
+
+  test("a prefix named api does not mistake the application's API path for an already prefixed path", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/api";
+    expect(withBasePath("/api/db/query")).toBe("/api/api/db/query");
+  });
+
+  for (const invalid of [
+    "libredb",
+    "//evil.example",
+    "/a//b",
+    "/a/",
+    "/.",
+    "/a/../b",
+    "/a/./b",
+    "/x?y",
+    "/x#y",
+    "/%2fadmin",
+    "/a\\b",
+    "/foo bar",
+    "/foo\nbar",
+    "/foo\n",
+    "/foo\r",
+    "/foo\u2028",
+    "/foo\u2029",
+    "https://host/path",
+  ]) {
+    test(`rejects ambiguous configuration ${JSON.stringify(invalid)}`, () => {
+      expect(() => readBasePath(invalid)).toThrow("BASE_PATH");
+    });
+  }
+
+  test("leaves explicit remote, relative and protocol-relative URLs alone", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/tools/libredb";
+    for (const url of ["https://cdn.example/vs", "//cdn.example/vs", "assets/icon.svg"]) {
+      expect(withBasePath(url)).toBe(url);
+    }
+  });
+
+  test("API requests preserve the original init, abort signal, body and response", async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/~/libredb";
+    const response = new Response("ok");
+    const fetchMock = mock(async () => response);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const controller = new AbortController();
+    const init = { method: "POST", body: "query", signal: controller.signal };
+    expect(await appFetch("/api/db/query", init)).toBe(response);
+    expect(fetchMock).toHaveBeenCalledWith("/~/libredb/api/db/query", init);
+    await appFetch("/api/auth/me");
+    expect(fetchMock).toHaveBeenLastCalledWith("/~/libredb/api/auth/me");
+  });
+});

--- a/tests/unit/editor/monaco-loader.test.ts
+++ b/tests/unit/editor/monaco-loader.test.ts
@@ -1,3 +1,4 @@
+import { withBasePathEnv } from "../../helpers/base-path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { configureMonacoLoader, DEFAULT_MONACO_VS_PATH, resolveMonacoVsPath } from "@/lib/editor/monaco-loader";
 
@@ -57,5 +58,13 @@ describe("configureMonacoLoader", () => {
     configureMonacoLoader(fakeLoader);
 
     expect(fakeLoader.calls).toEqual([{ paths: { vs: "/embedded/monaco/vs" } }]);
+  });
+});
+
+test("default Monaco assets follow basePath while an explicit asset origin remains exact", async () => {
+  await withBasePathEnv("/~/libredb", () => {
+    expect(resolveMonacoVsPath(undefined)).toBe("/~/libredb/monaco/vs");
+    expect(resolveMonacoVsPath("https://assets.example/vs/")).toBe("https://assets.example/vs");
+    expect(resolveMonacoVsPath("/custom/vs")).toBe("/custom/vs");
   });
 });

--- a/tests/unit/env-documentation.test.ts
+++ b/tests/unit/env-documentation.test.ts
@@ -48,6 +48,8 @@ const ENV_EXAMPLE = readFileSync(path.join(ROOT, ".env.example"), "utf8");
  * the reason it is not operator-facing. Platform- or build-time only.
  */
 const ALLOWLIST: Record<string, string> = {
+  NEXT_PUBLIC_BASE_PATH:
+    "Derived from BASE_PATH by next.config.ts and baked into routes/bundles; not an independent operator setting",
   NODE_ENV: "Set by the runtime and by `next build`, never by an operator.",
   NEXT_RUNTIME: "Injected by Next.js to distinguish the edge and Node runtimes.",
   PORT: "Supplied by the platform (Docker, systemd, the chart), not by `.env`.",

--- a/tests/unit/helm-chart-base-path.test.ts
+++ b/tests/unit/helm-chart-base-path.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { parseAllDocuments } from "yaml";
+
+const chart = join(import.meta.dir, "../../charts/libredb-studio");
+function render(args: string[] = []) {
+  const result = Bun.spawnSync(["helm", "template", "base-path-test", chart, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return { code: result.exitCode, output: result.stdout.toString(), error: result.stderr.toString() };
+}
+function container(output: string) {
+  const documents = parseAllDocuments(output).map((document) => document.toJSON());
+  return documents.find((document) => document?.kind === "Deployment").spec.template.spec.containers[0];
+}
+
+describe("chart probes for a build-time basePath", () => {
+  test("root remains the default", () => {
+    const result = render();
+    expect(result.code).toBe(0);
+    for (const name of ["startupProbe", "readinessProbe", "livenessProbe"]) {
+      expect(container(result.output)[name].httpGet.path).toBe("/api/db/health");
+    }
+  });
+  for (const prefix of ["/libredb", "/tools/libredb", "/~/libredb"]) {
+    test(`${prefix} prefixes each default probe without changing custom probes`, () => {
+      const result = render(["--set-string", `config.basePath=${prefix}`]);
+      expect(result.code).toBe(0);
+      for (const name of ["startupProbe", "readinessProbe", "livenessProbe"]) {
+        expect(container(result.output)[name].httpGet.path).toBe(`${prefix}/api/db/health`);
+      }
+      expect(result.output).not.toMatch(/name: BASE_PATH|BASE_PATH:/);
+      const custom = render([
+        "--set-string",
+        `config.basePath=${prefix}`,
+        "--set-string",
+        "readinessProbe.httpGet.path=/custom-health",
+      ]);
+      expect(container(custom.output).readinessProbe.httpGet.path).toBe("/custom-health");
+    });
+  }
+  for (const prefix of ["//outside", "/a/../b", "/a/", "/%2f", "/a?x"]) {
+    test(`rejects malformed prefix ${prefix}`, () => {
+      const result = render(["--set-string", `config.basePath=${prefix}`]);
+      expect(result.code).not.toBe(0);
+      expect(result.error).toContain("basePath");
+    });
+  }
+  test("custom exec probes stay exact", () => {
+    const result = render([
+      "--set-string",
+      "config.basePath=/tools/libredb",
+      "--set",
+      "readinessProbe.httpGet=null",
+      "--set",
+      "readinessProbe.exec.command[0]=true",
+    ]);
+    expect(result.code).toBe(0);
+    expect(container(result.output).readinessProbe.httpGet).toBeUndefined();
+    expect(container(result.output).readinessProbe.exec).toBeDefined();
+  });
+});

--- a/tests/unit/lib/auth.test.ts
+++ b/tests/unit/lib/auth.test.ts
@@ -1,3 +1,4 @@
+import { withBasePathEnv } from "../../helpers/base-path";
 import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
 import * as jose from "jose";
 import { logger } from "@/lib/logger";
@@ -9,7 +10,7 @@ import { logger } from "@/lib/logger";
 
 let mockCookieStore: Record<string, { value: string } | undefined> = {};
 let mockSetCalls: Array<{ name: string; value: string; opts: unknown }> = [];
-let mockDeleteCalls: string[] = [];
+let mockDeleteCalls: Array<string | { name: string; path: string }> = [];
 
 // ============================================================================
 // Module Mocks — only next/headers
@@ -25,9 +26,9 @@ mock.module("next/headers", () => ({
       mockSetCalls.push({ name, value, opts });
       mockCookieStore[name] = { value };
     },
-    delete: (name: string) => {
-      mockDeleteCalls.push(name);
-      delete mockCookieStore[name];
+    delete: (cookie: string | { name: string; path: string }) => {
+      mockDeleteCalls.push(cookie);
+      delete mockCookieStore[typeof cookie === "string" ? cookie : cookie.name];
     },
   }),
   headers: async () => {
@@ -335,7 +336,17 @@ describe("auth", () => {
   describe("logout()", () => {
     test("deletes auth-token cookie", async () => {
       await logout();
-      expect(mockDeleteCalls).toContain("auth-token");
+      expect(mockDeleteCalls).toContainEqual({ name: "auth-token", path: "/" });
+    });
+  });
+  test("session creation and deletion use the same nested cookie path", async () => {
+    await withBasePathEnv("/tools/libredb", async () => {
+      mockSetCalls = [];
+      mockDeleteCalls = [];
+      await login("user", "prefix-user");
+      expect(mockSetCalls[0].opts).toMatchObject({ path: "/tools/libredb", httpOnly: true, sameSite: "lax" });
+      await logout();
+      expect(mockDeleteCalls).toContainEqual({ name: "auth-token", path: "/tools/libredb" });
     });
   });
 });


### PR DESCRIPTION
Closes #369.

Studio can now be built for a path such as `/tools/libredb` and served through a proxy that preserves that prefix. Previously, root-relative APIs, editor assets, redirects and cookies broke deployments on a shared domain.

- Validate `BASE_PATH` at build time and bake it into Next routing and a shared helper for browser requests, native navigation, metadata and Monaco. Keep Next Link/router paths app-relative so they are prefixed once.
- Scope session and OIDC state cookies to the mount path, delete them with the same path, and prefix OIDC callback/return/error URLs. Match the bare mount path as well as its children: the real browser test caught Next's catch-all skipping `/tools/libredb` after logout.
- Add the Docker build argument and Compose support. Chart `config.basePath` prefixes the three default health probes while preserving custom probes. Bump chart 0.1.61 to 0.1.62 (app 0.15.0) and mirror it into the operator.
- Document source/Docker builds, Nginx, Traefik, Ingress, HTTPRoute, auth and npm embedding in `docs/SUBPATH.md`; retire backlog N3. Add a production browser test to CI through a path-routing proxy that returns 404 outside the mount.

The branch includes upstream 0.15.0. Its catalog-layout error now retains the original error cause, correcting upstream lint and formatting failures; all 77 catalog regression tests pass.

Validation:

- `bun run test`: 14,637 passed, zero failed; all 34 isolated component groups passed.
- `bun run test:coverage && bun run coverage:check`: 46,218/46,218 source lines, 100.00%.
- Chromium production flow at `/~/libredb` through the proxy: login, actual SQLite employee-count query, API calls, self-hosted Monaco, native admin links, server redirects, RBAC, cookie deletion and cross-origin write rejection. No failed app requests or page errors.
- Built and ran the actual Docker image with `--build-arg BASE_PATH=/tools/libredb`, without a runtime `BASE_PATH`; the same browser/query flow passed through the proxy. Default root deployment also passed the auth/editor/API/admin/logout browser flow.
- OIDC unit tests verify prefixed callback and logout URLs, state-cookie scope/deletion and callback exchange URL preservation. The production browser test verifies the missing-config OIDC error redirect. A live identity-provider exchange was not run.
- Formatting, lint (zero errors; 133 existing warnings), TypeScript, Knip, README/chart/channel/security guards, strict chart sync, Helm lint, production build, library build, packed-package type resolution, and launcher gofmt/vet/tests passed.

Next.js fixes `basePath` at build time. The published root image cannot be relocated by a runtime environment variable; operators must rebuild a custom image and preserve the prefix at their proxy. The chart value configures probe paths, not runtime app routing.
