### PR TITLE
fix(db): append query preview ellipsis only when truncated

### DIFF
--- a/src/lib/db/errors.ts
+++ b/src/lib/db/errors.ts
@@ -6,6 +6,8 @@
 import type { DatabaseType } from "./types";
 import { ApiErrorCode } from "@/lib/api/error-codes";
 
+const QUERY_PREVIEW_MAX_LENGTH = 100;
+
 // ============================================================================
 // Base Database Error
 // ============================================================================
@@ -32,7 +34,11 @@ export class DatabaseError extends Error {
       provider: this.provider,
       code: this.code,
       // Don't expose full query in production for security
-      query: this.query ? this.query.substring(0, 100) + "..." : undefined,
+      query: this.query
+        ? this.query.length > QUERY_PREVIEW_MAX_LENGTH
+          ? this.query.substring(0, QUERY_PREVIEW_MAX_LENGTH) + "..."
+          : this.query
+        : undefined,
     };
   }
 }

--- a/tests/unit/db/errors.test.ts
+++ b/tests/unit/db/errors.test.ts
@@ -51,8 +51,23 @@ describe("DatabaseError", () => {
       message: "test",
       provider: "mysql",
       code: ApiErrorCode.QUERY_ERROR,
-      query: "SELECT 1...",
+      query: "SELECT 1",
     });
+  });
+
+  test("toJSON() preserves a query at the preview limit", () => {
+    const query = "A".repeat(100);
+    const json = new DatabaseError("msg", "postgres", undefined, query).toJSON();
+    expect(json.query).toBe(query);
+    expect(json.query?.endsWith("...")).toBe(false);
+  });
+
+  test("toJSON() marks a query just beyond the preview limit", () => {
+    const query = "A".repeat(101);
+    const json = new DatabaseError("msg", "postgres", undefined, query).toJSON();
+    expect(json.query).toBe("A".repeat(100) + "...");
+    expect(json.query?.length).toBe(103);
+    expect(json.query?.endsWith("...")).toBe(true);
   });
 
   test("toJSON() truncates query to 100 chars", () => {


### PR DESCRIPTION
## Description
Short queries in DatabaseError.toJSON() incorrectly end in "...", implying omitted text. Preserve queries up to 100 characters verbatim and append the suffix only when truncation actually occurs.

## Type of Change
- [x] Bug fix
- [x] Test addition or update

## Related Issue
Closes #665

## Changes Made
- Add one module-scope QUERY_PREVIEW_MAX_LENGTH constant for comparison and slicing.
- Correct the SELECT 1 expectation and cover the 100/101-character boundaries.
- Retain the existing 200-character truncation test and absent-query behavior.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] All existing tests pass

Failing-first: `bun run test:unit -t 'DatabaseError'` produced 50 passes and two expected failures (short and exactly-100-character queries) before the implementation change. Afterward: 52 passed, zero failed.

Passed: format, lint (133 existing warnings, no errors), typecheck, knip, readme:check, chart:check, channels:showcase:check, security:check, and build:lib.

`bun run test` now passes end to end: 14,715 tests passed, zero failures, including all 34 component groups. The initial failures were resolved by installing workspace-local Helm 4.1.3 and 7-Zip 26.03 (official checksums verified) and the locked PostgreSQL chart dependency. Source files are unchanged from the submitted head.

The independently collected core and component LCOV was merged with the repository script; `coverage:check` passed at 46,328/46,328 lines (100%).

`bun run build` remains blocked by Turbopack's worker port binding ("Operation not permitted"), including a permission-expanded retry. Required CI still needs to verify the full test/build gates.

### Test Environment
LibreDB Studio 0.15.0, macOS arm64, Bun 1.4.2, Node 26.5.0. No database or browser needed for the serializer regression.

## Checklist
- [x] Code style checked
- [x] Patch reviewed against the issue scope
- [x] Regression tests demonstrate the fix
- [x] Full existing test suite passes locally

## Additional Notes
AI-assisted implementation, review, and tests. Both published files match the tested local files. Only the two issue-scoped files changed.