### PR TITLE
fix(cli): print usable startup URLs for wildcard and IPv6 hosts

### DIFF
--- a/bin/lib/launcher-utils.mjs
+++ b/bin/lib/launcher-utils.mjs
@@ -10,6 +10,22 @@ import { createHash } from "node:crypto";
 import { createReadStream, existsSync, renameSync, rmSync } from "node:fs";
 import * as path from "node:path";
 
+export const DEFAULT_PORT = "3000";
+
+/**
+ * Format a local startup link without changing the server's bind address.
+ * @param {string | null | undefined} hostname
+ * @param {string | number | null | undefined} port
+ * @returns {string}
+ */
+export function startupUrl(hostname, port) {
+  let host = hostname || "127.0.0.1";
+  if (host === "0.0.0.0") host = "127.0.0.1";
+  else if (host === "::" || host === "[::]") host = "[::1]";
+  else if (host.includes(":") && !host.startsWith("[")) host = `[${host}]`;
+  return `http://${host}:${port || DEFAULT_PORT}`;
+}
+
 /**
  * Platform/arch pairs the release workflow builds standalone payloads for
  * (must mirror the build jobs in .github/workflows/release-artifacts.yml).

--- a/bin/studio.js
+++ b/bin/studio.js
@@ -38,6 +38,8 @@ import {
   assessNodeRuntime,
   assessProvenance,
   extractArchive,
+  DEFAULT_PORT,
+  startupUrl,
   LauncherUsageError,
   parseLauncherArgs,
   parseSha256Sums,
@@ -67,7 +69,7 @@ network only prints a warning; an archive whose provenance is actively
 rejected stops the launcher (override: LIBREDB_STUDIO_SKIP_PROVENANCE=1).
 
 Options:
-  --port <n>        Port to listen on (default: $PORT or 3000)
+  --port <n>        Port to listen on (default: $PORT or ${DEFAULT_PORT})
   --host <addr>     Address to bind (default: $HOSTNAME or 127.0.0.1;
                     use --host 0.0.0.0 to expose on the network)
   --archive <path>  Start from a local standalone archive instead of
@@ -316,7 +318,7 @@ function startServer(payloadDir, port, host) {
   if (!env.WORKFLOW_LOCAL_DATA_DIR) env.WORKFLOW_LOCAL_DATA_DIR = resolveLedgerDir(os.homedir());
   // Log-line contract: npx-engine-smoke.yml parses the resolved version from
   // "Starting LibreDB Studio <version> " - keep the prefix stable.
-  console.log(`Starting LibreDB Studio ${pkg.version} on http://${env.HOSTNAME}:${env.PORT || "3000"}`);
+  console.log(`Starting LibreDB Studio ${pkg.version} on ${startupUrl(env.HOSTNAME, env.PORT)}`);
   const child = spawn(process.execPath, ["server.js"], { cwd: payloadDir, env, stdio: "inherit" });
   child.on("error", (error) => fail(`Could not start server.js: ${error.message}`));
   for (const signal of /** @type {const} */ (["SIGINT", "SIGTERM"])) {

--- a/tests/unit/launcher-utils.test.ts
+++ b/tests/unit/launcher-utils.test.ts
@@ -8,6 +8,7 @@ import * as os from "os";
 import * as path from "path";
 import {
   artifactName,
+  startupUrl,
   assertReleaseVersion,
   assessNodeRuntime,
   assessProvenance,
@@ -564,5 +565,57 @@ describe("assessProvenance", () => {
     const result = assess({ stderr: POLICY_MISMATCH, version: "0.9.0" });
     expect(result.action).toBe("fail");
     expect(result.message).toContain(ARTIFACT);
+  });
+});
+
+describe("launcher startup URL", () => {
+  test.each([
+    ["0.0.0.0", "http://127.0.0.1:3000"],
+    ["::", "http://[::1]:3000"],
+    ["127.0.0.1", "http://127.0.0.1:3000"],
+  ])("prints a usable URL for %s without changing the bind address", (host, url) => {
+    const home = fs.mkdtempSync(path.join(tempDir, "startup-"));
+    const root = path.resolve(import.meta.dir, "../..");
+    const version = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
+    const payload = path.join(home, ".libredb-studio", version, "payload");
+    fs.mkdirSync(payload, { recursive: true });
+    fs.writeFileSync(path.join(payload, "server.js"), 'console.log("BIND=" + process.env.HOSTNAME);');
+    const preload = path.join(home, "home-fixture.mjs");
+    fs.writeFileSync(
+      preload,
+      'import os from "node:os"; import { syncBuiltinESMExports } from "node:module"; ' +
+        `os.homedir = () => ${JSON.stringify(home)}; syncBuiltinESMExports();`,
+    );
+    const node = Bun.which("node");
+    expect(node).not.toBeNull();
+    const run = Bun.spawnSync([node!, "--import", preload, path.join(root, "bin/studio.js"), "--host", host], {
+      env: { PATH: process.env.PATH },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(run.exitCode).toBe(0);
+    const output = run.stdout.toString();
+    expect(output).toContain(`Starting LibreDB Studio ${version} on ${url}\n`);
+    expect(output).toContain(`BIND=${host}\n`);
+    expect(output.match(/^Starting LibreDB Studio ([0-9][0-9.]*) /m)?.[1]).toBe(version);
+  });
+});
+
+describe("startupUrl", () => {
+  test.each([
+    ["0.0.0.0", "4000", "http://127.0.0.1:4000"],
+    ["::", "4000", "http://[::1]:4000"],
+    ["[::]", "4000", "http://[::1]:4000"],
+    ["fe80::1", "4000", "http://[fe80::1]:4000"],
+    ["[fe80::1]", "4000", "http://[fe80::1]:4000"],
+    ["127.0.0.1", "4000", "http://127.0.0.1:4000"],
+    ["example.internal", "4000", "http://example.internal:4000"],
+    ["", "4000", "http://127.0.0.1:4000"],
+    [undefined, undefined, "http://127.0.0.1:3000"],
+    [null, null, "http://127.0.0.1:3000"],
+    ["127.0.0.1", "", "http://127.0.0.1:3000"],
+    ["127.0.0.1", 4000, "http://127.0.0.1:4000"],
+  ])("formats host %s and port %s", (host, port, expected) => {
+    expect(startupUrl(host, port)).toBe(expected);
   });
 });

--- a/tests/unit/launcher-utils.test.ts
+++ b/tests/unit/launcher-utils.test.ts
@@ -568,39 +568,6 @@ describe("assessProvenance", () => {
   });
 });
 
