### PR TITLE
fix(ui): append saved-query ellipsis only when truncated

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -202,7 +202,7 @@ export function CommandPalette({
                 <Bookmark strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-purple" />
                 <span>{sq.name}</span>
                 <span className="ml-auto text-xs text-fg-subtle truncate max-w-[150px]">
-                  {sq.query.substring(0, 40)}...
+                  {sq.query.length > 40 ? sq.query.substring(0, 40) + "..." : sq.query}
                 </span>
               </CommandItem>
             ))}

--- a/tests/components/CommandPalette.test.tsx
+++ b/tests/components/CommandPalette.test.tsx
@@ -78,7 +78,7 @@ mock.module("@/lib/db-ui-config", () => ({
 }));
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { render, fireEvent, cleanup } from "@testing-library/react";
+import { render, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import React from "react";
 
 import { CommandPalette } from "@/components/CommandPalette";
@@ -300,6 +300,35 @@ describe("CommandPalette", () => {
 
     // Restore default
     (storage.getSavedQueries as ReturnType<typeof mock>).mockReturnValue([]);
+  });
+
+  test.each([
+    ["short", "SELECT id FROM users", "SELECT id FROM users"],
+    ["at the limit", "A".repeat(40), "A".repeat(40)],
+    ["beyond the limit", "A".repeat(41), "A".repeat(40) + "..."],
+  ])("saved-query preview %s marks only truncated text", async (_case, query, preview) => {
+    (storage.getSavedQueries as ReturnType<typeof mock>).mockReturnValue([
+      {
+        id: "preview-regression",
+        name: "Preview regression",
+        query,
+        connectionType: "postgres" as const,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    try {
+      const onLoadSavedQuery = mock(() => {});
+      const { getByText } = render(<CommandPalette {...createDefaultProps({ onLoadSavedQuery })} />);
+      fireEvent.keyDown(document, { key: "k", metaKey: true });
+      expect(getByText(preview, { exact: true })).not.toBeNull();
+      const item = getByText("Preview regression").closest('[role="option"]');
+      expect(item).not.toBeNull();
+      fireEvent.click(item!);
+      await waitFor(() => expect(onLoadSavedQuery).toHaveBeenCalledWith(query));
+    } finally {
+      (storage.getSavedQueries as ReturnType<typeof mock>).mockReturnValue([]);
+    }
   });
 
   test("Recent Queries group renders from history", () => {


### PR DESCRIPTION
## Description
Saved-query previews in the command palette always end in "...", even when the complete query fits. Append the suffix only for queries longer than 40 characters, following the existing QuerySafetyDialog pattern.

## Type of Change
- [x] Bug fix
- [x] Test addition or update

## Related Issue
Closes #687

## Changes Made
- Make the saved-query preview suffix conditional on truncation.
- Add component tests for short, exactly 40-character, and 41-character queries.
- Verify selection still loads the complete query, including when its preview is truncated.

## Testing
- [x] Tested locally
- [x] Added tests
- [x] All existing tests pass

Failing-first: the new short/exact-limit assertions failed on the original component; the longer-query case passed. This initial filtered component run also reported no-match errors in unrelated groups. The subsequent unfiltered component coverage run passed all 34 groups, including all three new cases.

Passed: format, lint (existing warnings, no errors), typecheck, knip, chart:check, channels:showcase:check, readme:check, security:check, build:lib, and diff checks.

`bun run test` now passes end to end: 14,716 tests passed, zero failures, including all 34 component groups. Installing workspace-local Helm 4.1.3 and 7-Zip 26.03 and the locked PostgreSQL chart dependency resolved the initial infrastructure failures. Source files are unchanged from the submitted head.

The independently collected core and component LCOV was merged with the repository script; the coverage checker passed at 46,324/46,324 lines (100%).

Production `bun run build` was not repeated for this patch: the same checkout base and dependencies in #706 fail Turbopack worker port binding with "Operation not permitted", including a permission-expanded retry. CI must verify the full production build and infrastructure-dependent tests.

### Test Environment
LibreDB Studio 0.15.0, macOS arm64, Bun 1.4.2, Node 26.5.0. Component tests render the real CommandPalette with the existing cmdk/storage mocks; no live-browser result is claimed.

## Checklist
- [x] Code style checked
- [x] Patch reviewed against issue scope
- [x] Regression tests demonstrate the fix
- [x] Full existing test suite passes locally

## Additional Notes
AI-assisted implementation, review, and tests. Only CommandPalette.tsx and its component test changed. Both published files match the tested local files. Independent of #706.