### PR TITLE
fix(ui): remove inert settings cog from desktop header

### DIFF
--- a/src/components/studio/StudioDesktopHeader.tsx
+++ b/src/components/studio/StudioDesktopHeader.tsx
@@ -113,10 +113,6 @@ export function StudioDesktopHeader({
             </DropdownMenuContent>
           </DropdownMenu>
         )}
-        <Settings
-          strokeWidth={1.5}
-          className="w-3.5 h-3.5 text-fg-tertiary cursor-pointer hover:text-fg-bright transition-colors mx-2"
-        />
         {/* Renders nothing when a host (platform) owns the theme — see ThemeToggle. */}
         <ThemeToggle className="mr-1" />
         <GitHubRepoLink className="text-fg-tertiary hover:text-fg-bright mr-2" />

--- a/tests/components/studio/StudioDesktopHeader.test.tsx
+++ b/tests/components/studio/StudioDesktopHeader.test.tsx
@@ -230,6 +230,22 @@ describe("StudioDesktopHeader", () => {
 
   // ── User Dropdown Menu ──
 
+  test.each([
+    ["anonymous", null, false],
+    ["regular user", { role: "user" }, false],
+    ["admin", { role: "admin" }, true],
+  ] as const)("%s sees settings only in an actionable admin menu item", (_name, user, isAdmin) => {
+    const { container } = render(<StudioDesktopHeader {...defaultProps} user={user} isAdmin={isAdmin} />);
+    const settingsIcons = container.querySelectorAll("svg.lucide-settings");
+    expect(settingsIcons.length).toBe(isAdmin ? 1 : 0);
+    for (const icon of settingsIcons) {
+      const action = icon.closest('[role="menuitem"]');
+      expect(action).not.toBeNull();
+      fireEvent.click(action!);
+      expect(mockRouterPush).toHaveBeenCalledWith("/admin");
+    }
+  });
+
   describe("user dropdown menu", () => {
     test("renders user dropdown when user exists", () => {
       const { container } = render(<StudioDesktopHeader {...defaultProps} />);


### PR DESCRIPTION
## Description
The desktop header shows a standalone settings cog with pointer and hover styling but no click handler or destination. Remove the inert icon, using the removal option proposed in #700, while preserving the working Admin Dashboard menu action.

## Type of Change
- [x] Bug fix

## Related Issue
Closes #700

## Changes Made
- Remove the four-line standalone Settings SVG from StudioDesktopHeader.
- Add rendered regression cases for anonymous, regular-user, and admin headers. Only the admin menu may retain a settings icon, and clicking that action must navigate to /admin.

## Testing
- [x] All three new cases fail on the original header because each state renders one extra settings icon.
- [x] Full `bun run test`: 14,716 passes, zero failures, all 34 component groups. All three regression cases pass.
- [x] Full `bun run test:coverage` and threshold check: 46,320/46,320 lines (100%).
- [x] Format, lint, typecheck, knip, chart/channel/README/security guards, `build:lib`, and diff checks pass.
- [x] Both published files match the tested local source exactly.

## Test Environment
macOS arm64; Node 26.5.0; Bun 1.4.2; GNU Bash 5.2.37; Helm 4.1.3; 7-Zip 26.03.

## Checklist
- [x] Focused two-file change.
- [x] Existing Admin Dashboard action retained and tested.
- [x] No new dependencies or settings routes.

## Additional Notes
AI-assisted implementation and validation. Tests render the component with existing test mocks; no live-browser verification is claimed. Lint reports existing warnings without errors.

Production `bun run build` remains for CI: the same base/dependency set hit a local Turbopack worker-port permission error in #706 even after a broader-permission retry. That environment-limited production build was not repeated here.