-describe("launcher startup URL", () => {
-  test.each([
-    ["0.0.0.0", "http://127.0.0.1:3000"],
-    ["::", "http://[::1]:3000"],
-    ["127.0.0.1", "http://127.0.0.1:3000"],
-  ])("prints a usable URL for %s without changing the bind address", (host, url) => {
-    const home = fs.mkdtempSync(path.join(tempDir, "startup-"));
-    const root = path.resolve(import.meta.dir, "../..");
-    const version = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
-    const payload = path.join(home, ".libredb-studio", version, "payload");
-    fs.mkdirSync(payload, { recursive: true });
-    fs.writeFileSync(path.join(payload, "server.js"), 'console.log("BIND=" + process.env.HOSTNAME);');
-    const preload = path.join(home, "home-fixture.mjs");
-    fs.writeFileSync(
-      preload,
-      'import os from "node:os"; import { syncBuiltinESMExports } from "node:module"; ' +
-        `os.homedir = () => ${JSON.stringify(home)}; syncBuiltinESMExports();`,
-    );
-    const node = Bun.which("node");
-    expect(node).not.toBeNull();
-    const run = Bun.spawnSync([node!, "--import", preload, path.join(root, "bin/studio.js"), "--host", host], {
-      env: { PATH: process.env.PATH },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect(run.exitCode).toBe(0);
-    const output = run.stdout.toString();
-    expect(output).toContain(`Starting LibreDB Studio ${version} on ${url}\n`);
-    expect(output).toContain(`BIND=${host}\n`);
-    expect(output.match(/^Starting LibreDB Studio ([0-9][0-9.]*) /m)?.[1]).toBe(version);
-  });
-});
-
 describe("startupUrl", () => {
   test.each([
     ["0.0.0.0", "4000", "http://127.0.0.1:4000"],


### PR DESCRIPTION
## Description
The launcher prints unusable startup links for wildcard bind addresses: `0.0.0.0` is shown directly and `::` produces `http://:::3000`. Format the displayed URL with a pure `startupUrl` helper while preserving the server bind settings and version-parsing log prefix.

Closes #670.

## Changes
- Map wildcard addresses to loopback in the displayed link and bracket other IPv6 addresses.
- Share the default port constant with the help text.
- Add 12 pure helper cases covering wildcard, IPv6, ordinary hosts and default ports.

Actual launcher output previously verified with `--host 0.0.0.0` and an isolated cached stub payload:
```text
Starting LibreDB Studio 0.15.0 on http://127.0.0.1:3000
BIND=0.0.0.0
```

## Validation
- Current revision: launcher helper suite **99 passed, 0 failed**, 178 assertions. Focused helper coverage remains **100% lines**.
- Removed the three launcher subprocess tests as requested in review: the unit CI job uses an ambient Node 22 below the launcher's Node 24 floor. The pure case table remains; production code is unchanged by this revision.
- Initial implementation passed the full local suite (14,728 tests), full 100% coverage gate, format/lint/type checks, and repository guards on Node 26.5.0/Bun 1.4.2. Those are prior-revision results; current full CI is running.
- Previous-head CI passed lint/typecheck/build, browser E2E, PostgreSQL functional smoke and both Node engine smoke jobs. Its unit job failed on the three now-removed subprocess cases.

AI-assisted implementation and validation. The manual launcher fixture used a cached stub server, not a real Next.js server or downloaded release. No dependencies added; server bind settings and the startup version prefix are preserved.
