### PR TITLE
fix(test): run omitted component suite and guard runner completeness

### DIFF
--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -239,6 +239,7 @@ run_group "Group 11/12: Smoke tests" \
   tests/components/ConnectionSignature.test.tsx \
   tests/components/GitHubRepoLink.test.tsx \
   tests/components/MonitoringPage.test.tsx \
+  tests/components/monitoring/PanelUnavailable.test.tsx \
   tests/components/monitoring/MetricChart.test.tsx
 
 # Group 12: MaskingSettings (isolated — mocks @/lib/data-masking with different shape than ResultsGrid/DataProfiler)

--- a/tests/unit/component-runner-coverage.test.ts
+++ b/tests/unit/component-runner-coverage.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dir, "../..");
+const runner = readFileSync(path.join(root, "tests/run-components.sh"), "utf8");
+const commands = runner
+  .split("\n")
+  .filter((line) => !line.trimStart().startsWith("#"))
+  .join("\n");
+const named = new Set(commands.match(/tests\/(?:components|isolated)\/[^\s"']+\.test\.tsx?\b/g) ?? []);
+
+function testFiles(directory: string): string[] {
+  return readdirSync(path.join(root, directory), { withFileTypes: true }).flatMap((entry) => {
+    const file = `${directory}/${entry.name}`;
+    if (entry.isDirectory()) return testFiles(file);
+    return entry.isFile() && /\.test\.tsx?$/.test(entry.name) ? [file] : [];
+  });
+}
+
+const onDisk = new Set(["tests/components", "tests/isolated"].flatMap(testFiles));
+
+describe("component runner coverage", () => {
+  test("every component and isolated test file is named by the runner", () => {
+    expect([...onDisk].filter((file) => !named.has(file)).sort()).toEqual([]);
+  });
+
+  test("every test path named by the runner exists on disk", () => {
+    expect([...named].filter((file) => !onDisk.has(file)).sort()).toEqual([]);
+  });
+
+  test("TOTAL_GROUPS matches the number of run_group calls", () => {
+    const declared = runner.match(/^TOTAL_GROUPS=(\d+)$/m);
+    expect(declared).not.toBeNull();
+    expect(Number(declared![1])).toBe((runner.match(/^run_group /gm) ?? []).length);
+  });
+});


### PR DESCRIPTION
## Description
The component runner omitted PanelUnavailable.test.tsx, so its eight existing cases never ran in the normal or coverage workflows. Add it to the existing smoke group and measure runner completeness against the files on disk.

## Type of Change
- [x] Bug fix

## Related Issue
Closes #671

## Changes Made
- Add PanelUnavailable.test.tsx to Group 11 without adding a group or changing TOTAL_GROUPS.
- Add three unit checks: every component/isolated test file is named, every named test path exists, and TOTAL_GROUPS equals the number of run_group calls.
- Derive the lists and counts at runtime; no individual suite paths or group-count literals are duplicated in the guard. Ignore comment-only lines when extracting named paths.

## Testing
- [x] Test first: the new guard failed on the original runner's missing PanelUnavailable suite (2 pass, 1 fail).
- [x] Restored runner: all three guard checks pass.
- [x] Mutation proof: removing the new Group 11 line makes the file-inclusion guard fail, naming PanelUnavailable.test.tsx.
- [x] Mutation proof: replacing that path with a nonexistent NoSuchPanel.test.tsx makes both the omitted-file and nonexistent-path checks fail.
- [x] Mutation proof: changing TOTAL_GROUPS to 33 makes the count check fail (expected the derived 34 calls, received 33). Restored the runner after every mutation.
- [x] Full `bun run test`: 14,724 passes, zero failures, all 34 groups. All eight PanelUnavailable cases appear as passing in the normal run.
- [x] Full `bun run test:coverage` and threshold check: 46,324/46,324 lines (100%).
- [x] Format, lint, typecheck, knip, chart/channel/README/security guards, `build:lib`, and diff checks pass.

## Test Environment
macOS arm64; Node 26.5.0; Bun 1.4.2; GNU Bash 5.2.37; Helm 4.1.3; 7-Zip 26.03.

## Checklist
- [x] Focused two-file change with demonstrated regression protection.
- [x] Existing process-isolation groups preserved.
- [x] No application code or dependencies changed.

## Additional Notes
AI-assisted implementation and validation. Lint reports existing warnings without errors. The first focused command attempt omitted Bun from the child process PATH; the corrected invocation produced the test-first result above.

Production `bun run build` remains for CI: the identical base/dependency set hit a local Turbopack worker-port permission error in #706 even after a broader-permission retry. That environment-limited production build was not repeated for this test-runner-only change.
