### PR TITLE
Count the Rancher app-readme overlay the partner catalog renders

### DIFF
--- a/deploy/rancher/CATALOG_LISTING.md
+++ b/deploy/rancher/CATALOG_LISTING.md
@@ -5,8 +5,8 @@ Solutions Catalog (PCSC), requested by SUSE as part of the SUSE Ready for Ranche
 certification (see rancher/partner-charts#1158 and tracking issue #166). This file is
 the single source for the catalog text.
 The overlay Rancher renders is cut from it into `app-readme.md` beside this file, which is
-what a partner-charts submission copies, most recently on 2026-09-09 (see the delivery note
-at the end).
+what a partner-charts submission copies; the refresh submitted on 2026-09-09 is still open
+(see the delivery note at the end).
 `E2E_VALIDATION_TASK.md` covers the validation side.
 
 The listing is live at https://www.suse.com/pcsc/viewVersionPage?versionID=26969 (SUSE
@@ -196,8 +196,9 @@ pre-Couchbase app-readme, so merging it would have offered a months-old version 
 Rancher catalog. The overlay in that PR now carries the ten-engine wording from this
 file. The corrections above have **not** been mailed to SUSE yet.
 
-**2026-09-09.** rancher/partner-charts#1168 refreshes the overlay to the sixteen-engine
-wording, from `libredb/partner-charts`.
+**2026-09-09.** rancher/partner-charts#1168 is OPEN, submitted from `libredb/partner-charts`,
+and refreshes the overlay to the sixteen-engine wording.
+The catalog keeps rendering the ten-engine text until it merges.
 It had stayed on the ten-engine text from 2026-08-18 while the chart's own description moved
 to sixteen, because the file Rancher renders lives in that repository and nothing here could
 read it.
@@ -207,7 +208,8 @@ So the submitted text now lives in `app-readme.md` beside this file and is count
 
 Chart versions need no submission of their own: partner-charts runs
 `partner-charts-ci update` nightly against <https://libredb.org/libredb-studio/> and has
-carried every release since the 0.1.36 listing without a pull request.
+carried our releases since the 0.1.36 listing without a pull request, taking the newest
+chart version at each run rather than every version in between.
 An overlay edit reaches the catalog with the next version that CI integrates, because the
 overlay is copied in only when a new chart version is built.
 

--- a/deploy/rancher/CATALOG_LISTING.md
+++ b/deploy/rancher/CATALOG_LISTING.md
@@ -206,6 +206,16 @@ So the submitted text now lives in `app-readme.md` beside this file and is count
 `tests/unit/lib/catalog-copy-engine-count.test.ts` and scoped by
 `tests/unit/marketplace-copy.test.ts`, the same two gates the copy above answers to.
 
+Review of that submission found two claims those gates did not cover, and both are now
+covered by `tests/unit/marketplace-copy.test.ts` rather than by this prose.
+The overlay had written "manage data across sixteen engines", which the rule above forbids
+by name and which prose alone did not prevent; the checker now derives the editable set
+from `supportsInlineRowEdit` and fails any manage-data sentence that names an engine
+outside it.
+It had also called SQLite the default storage, where `charts/libredb-studio/values.yaml`
+sets `config.storageProvider` to `local`; a storage default named in the overlay is now
+read back from the chart.
+
 Chart versions need no submission of their own: partner-charts runs
 `partner-charts-ci update` nightly against <https://libredb.org/libredb-studio/> and has
 carried our releases since the 0.1.36 listing without a pull request, taking the newest

--- a/deploy/rancher/CATALOG_LISTING.md
+++ b/deploy/rancher/CATALOG_LISTING.md
@@ -3,8 +3,10 @@
 Canonical listing content for LibreDB Studio in the SUSE Partner Certification &
 Solutions Catalog (PCSC), requested by SUSE as part of the SUSE Ready for Rancher
 certification (see rancher/partner-charts#1158 and tracking issue #166). This file is
-the single source for the catalog text; the partner-charts `app-readme.md` overlay is
-refreshed from it, most recently on 2026-08-18 (see the delivery note at the end).
+the single source for the catalog text.
+The overlay Rancher renders is cut from it into `app-readme.md` beside this file, which is
+what a partner-charts submission copies, most recently on 2026-09-09 (see the delivery note
+at the end).
 `E2E_VALIDATION_TASK.md` covers the validation side.
 
 The listing is live at https://www.suse.com/pcsc/viewVersionPage?versionID=26969 (SUSE
@@ -193,6 +195,21 @@ was dropped rather than carried alongside: it pinned appVersion 0.9.44 and the
 pre-Couchbase app-readme, so merging it would have offered a months-old version in the
 Rancher catalog. The overlay in that PR now carries the ten-engine wording from this
 file. The corrections above have **not** been mailed to SUSE yet.
+
+**2026-09-09.** rancher/partner-charts#1168 refreshes the overlay to the sixteen-engine
+wording, from `libredb/partner-charts`.
+It had stayed on the ten-engine text from 2026-08-18 while the chart's own description moved
+to sixteen, because the file Rancher renders lives in that repository and nothing here could
+read it.
+So the submitted text now lives in `app-readme.md` beside this file and is counted by
+`tests/unit/lib/catalog-copy-engine-count.test.ts` and scoped by
+`tests/unit/marketplace-copy.test.ts`, the same two gates the copy above answers to.
+
+Chart versions need no submission of their own: partner-charts runs
+`partner-charts-ci update` nightly against <https://libredb.org/libredb-studio/> and has
+carried every release since the 0.1.36 listing without a pull request.
+An overlay edit reaches the catalog with the next version that CI integrates, because the
+overlay is copied in only when a new chart version is built.
 
 Vendor naming, as settled: the page heads the partner as **Sekoya** (the legal entity,
 Sekoya Grup Bilisim ve Teknoloji Ltd. Sti.) with the product named **LibreDB Studio**.

--- a/deploy/rancher/app-readme.md
+++ b/deploy/rancher/app-readme.md
@@ -1,0 +1,12 @@
+# LibreDB Studio
+
+LibreDB Studio is an MIT-licensed, AI-assisted open source SQL IDE that connects to sixteen database engines directly from the browser.
+
+Use cases:
+
+* Browser-based database management
+  * Browse schemas, run queries and manage data across sixteen engines: PostgreSQL, MySQL, Oracle, SQL Server, SQLite, libSQL, DuckDB, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra. Editing data follows the engine rather than the IDE: where an engine's grammar has no mutation, the controls are reported as unsupported rather than offered and then failed.
+* AI-assisted querying
+  * An optional AI assistant (bring your own key: Gemini, OpenAI, or a local model) explains a query in plain English from the engine's own EXPLAIN plan, on PostgreSQL, MySQL, SQLite, libSQL, DuckDB, Couchbase, ClickHouse, Apache Druid and Apache Trino, and runs a read-only investigation agent on PostgreSQL, SQLite and DuckDB where the database, not the IDE, enforces the read-only session. It stays off unless you configure a provider.
+* Self-hosted data
+  * Runs entirely on your own infrastructure with SQLite storage by default, so no external database is required to operate the IDE itself. Installs from the Rancher Apps catalog with default values: first-run admin credentials are generated automatically and printed to the pod log.

--- a/deploy/rancher/app-readme.md
+++ b/deploy/rancher/app-readme.md
@@ -5,8 +5,8 @@ LibreDB Studio is an MIT-licensed, AI-assisted open source SQL IDE that connects
 Use cases:
 
 * Browser-based database management
-  * Browse schemas, run queries and manage data across sixteen engines: PostgreSQL, MySQL, Oracle, SQL Server, SQLite, libSQL, DuckDB, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra. Editing data follows the engine rather than the IDE: where an engine's grammar has no mutation, the controls are reported as unsupported rather than offered and then failed.
+  * Browse schemas and run queries across sixteen engines: PostgreSQL, MySQL, Oracle, SQL Server, SQLite, libSQL, DuckDB, MongoDB, Redis, Couchbase, ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra. Editing data follows the engine rather than the IDE: inline row editing on PostgreSQL, MySQL, Oracle, SQL Server, SQLite, libSQL and DuckDB, and everywhere else the controls are reported as unsupported rather than offered and then failed.
 * AI-assisted querying
   * An optional AI assistant (bring your own key: Gemini, OpenAI, or a local model) explains a query in plain English from the engine's own EXPLAIN plan, on PostgreSQL, MySQL, SQLite, libSQL, DuckDB, Couchbase, ClickHouse, Apache Druid and Apache Trino, and runs a read-only investigation agent on PostgreSQL, SQLite and DuckDB where the database, not the IDE, enforces the read-only session. It stays off unless you configure a provider.
 * Self-hosted data
-  * Runs entirely on your own infrastructure with SQLite storage by default, so no external database is required to operate the IDE itself. Installs from the Rancher Apps catalog with default values: first-run admin credentials are generated automatically and printed to the pod log.
+  * Runs entirely on your own infrastructure, so no external database is required to operate the IDE itself. Installs from the Rancher Apps catalog with default values: first-run admin credentials are generated automatically and printed to the pod log.

--- a/distribution/channels.yaml
+++ b/distribution/channels.yaml
@@ -726,11 +726,14 @@ channels:
       upstream_repo: https://github.com/rancher/partner-charts
     pin:
       strategy: none
-      note: Merged in rancher/partner-charts#1158 (17 Aug 2026); live in Rancher Partner Charts (the repo
-        index.yaml carries libredb-studio at appVersion 0.12.0) and listed in the SUSE Solutions Catalog.
-        Partner catalog, not self-serve - the chart is regenerated on Rancher's cadence and index.yaml
-        accumulates every chart version, so an image-tag extract there would be ambiguous; strategy stays
-        none like the other tier-4 partner/curated catalogs.
+      note: Merged in rancher/partner-charts#1158 (17 Aug 2026); live in Rancher Partner Charts and listed
+        in the SUSE Solutions Catalog. Chart versions need no submission of ours - partner-charts runs
+        partner-charts-ci update nightly against https://libredb.org/libredb-studio/ and has carried our
+        releases since the listing without a pull request, taking the newest chart version at each run.
+        So upstream_pr here is a copy change to the app-readme overlay (rancher/partner-charts#1168), not
+        a version bump. Strategy stays none because the catalog names one directory per CHART version and
+        the app version each ships is only inside its Chart.yaml, so a directory listing cannot measure it
+        - unlike the two operator catalogs, whose directories are named for the app version.
 
   - id: koyeb-catalog
     name: Koyeb One-Click Apps catalog (curated by Koyeb)

--- a/tests/unit/lib/catalog-copy-engine-count.test.ts
+++ b/tests/unit/lib/catalog-copy-engine-count.test.ts
@@ -1,7 +1,7 @@
 /**
  * The accuracy gate for the engine COUNT in outward-facing catalog copy (#518).
  *
- * Eleven files outside `src/` name the engine set by hand, and until this test nothing
+ * Twelve files outside `src/` name the engine set by hand, and until this test nothing
  * counted them: `scripts/readme-check.mjs` locates the engine table in the three
  * READMEs and `chart:check` pins a version across files, but a storefront listing was
  * only ever corrected by somebody noticing. Measured on the DuckDB registration branch,
@@ -29,8 +29,14 @@ import { EXTERNAL_DATABASE_TYPES } from "@/lib/db/compatibility";
 const REPO_ROOT = join(import.meta.dir, "../../..");
 
 /**
- * The eleven files that publish the engine set outward. Each is copy somebody else's
+ * The twelve files that publish the engine set outward. Each is copy somebody else's
  * catalog renders, so nobody in this repo reads it again once it is submitted.
+ *
+ * `deploy/rancher/app-readme.md` is the one that is not itself the submitted artifact: the
+ * file Rancher renders lives in `rancher/partner-charts` under
+ * `packages/libredb/libredb-studio/overlay/`, out of reach of any test here, and it drifted
+ * six engines behind before anybody looked. This copy is what a submission is cut from, so
+ * the drift fails here first.
  *
  * `from`/`to` cut away editorial matter, and only `CATALOG_LISTING.md` has any: its
  * accuracy-gate blockquote and its outstanding-corrections table exist to NAME stale
@@ -50,6 +56,7 @@ const COPY_FILES: ReadonlyArray<{ path: string; from?: string; to?: string }> = 
   { path: "deploy/aws/listing/listing-fields.md" },
   { path: "deploy/aws/listing/description.md" },
   { path: "deploy/rancher/CATALOG_LISTING.md", from: "## Short description", to: "## Outstanding corrections" },
+  { path: "deploy/rancher/app-readme.md" },
 ];
 
 const NUMERAL_WORDS: Record<string, number> = {
@@ -193,7 +200,7 @@ describe("outward-facing catalog copy counts the engines the registry ships", ()
       );
     });
 
-    // Eleven numerals and seven counted lists on this revision - the two AWS
+    // Thirteen numerals and eight counted lists on this revision - the two AWS
     // listing files abridge, so they add numerals without adding counted lists.
     expect(segments.length).toBeGreaterThanOrEqual(8);
     const counted = segments.filter(

--- a/tests/unit/marketplace-copy.test.ts
+++ b/tests/unit/marketplace-copy.test.ts
@@ -1,11 +1,12 @@
 /**
  * The accuracy gate for outward-facing marketplace copy.
  *
- * These five files are submissions to somebody else's catalog: Railway,
- * DigitalOcean, SUSE PCSC, Azure Partner Center and the AWS Marketplace
- * Management Portal. Nobody in this repo reviews them again once they
- * are mailed, so the only thing standing between a corrected claim and its return is a
- * test. A previous revision replaced a false natural-language-to-SQL claim with two new
+ * These six files are copy submitted to somebody else's catalog: Railway,
+ * DigitalOcean, SUSE PCSC, Azure Partner Center, the AWS Marketplace Management Portal,
+ * and the app-readme overlay Rancher renders. Nobody in this repo reviews them again once
+ * they are submitted - the first five by mail, the last by a pull request against
+ * `rancher/partner-charts`, where no test here can reach the copy that ships - so the only
+ * thing standing between a corrected claim and its return is a test. A previous revision replaced a false natural-language-to-SQL claim with two new
  * ones - "AI query explanation on any connection" (true on 7 of the 14 engines) and
  * "never executes what it recommends" (the consented hand-over runs exactly the
  * recommended statement) - which is why the gate is phrase-level rather than a review

--- a/tests/unit/marketplace-copy.test.ts
+++ b/tests/unit/marketplace-copy.test.ts
@@ -34,6 +34,7 @@ const LISTINGS = {
   rancher: "deploy/rancher/CATALOG_LISTING.md",
   azure: "deploy/azure/listing/listing-fields.md",
   aws: "deploy/aws/listing/listing-fields.md",
+  rancherAppReadme: "deploy/rancher/app-readme.md",
 } as const;
 
 /**

--- a/tests/unit/marketplace-copy.test.ts
+++ b/tests/unit/marketplace-copy.test.ts
@@ -6,7 +6,9 @@
  * and the app-readme overlay Rancher renders. Nobody in this repo reviews them again once
  * they are submitted - the first five by mail, the last by a pull request against
  * `rancher/partner-charts`, where no test here can reach the copy that ships - so the only
- * thing standing between a corrected claim and its return is a test. A previous revision replaced a false natural-language-to-SQL claim with two new
+ * thing standing between a corrected claim and its return is a test.
+ *
+ * A previous revision replaced a false natural-language-to-SQL claim with two new
  * ones - "AI query explanation on any connection" (true on 7 of the 14 engines) and
  * "never executes what it recommends" (the consented hand-over runs exactly the
  * recommended statement) - which is why the gate is phrase-level rather than a review
@@ -24,6 +26,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { DB_UI_CONFIG, getDBConfig } from "@/lib/db-ui-config";
+import { EXTERNAL_DATABASE_TYPES } from "@/lib/db/compatibility";
 import type { DatabaseType } from "@/lib/types";
 
 const REPO_ROOT = join(import.meta.dir, "../..");
@@ -157,6 +160,147 @@ describe("no listing claims the agent never runs what it recommends", () => {
       expect(submittedCopy(path)).not.toMatch(/\bwhat it recommends\b|\bnothing it recommends\b/i);
     });
   }
+});
+
+/**
+ * A provider file that declares inline row editing, anchored to the start of a line for
+ * the same reason `DECLARES_EXPLAIN_FORMAT` is.
+ */
+const DECLARES_INLINE_ROW_EDIT = /^\s*supportsInlineRowEdit:\s*true/m;
+
+/** The engines whose provider declares inline row editing. */
+const editable: DatabaseType[] = providerFiles(PROVIDER_ROOT)
+  .filter((file) => DECLARES_INLINE_ROW_EDIT.test(readFileSync(file, "utf8")))
+  .map(typeIdOf)
+  .filter((id): id is DatabaseType => id in DB_UI_CONFIG)
+  .sort();
+
+/**
+ * The engines a data-management claim may NOT name. Taken as the complement of the `true`
+ * declarations rather than by scanning for the `false` ones: `providers/sql/search/index.ts`
+ * serves TWO type-ids and its path reads as neither, so scanning the false side would leave
+ * Elasticsearch and OpenSearch out of the set a listing is checked against.
+ *
+ * `supportsInlineRowEdit` defaults to true in `base-provider.ts`, so a provider declaring
+ * nothing lands here even though it can edit. That direction is deliberate: its cost is a
+ * failing gate somebody reads, where the other direction's cost is an overclaim standing in
+ * somebody else's catalog, which is the thing this file exists to prevent.
+ */
+const notEditable = EXTERNAL_DATABASE_TYPES.filter((type) => !editable.includes(type)).sort();
+
+/**
+ * The sentences claiming the product MANAGES data, which is the one phrase
+ * `deploy/rancher/CATALOG_LISTING.md` singles out by name: browsing and querying reach
+ * every engine, editing does not, so "manage data across ..." must never be written over
+ * the whole list.
+ *
+ * Only that phrase, not "editing data": the canonical long description opens an editing
+ * sentence with "Editing data follows the engine rather than the IDE" and then names the
+ * engines that CANNOT edit, one reason each, which is the nuance the gate asks for rather
+ * than the overclaim it forbids.
+ */
+function manageDataClaims(content: string): string[] {
+  return content
+    .replace(/\n(?![\n\-*|>])/g, " ")
+    .split(/(?<=\.)\s+|\n/)
+    .filter((sentence) => /manag(?:e|es|ing)\s+(?:your\s+)?data/i.test(sentence));
+}
+
+/** The engines a manage-data sentence names that cannot edit. */
+function overclaimed(claim: string): DatabaseType[] {
+  return notEditable.filter((type) => claim.includes(getDBConfig(type).label));
+}
+
+describe("no listing claims data management on an engine that cannot edit", () => {
+  test("the derived editable set is a real, non-trivial subset", () => {
+    // A regex that matched nothing would make every assertion below vacuous, and one that
+    // matched every provider would make the complement empty.
+    expect(editable.length).toBeGreaterThan(0);
+    expect(notEditable.length).toBeGreaterThan(0);
+    for (const type of ["postgres", "mysql", "sqlite"]) {
+      expect(editable).toContain(type as DatabaseType);
+    }
+    for (const type of ["mongodb", "redis", "elasticsearch", "opensearch"]) {
+      expect(notEditable).toContain(type as DatabaseType);
+    }
+  });
+
+  test("the checker rejects the sentence that reached rancher/partner-charts#1168", () => {
+    // The submitted wording, verbatim. The two gates above passed on it: the count was
+    // right and it made no explanation claim, so nothing here read the verb. It named
+    // nine engines that report the editing controls as unsupported.
+    const submitted =
+      "Browse schemas, run queries and manage data across sixteen engines: PostgreSQL, MySQL, " +
+      "Oracle, SQL Server, SQLite, libSQL, DuckDB, MongoDB, Redis, Couchbase, ClickHouse, " +
+      "Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache Cassandra.";
+    const claims = manageDataClaims(submitted);
+    expect(claims).toHaveLength(1);
+    expect(overclaimed(claims[0])).toEqual(notEditable);
+  });
+
+  test("an editing sentence that names what cannot edit is left alone", () => {
+    // The canonical form. It names the engines that cannot edit ON PURPOSE, and the phrase
+    // gate must not read that as the claim it bans.
+    expect(
+      manageDataClaims(
+        "Editing data follows the engine rather than the IDE: inline row editing on PostgreSQL, and Elasticsearch SQL has no mutation in its grammar at all.",
+      ),
+    ).toEqual([]);
+  });
+
+  for (const [name, path] of Object.entries(LISTINGS)) {
+    test(`${name} claims no data management it cannot deliver`, () => {
+      for (const claim of manageDataClaims(submittedCopy(path))) {
+        expect(overclaimed(claim)).toEqual([]);
+      }
+    });
+  }
+});
+
+/**
+ * The storage mode the chart actually installs with, read from the chart rather than
+ * restated here. The overlay is copy about THIS chart, so its "by default" sentences are
+ * checkable against `values.yaml` in a way the other five listings' are not: the Azure and
+ * DigitalOcean images configure SQLite themselves, and a chart-derived rule applied to them
+ * would fail true copy.
+ */
+const STORAGE_MODES = ["local", "sqlite", "postgres"];
+
+const CHART_STORAGE_DEFAULT = ((): string => {
+  const values = readFileSync(join(REPO_ROOT, "charts/libredb-studio/values.yaml"), "utf8");
+  const declared = /^\s*storageProvider:\s*"([a-z]+)"/m.exec(values)?.[1];
+  // Thrown rather than defaulted. A chart whose default cannot be read is a chart this
+  // gate cannot check, and a fallback would turn that into a passing test.
+  if (!declared) {
+    throw new Error("charts/libredb-studio/values.yaml: config.storageProvider is unreadable");
+  }
+  return declared;
+})();
+
+/** The storage mode a sentence calls the default, if it names one. */
+function storageDefaultsClaimed(copy: string): string[] {
+  return STORAGE_MODES.filter((mode) => new RegExp(`${mode}[^.]*\\bby default\\b`, "i").test(copy));
+}
+
+describe("the Rancher overlay names no storage default the chart does not set", () => {
+  test("the chart's default is one of the modes, and the checker sees a wrong one", () => {
+    // Without both halves the assertion below passes on a chart default nothing recognises
+    // and on a checker that matches nothing.
+    expect(STORAGE_MODES).toContain(CHART_STORAGE_DEFAULT);
+    // The sentence that reached rancher/partner-charts#1168, verbatim. `values.yaml` sets
+    // `config.storageProvider: "local"`; the copy promoted the SQLite mode to the default.
+    expect(
+      storageDefaultsClaimed(
+        "Runs entirely on your own infrastructure with SQLite storage by default, so no external database is required to operate the IDE itself.",
+      ),
+    ).toEqual(["sqlite"]);
+  });
+
+  test("the submitted overlay claims only the chart's default, if any", () => {
+    for (const mode of storageDefaultsClaimed(submittedCopy(LISTINGS.rancherAppReadme))) {
+      expect(mode).toBe(CHART_STORAGE_DEFAULT);
+    }
+  });
 });
 
 describe("the Druid write claim matches the provider documentation", () => {


### PR DESCRIPTION
The text Rancher renders in its Apps view had drifted to ten engines while the chart's own description moved to sixteen.
It lives in `rancher/partner-charts` under `packages/libredb/libredb-studio/overlay/app-readme.md`, so no gate in this repo could read it.
Sent upstream as [rancher/partner-charts#1168](https://github.com/rancher/partner-charts/pull/1168); this PR is the part that stops it happening again.

## Type of Change

- [x] Test addition or update
- [x] Documentation update

## Related Issue

None. Found while sending the 0.15.0 version update to rancher/partner-charts.

## Changes Made

- [`deploy/rancher/app-readme.md`](deploy/rancher/app-readme.md) holds the submitted overlay text, byte-identical to what #1168 carries. `CATALOG_LISTING.md` stays the canonical listing wording; this is the cut of it that partner-charts copies.
- It joins `COPY_FILES` in [`tests/unit/lib/catalog-copy-engine-count.test.ts`](tests/unit/lib/catalog-copy-engine-count.test.ts) as the twelfth outward file, and `LISTINGS` in [`tests/unit/marketplace-copy.test.ts`](tests/unit/marketplace-copy.test.ts).
- Writing the text against those two gates caught two defects in it before submission: the numeral introduced no list, so the sixteen names went unchecked, and the plain-English claim named three engines where nine return a plan.
- The `rancher-partner` note in [`distribution/channels.yaml`](distribution/channels.yaml) put the catalog at appVersion 0.12.0 and called the update "Rancher's cadence". Measured: `partner-charts` runs `partner-charts-ci update` nightly against `https://libredb.org/libredb-studio/` and has carried our releases since the 0.1.36 listing with no pull request of ours, taking the newest chart version at each run. So `upstream_pr` here is a copy change, not a version bump.
- Stale prose counts in the count guard corrected from eleven files / eleven numerals / seven lists to twelve / thirteen / eight, measured rather than incremented. The assertions stay `>=` and unpinned.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

`bun run test` 34/34 groups, `bun run build`, and `format`, `lint`, `typecheck`, `knip`, `chart:check`, `channels:showcase:check`, `readme:check`, `security:check`, `distribution:check` all exit 0.

Both new guards were verified to fire on the new file rather than pass vacuously:

- numeral back to "ten" gives `deploy/rancher/app-readme.md: "ten engines" publishes 10, and there are 16`
- MySQL dropped from the explain list fails `rancherAppReadme scopes its explanation claim to those engines`

No `src/` lines change, so the coverage gate's universe is untouched.
