### PR TITLE
fix(a11y): name six icon controls and test accessible interactions

### DIFF
--- a/src/components/CreateTableModal.tsx
+++ b/src/components/CreateTableModal.tsx
@@ -523,6 +523,7 @@ export function CreateTableModal({ isOpen, onClose, onTableCreated, dbType }: Cr
                     size="icon"
                     className="h-8 w-8 text-fg-subtle hover:text-danger hover:bg-danger-tint/10 mb-0.5"
                     onClick={() => removeColumn(index)}
+                    aria-label={`Remove column ${index + 1}`}
                   >
                     <Trash2 strokeWidth={1.5} className="w-3.5 h-3.5" />
                   </Button>

--- a/src/components/SchemaDiagram.tsx
+++ b/src/components/SchemaDiagram.tsx
@@ -445,6 +445,7 @@ function SchemaDiagramInner({ schema, onClose }: SchemaDiagramProps) {
                   size="icon"
                   className="rounded-full bg-raised border-hairline-strong hover:bg-fill"
                   onClick={onClose}
+                  aria-label="Close schema diagram"
                 >
                   <X strokeWidth={1.5} className="w-3.5 h-3.5" />
                 </Button>

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -672,6 +672,7 @@ export function OperationsTab() {
                           size="icon"
                           className="h-6 w-6 text-fg-subtle hover:text-danger hover:bg-danger-tint/10 opacity-0 group-hover:opacity-100 transition-all"
                           onClick={() => handleKillClick(session)}
+                          aria-label={`Terminate session ${session.pid}`}
                           disabled={killingPid === session.pid}
                         >
                           {killingPid === session.pid ? (

--- a/src/components/monitoring/MonitoringDashboard.tsx
+++ b/src/components/monitoring/MonitoringDashboard.tsx
@@ -111,6 +111,7 @@ export function MonitoringDashboard({ isEmbedded = false }: MonitoringDashboardP
                 variant="ghost"
                 size="icon"
                 onClick={() => router.push("/")}
+                aria-label="Back"
                 className="h-8 w-8 sm:h-9 sm:w-auto sm:px-3"
               >
                 <ArrowLeft className="h-4 w-4" />

--- a/src/components/monitoring/tabs/PoolTab.tsx
+++ b/src/components/monitoring/tabs/PoolTab.tsx
@@ -122,7 +122,14 @@ export function PoolTab({ connection }: PoolTabProps) {
           <Server strokeWidth={1.5} className="h-4 w-4 sm:h-5 sm:w-5 text-primary" />
           <h2 className="text-xs sm:text-base font-medium">Connection Pool</h2>
         </div>
-        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={reload} disabled={loading}>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={reload}
+          disabled={loading}
+          aria-label="Refresh connection pool"
+        >
           <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
         </Button>
       </div>

--- a/src/components/monitoring/tabs/SessionsTab.tsx
+++ b/src/components/monitoring/tabs/SessionsTab.tsx
@@ -237,6 +237,7 @@ export function SessionsTab({ data, loading, onKillSession, isAdmin = true, labe
                             size="icon"
                             className="h-6 w-6 sm:h-8 sm:w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
                             onClick={() => handleKillClick(session)}
+                            aria-label={`Terminate session ${session.pid}`}
                             disabled={killingPid === session.pid}
                           >
                             {killingPid === session.pid ? (

--- a/tests/components/CreateTableModal.test.tsx
+++ b/tests/components/CreateTableModal.test.tsx
@@ -73,16 +73,11 @@ describe("CreateTableModal", () => {
     });
     expect(baseElement.querySelectorAll('input[placeholder="column_name"]').length).toBe(2);
 
-    // Find trash/remove buttons — they are the last button in each column row
-    const trashButtons = baseElement.querySelectorAll("button");
-    const removeButtons = Array.from(trashButtons).filter((btn) => {
-      const icon = btn.querySelector('[data-icon="Trash2"]') || btn.querySelector("svg");
-      return icon !== null && btn.textContent === "";
-    });
+    const removeButton = body.getByRole("button", { name: "Remove column 2" });
 
     // Click the last remove button (removes the newly added column)
     act(() => {
-      fireEvent.click(removeButtons[removeButtons.length - 1]);
+      fireEvent.click(removeButton);
     });
 
     expect(baseElement.querySelectorAll('input[placeholder="column_name"]').length).toBe(1);

--- a/tests/components/SchemaDiagram.test.tsx
+++ b/tests/components/SchemaDiagram.test.tsx
@@ -399,11 +399,9 @@ describe("SchemaDiagram", () => {
   test("onClose fires when close button clicked", () => {
     const onClose = mock(() => {});
     const props = createDefaultProps({ onClose });
-    const { container } = render(<SchemaDiagram {...props} />);
+    const { getByRole } = render(<SchemaDiagram {...props} />);
 
-    const closeButton = Array.from(container.querySelectorAll("button")).find((btn) =>
-      btn.className.includes("rounded-full"),
-    );
+    const closeButton = getByRole("button", { name: "Close schema diagram" });
     expect(closeButton).not.toBeNull();
 
     fireEvent.click(closeButton!);

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -869,13 +869,9 @@ describe("OperationsTab", () => {
     await act(async () => {
       renderResult = render(<OperationsTab />);
     });
-    const { container, baseElement } = renderResult!;
+    const { getByRole, baseElement } = renderResult!;
 
-    // Click kill button
-    const cells = container.querySelectorAll("td");
-    const pidCell = Array.from(cells).find((td) => td.textContent?.includes("1234"));
-    const row = pidCell!.closest("tr");
-    const killBtn = row!.querySelector("td:last-child button");
+    const killBtn = getByRole("button", { name: "Terminate session 1234" });
     await act(async () => {
       fireEvent.click(killBtn!);
     });

--- a/tests/components/monitoring/MonitoringDashboard.test.tsx
+++ b/tests/components/monitoring/MonitoringDashboard.test.tsx
@@ -211,7 +211,7 @@ mock.module("@/components/monitoring/tabs/PoolTab", () => ({
 }));
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { render, act, cleanup, waitFor } from "@testing-library/react";
+import { render, act, cleanup, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -338,6 +338,18 @@ describe("MonitoringDashboard", () => {
 
     // Restore
     (storageModule.storage as unknown as Record<string, unknown>).getConnections = originalGetConnections;
+  });
+
+  test("back button remains named when its responsive text is hidden", async () => {
+    mockRouterPush.mockClear();
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<MonitoringDashboard />);
+    });
+    // Model the small-screen CSS state in the DOM test environment.
+    view!.getByText("Back").style.display = "none";
+    fireEvent.click(view!.getByRole("button", { name: "Back" }));
+    expect(mockRouterPush).toHaveBeenCalledWith("/");
   });
 
   test("isEmbedded=true hides back button", async () => {

--- a/tests/components/monitoring/PoolTab.test.tsx
+++ b/tests/components/monitoring/PoolTab.test.tsx
@@ -90,13 +90,12 @@ describe("PoolTab", () => {
   });
 
   test("the refresh button re-issues the request", async () => {
-    const { container, queryByText } = render(<PoolTab connection={conn} />);
+    const { getByRole, queryByText } = render(<PoolTab connection={conn} />);
     await waitFor(() => {
       expect(queryByText("10")).not.toBeNull();
     });
 
-    // The header refresh control is the only button on the settled tab.
-    const refreshButton = container.querySelector("button");
+    const refreshButton = getByRole("button", { name: "Refresh connection pool" });
     expect(refreshButton).not.toBeNull();
 
     await act(async () => {

--- a/tests/components/monitoring/SessionsTab.test.tsx
+++ b/tests/components/monitoring/SessionsTab.test.tsx
@@ -151,15 +151,11 @@ describe("SessionsTab", () => {
 
   test("calls onKillSession after confirming terminate action", async () => {
     const onKillSession = mock(async () => true);
-    const { container, queryByText } = render(
+    const { getByRole, queryByText } = render(
       <SessionsTab data={makeData()} loading={false} onKillSession={onKillSession} isAdmin />,
     );
 
-    const killButtons = Array.from(container.querySelectorAll("button")).filter((btn) =>
-      btn.className.includes("text-destructive"),
-    );
-    expect(killButtons.length).toBeGreaterThan(0);
-    fireEvent.click(killButtons[0]!);
+    fireEvent.click(getByRole("button", { name: "Terminate session 101" }));
 
     expect(queryByText("Terminate Session?")).not.toBeNull();
     const terminateButton = queryByText("Terminate");


### PR DESCRIPTION
## Description
Six controls have no accessible name, including session termination and column removal. Add action-specific aria-labels, keeping the monitoring Back button named when its responsive text is hidden. Include session IDs and column numbers to distinguish repeated controls.

## Type of Change
- [x] Bug fix

## Related Issue
Closes #686

## Changes Made
- Name pool refresh, monitoring Back, session termination in monitoring and admin, column removal, and schema-diagram close.
- Update five existing interaction regressions to find controls by role and accessible name, preserving their action assertions.
- Add a Back regression that hides the responsive text and verifies the named button still navigates home.
- Audit all 13 literal size="icon" controls under src/components: twelve now have naming attributes; the remaining SidebarTrigger already has sr-only "Toggle Sidebar" text.

## Testing
- [x] Before implementation, all six accessible-name checks fail on the original components. The initial Back test had a missing fireEvent import; corrected it and repeated the complete component run to establish the six intended failures.
- [x] Full `bun run test`: 14,714 passes, zero failures, all 34 component groups. All six named-control interaction checks pass.
- [x] Full `bun run test:coverage` and threshold check: 46,335/46,335 lines (100%).
- [x] Format, lint, typecheck, knip, chart/channel/README/security guards, `build:lib`, and diff checks pass.
- [x] All twelve published files match the tested local patch exactly.

## Test Environment
macOS arm64; Node 26.5.0; Bun 1.4.2; GNU Bash 5.2.37; Helm 4.1.3; 7-Zip 26.03.

## Checklist
- [x] Labels describe the controls' actions.
- [x] Repeated session and column controls have distinct names.
- [x] Existing click behavior and confirmation flows remain covered.
- [x] No dependencies added.

## Additional Notes
AI-assisted implementation and validation. The mobile regression models hidden text in the DOM test environment; no live screen-reader or browser-rendering verification is claimed. Existing lint warnings remain without errors.

Production `bun run build` remains for CI: the same base/dependency set hit a local Turbopack worker-port permission error in #706 even after a broader-permission retry. That environment-limited production build was not repeated here.
