### PR TITLE
fix(connections): confirm before deleting a connection

### DIFF
--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -61,7 +61,7 @@ import {
 } from "@/lib/data-masking";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { TriangleAlert, Database, Plus } from "lucide-react";
+import { TriangleAlert, Database, Plus, Trash2 } from "lucide-react";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
@@ -194,6 +194,7 @@ export default function Studio() {
   // === Modal state ===
   const [isConnectionModalOpen, setIsConnectionModalOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<DatabaseConnection | null>(null);
+  const [pendingDeleteConnectionId, setPendingDeleteConnectionId] = useState<string | null>(null);
   const [isCreateTableModalOpen, setIsCreateTableModalOpen] = useState(false);
   const [showDiagram, setShowDiagram] = useState(false);
   const [isSaveQueryModalOpen, setIsSaveQueryModalOpen] = useState(false);
@@ -395,6 +396,10 @@ export default function Studio() {
     tabMgr.handleTableClick(tableName, queryExec.executeQuery);
   };
 
+  const requestDeleteConnection = (id: string) => {
+    setPendingDeleteConnectionId(id);
+  };
+
   const handleDeleteConnection = (id: string) => {
     // Clean up server-side provider cache and close connections/tunnels
     fetch("/api/db/disconnect", {
@@ -412,6 +417,12 @@ export default function Studio() {
     const updated = [...managedConns, ...userConns];
     conn.setConnections(updated);
     if (conn.activeConnection?.id === id) conn.setActiveConnection(updated[0] || null);
+  };
+
+  const confirmDeleteConnection = () => {
+    if (!pendingDeleteConnectionId) return;
+    handleDeleteConnection(pendingDeleteConnectionId);
+    setPendingDeleteConnectionId(null);
   };
 
   /**
@@ -475,7 +486,7 @@ export default function Studio() {
                 isLoadingSchema={conn.isLoadingSchema}
                 schemaError={conn.schemaError}
                 onSelectConnection={conn.setActiveConnection}
-                onDeleteConnection={handleDeleteConnection}
+                onDeleteConnection={requestDeleteConnection}
                 onEditConnection={(c) => {
                   setEditingConnection(c);
                   setIsConnectionModalOpen(true);
@@ -593,7 +604,7 @@ export default function Studio() {
                       conn.setActiveConnection(c);
                       setActiveMobileTab("editor");
                     }}
-                    onDeleteConnection={handleDeleteConnection}
+                    onDeleteConnection={requestDeleteConnection}
                     onAddConnection={() => setIsConnectionModalOpen(true)}
                   />
                 </div>
@@ -859,6 +870,46 @@ export default function Studio() {
               className="flex-1 h-9 bg-warning-solid border-0 text-white text-xs font-medium hover:bg-warning-solid-hover"
             >
               Load All
+            </AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete Connection Confirmation */}
+      <AlertDialog
+        open={!!pendingDeleteConnectionId}
+        onOpenChange={(open) => {
+          if (!open) setPendingDeleteConnectionId(null);
+        }}
+      >
+        <AlertDialogContent className="bg-overlay border-hairline max-w-sm p-0 gap-0 overflow-hidden">
+          <div className="px-6 pt-6 pb-4">
+            <div className="flex items-start gap-3">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-red-500/20 to-red-500/10 flex items-center justify-center shrink-0">
+                <Trash2 strokeWidth={1.5} className="w-5 h-5 text-danger" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <AlertDialogTitle className="text-[0.8125rem] font-medium text-fg mb-1">
+                  Delete connection?
+                </AlertDialogTitle>
+                <AlertDialogDescription className="text-xs text-fg-muted leading-relaxed">
+                  <span className="text-fg-tertiary">
+                    {conn.connections.find((c) => c.id === pendingDeleteConnectionId)?.name || "This connection"}
+                  </span>{" "}
+                  will be removed. This cannot be undone.
+                </AlertDialogDescription>
+              </div>
+            </div>
+          </div>
+          <div className="px-6 pb-6 flex gap-2">
+            <AlertDialogCancel className="flex-1 h-9 bg-fill border-0 text-fg-tertiary text-xs font-medium hover:bg-fill-strong hover:text-fg">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmDeleteConnection}
+              className="flex-1 h-9 bg-danger-solid border-0 text-white text-xs font-medium hover:bg-danger-solid-hover"
+            >
+              Delete
             </AlertDialogAction>
           </div>
         </AlertDialogContent>

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -773,6 +773,23 @@ describe("Studio", () => {
     expect(dialog.queryByText("Delete connection?")).toBeNull();
   });
 
+  /**
+   * Studio mounts the connections list twice: the desktop `Sidebar` above the breakpoint and the
+   * mobile database tab below it. Both were wired to the confirmation, but reverting only the mobile
+   * one to `handleDeleteConnection` left every test above green, so nothing held that half. The
+   * crowded-sidebar misclick this dialog exists for is likeliest on a phone.
+   */
+  test("the mobile connections list asks for confirmation too", () => {
+    connMgrOverride = { activeConnection: pgConn, connections: [pgConn] };
+    render(<Studio />);
+    const onTabChange = capturedMobileNavProps.onTabChange as (tab: string) => void;
+    act(() => onTabChange("database"));
+    const requestDelete = capturedConnectionsListProps.onDeleteConnection as (id: string) => void;
+    act(() => requestDelete("c1"));
+    expect(mockStorageDeleteConnection).not.toHaveBeenCalled();
+    expect(within(document.body as HTMLElement).getByText("Delete connection?")).toBeTruthy();
+  });
+
   test("cancelling the delete dialog leaves the connection untouched", () => {
     connMgrOverride = { activeConnection: pgConn, connections: [pgConn] };
     render(<Studio />);

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -3,7 +3,7 @@ import "../helpers/mock-sonner";
 import { mockRouterPush } from "../helpers/mock-navigation";
 
 import { describe, test, expect, afterEach, beforeEach, mock } from "bun:test";
-import { render, cleanup, act, fireEvent, waitFor } from "@testing-library/react";
+import { render, cleanup, act, fireEvent, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { setupMonacoMock, setupRechartssMock, setupXYFlowMock, setupFramerMotionMock } from "../helpers/mock-monaco";
 
@@ -747,16 +747,41 @@ describe("Studio", () => {
   });
 
   // --- handleDeleteConnection ---
-  test("handleDeleteConnection removes connection and updates list", () => {
+  test("onDeleteConnection asks for confirmation instead of deleting immediately", () => {
+    connMgrOverride = { activeConnection: pgConn, connections: [pgConn] };
+    render(<Studio />);
+    const requestDelete = capturedSidebarProps.onDeleteConnection as (id: string) => void;
+    act(() => requestDelete("c1"));
+    expect(mockStorageDeleteConnection).not.toHaveBeenCalled();
+    const dialog = within(document.body as HTMLElement);
+    expect(dialog.getByText("Delete connection?")).toBeTruthy();
+    expect(dialog.getByText(pgConn.name)).toBeTruthy();
+  });
+
+  test("confirming the delete dialog removes connection and updates list", () => {
     const remaining = [{ id: "c2", type: "mysql", name: "MySQL" }];
     mockStorageGetConnections.mockReturnValue(remaining);
     connMgrOverride = { activeConnection: pgConn, connections: [pgConn, remaining[0]] };
     render(<Studio />);
-    const deleteFn = capturedSidebarProps.onDeleteConnection as (id: string) => void;
-    act(() => deleteFn("c1"));
+    const requestDelete = capturedSidebarProps.onDeleteConnection as (id: string) => void;
+    act(() => requestDelete("c1"));
+    const dialog = within(document.body as HTMLElement);
+    fireEvent.click(dialog.getByText("Delete"));
     expect(mockStorageDeleteConnection).toHaveBeenCalledWith("c1");
     expect(mockSetConnections).toHaveBeenCalledWith(remaining);
     expect(mockSetActiveConnection).toHaveBeenCalledWith(remaining[0]);
+    expect(dialog.queryByText("Delete connection?")).toBeNull();
+  });
+
+  test("cancelling the delete dialog leaves the connection untouched", () => {
+    connMgrOverride = { activeConnection: pgConn, connections: [pgConn] };
+    render(<Studio />);
+    const requestDelete = capturedSidebarProps.onDeleteConnection as (id: string) => void;
+    act(() => requestDelete("c1"));
+    const dialog = within(document.body as HTMLElement);
+    fireEvent.click(dialog.getByText("Cancel"));
+    expect(mockStorageDeleteConnection).not.toHaveBeenCalled();
+    expect(dialog.queryByText("Delete connection?")).toBeNull();
   });
 
   // --- onTableClick ---


### PR DESCRIPTION
## Description

Deleting a connection from the sidebar called `handleDeleteConnection` directly
from the trash icon's `onClick`, with nothing in between: it fired the
disconnect request and deleted the connection immediately, no confirmation of
any kind. That's inconsistent with how the rest of the app treats destructive
actions (e.g. `QueryHistory`'s clear-history flow, which wraps the equivalent
action in a confirm step).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Closes #693

## Changes Made

- Added a `pendingDeleteConnectionId` state in `Studio.tsx` and a
  `requestDeleteConnection` handler that the sidebar's `onDeleteConnection` now
  calls instead of deleting directly.
- Added an `AlertDialog` (same pattern already used for the "unlimited query"
  warning) that names the connection and asks for confirmation; confirming
  calls the existing `handleDeleteConnection` logic unchanged.
- Left the existing `managed` connection special-casing in
  `handleDeleteConnection` untouched — the trash icon is still hidden for
  managed connections in `ConnectionItem.tsx`.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

Replaced the old single-shot delete test with three tests covering the new
flow: requesting a delete opens the dialog without deleting, confirming it
deletes and closes the dialog, and cancelling it leaves the connection
untouched.

Ran locally: `bun run format`, `bun run lint`, `bun run typecheck`, `bun run
knip`, `bun run chart:check`, `bun run channels:showcase:check`, `bun run
readme:check`, `bun run security:check`, `bun run test`, `bun run build` — all
green. `bun run test` includes 176 pre-existing failures in
`tests/integration/db/*` and `tests/unit/helm-chart-*` that need live database
containers / Helm and fail identically on a clean checkout of `main`; nothing
in this diff touches that code.

### Test Environment
- **LibreDB Studio Version**: 0.15.0
- **Browser**: N/A — sidebar/dialog behavior covered by component tests (`@testing-library/react` + jsdom), no interactive browser available in this environment
- **OS**: Linux
- **Node.js/Bun Version**: Bun 1.4.2
- **Database Type**: N/A — no database connection required to reproduce or fix this

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (none needed; the new dialog mirrors the existing unlimited-query-warning pattern)
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
