### PR TITLE
fix(package): add npm discovery metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,35 @@
 {
   "name": "@libredb/studio",
   "version": "0.15.0",
+  "description": "The database editor that deploys next to your data, not onto your laptop.",
+  "keywords": [
+    "sql",
+    "sql-ide",
+    "database-gui",
+    "database-editor",
+    "self-hosted",
+    "libredb",
+    "postgresql",
+    "mysql",
+    "oracle",
+    "sql-server",
+    "sqlite",
+    "libsql",
+    "duckdb",
+    "mongodb",
+    "redis",
+    "couchbase",
+    "clickhouse",
+    "druid",
+    "elasticsearch",
+    "opensearch",
+    "trino",
+    "cassandra"
+  ],
+  "homepage": "https://github.com/libredb/libredb-studio",
+  "bugs": {
+    "url": "https://github.com/libredb/libredb-studio/issues"
+  },
   "license": "MIT",
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
## Summary
Closes #664.

- Add the README tagline as the npm package description.
- Add category and engine keywords, including the internal LibreDB provider.
- Point homepage and bugs.url to the upstream repository and issue tracker.

Only package.json metadata changes; no executable code, dependencies, lockfile, version, or author attribution changes.

## Testing
Passed:
- npm pack --dry-run --json
- npm pack to a temporary directory, followed by reading package/package.json from the tarball and asserting all four fields equal the source manifest; keywords also checked for uniqueness. This validates metadata only, not built library output.
- bun run typecheck
- bun run readme:check
- bun run chart:check
- bun run channels:showcase:check
- bun run security:check
- git diff --check

Local environment: macOS arm64, Node 26.8.1, Bun 1.4.2 (invoked through npx); dependencies installed with bun install --frozen-lockfile.

Attempted but not green locally:
- bun run format: missing @biomejs/cli-darwin-arm64 binary.
- bun run lint: missing @oxlint/binding-darwin-arm64 native binding.
- bun run knip: missing @oxc-parser/binding-darwin-arm64 native binding.
- bun run build: missing lightningcss.darwin-arm64.node.
- bun run test: 10,646 passed, 264 failed in the first test group; local failures include missing Helm, 7-Zip, and native database bindings. Later groups did not run because the script stops on failure. Full coverage is not verified locally.

Per CONTRIBUTING.md, submitting with these local limitations documented for the fork CI gate; maintainer approval may be needed to run workflows. No new executable lines were added, so no new application tests are introduced.

## AI assistance
This contribution was prepared and validated with AI assistance.
