### PR TITLE
fix(auth): derive minimum-length messages from the shared constant

### DIFF
--- a/src/lib/auth-bootstrap.ts
+++ b/src/lib/auth-bootstrap.ts
@@ -12,6 +12,7 @@ import { getDataDir } from "@/lib/data-dir";
 import { JWT_SECRET_MIN_LENGTH } from "@/lib/config/auth-env";
 
 export const BOOTSTRAP_FILE_NAME = "auth-bootstrap.json";
+export const BOOTSTRAP_JWT_SECRET_INVALID_MESSAGE = `bootstrap file jwtSecret is not a string of at least ${JWT_SECRET_MIN_LENGTH} chars`;
 
 interface BootstrapFile {
   jwtSecret?: string;
@@ -62,7 +63,7 @@ function readBootstrapFile(filePath: string): BootstrapFile {
     // hand-edited short secret must regenerate here instead of being injected
     // and wedging every login on a misleading "JWT_SECRET too short" 503.
     if (jwtSecret !== undefined && (typeof jwtSecret !== "string" || jwtSecret.length < JWT_SECRET_MIN_LENGTH)) {
-      throw new Error("bootstrap file jwtSecret is not a string of at least 32 chars");
+      throw new Error(BOOTSTRAP_JWT_SECRET_INVALID_MESSAGE);
     }
     if (adminPassword !== undefined && typeof adminPassword !== "string") {
       throw new Error("bootstrap file adminPassword is not a string");

--- a/src/lib/config/auth-env.ts
+++ b/src/lib/config/auth-env.ts
@@ -5,7 +5,7 @@
  * proxy.ts, oidc.ts) into one module with the strictest semantics:
  * - missing in production -> AuthConfigError (login route maps it to a clear 503)
  * - missing outside production -> well-known development fallback (with warning)
- * - present but shorter than 32 characters -> AuthConfigError
+ * - present but shorter than JWT_SECRET_MIN_LENGTH -> AuthConfigError
  *
  * The reader is stateless and reads the environment on every call; consumers
  * that want memoization keep their own lazy cache so a module-level throw can
@@ -14,14 +14,6 @@
 
 import { AuthConfigError } from "@/lib/auth-errors";
 
-// Single-line messages, hoisted to module scope: bun's line coverage under-counts
-// the continuation lines of multi-line string concatenation, which would show as
-// uncovered "new code" in SonarCloud even though the throw is exercised by tests.
-export const JWT_SECRET_MISSING_MESSAGE =
-  "Login is unavailable: the server's JWT_SECRET is not configured. Set JWT_SECRET (at least 32 characters) and restart the server.";
-export const JWT_SECRET_TOO_SHORT_MESSAGE =
-  "Login is unavailable: the server's JWT_SECRET is too short; it must be at least 32 characters. Update JWT_SECRET and restart the server.";
-
 /**
  * Minimum accepted JWT_SECRET length. Single source of truth: the boot preflight
  * (auth-preflight.ts) and the bootstrap file reader (auth-bootstrap.ts) enforce
@@ -29,7 +21,14 @@ export const JWT_SECRET_TOO_SHORT_MESSAGE =
  */
 export const JWT_SECRET_MIN_LENGTH = 32;
 
-const DEV_FALLBACK_SECRET = "development-fallback-secret-32ch";
+// Single-line messages, hoisted to module scope: bun's line coverage under-counts
+// the continuation lines of multi-line string concatenation, which would show as
+// uncovered "new code" in SonarCloud even though the throw is exercised by tests.
+export const JWT_SECRET_MISSING_MESSAGE = `Login is unavailable: the server's JWT_SECRET is not configured. Set JWT_SECRET (at least ${JWT_SECRET_MIN_LENGTH} characters) and restart the server.`;
+export const JWT_SECRET_TOO_SHORT_MESSAGE = `Login is unavailable: the server's JWT_SECRET is too short; it must be at least ${JWT_SECRET_MIN_LENGTH} characters. Update JWT_SECRET and restart the server.`;
+
+/** Exported for the guard that checks the development fallback meets the enforced minimum. */
+export const DEV_FALLBACK_SECRET = "development-fallback-secret-32ch";
 
 export interface JwtSecretOptions {
   /**

--- a/src/lib/storage/encryption.ts
+++ b/src/lib/storage/encryption.ts
@@ -49,11 +49,9 @@ const HKDF_SALT = new Uint8Array(0);
 
 // Single-line messages, hoisted to module scope: bun's line coverage under-counts the continuation
 // lines of a wrapped string literal, which then reads as uncovered code. Same reason as
-// src/lib/config/auth-env.ts:20.
-export const STORAGE_ENCRYPTION_KEY_TOO_SHORT_MESSAGE =
-  "STORAGE_ENCRYPTION_KEY is too short; it must be at least 32 characters. Update it and restart the server.";
-export const STORAGE_ENCRYPTION_KEY_MISSING_MESSAGE =
-  "Server storage cannot encrypt credentials: neither STORAGE_ENCRYPTION_KEY nor JWT_SECRET is configured. Set one (at least 32 characters) and restart the server.";
+// src/lib/config/auth-env.ts.
+export const STORAGE_ENCRYPTION_KEY_TOO_SHORT_MESSAGE = `STORAGE_ENCRYPTION_KEY is too short; it must be at least ${JWT_SECRET_MIN_LENGTH} characters. Update it and restart the server.`;
+export const STORAGE_ENCRYPTION_KEY_MISSING_MESSAGE = `Server storage cannot encrypt credentials: neither STORAGE_ENCRYPTION_KEY nor JWT_SECRET is configured. Set one (at least ${JWT_SECRET_MIN_LENGTH} characters) and restart the server.`;
 
 /**
  * Derived once per process. A key is on the write path of every storage push, so re-deriving per

--- a/tests/unit/lib/config/auth-message-drift.test.ts
+++ b/tests/unit/lib/config/auth-message-drift.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import * as authEnv from "@/lib/config/auth-env";
+import * as authBootstrap from "@/lib/auth-bootstrap";
+import {
+  STORAGE_ENCRYPTION_KEY_MISSING_MESSAGE,
+  STORAGE_ENCRYPTION_KEY_TOO_SHORT_MESSAGE,
+} from "@/lib/storage/encryption";
+
+const ROOT = path.resolve(import.meta.dir, "../../../..");
+
+describe("minimum-length message guard", () => {
+  test("all five operator messages quote the enforced minimum", () => {
+    const messages = [
+      authEnv.JWT_SECRET_MISSING_MESSAGE,
+      authEnv.JWT_SECRET_TOO_SHORT_MESSAGE,
+      STORAGE_ENCRYPTION_KEY_MISSING_MESSAGE,
+      STORAGE_ENCRYPTION_KEY_TOO_SHORT_MESSAGE,
+      authBootstrap.BOOTSTRAP_JWT_SECRET_INVALID_MESSAGE,
+    ];
+    for (const message of messages) {
+      expect(message).toContain(`at least ${authEnv.JWT_SECRET_MIN_LENGTH} char`);
+    }
+  });
+
+  test("minimum-length messages contain no literal numeric floor and keep each template on one line", () => {
+    const files = ["src/lib/config/auth-env.ts", "src/lib/storage/encryption.ts", "src/lib/auth-bootstrap.ts"];
+    const templates = files.flatMap((file) => {
+      const source = readFileSync(path.join(ROOT, file), "utf8");
+      expect(source).not.toMatch(/at least \d+ chars?/);
+      return [...source.matchAll(/`[^`]*at least \$\{JWT_SECRET_MIN_LENGTH\}[^`]*`/g)];
+    });
+    expect(templates).toHaveLength(5);
+    for (const [template] of templates) expect(template).not.toMatch(/[\r\n]/);
+  });
+
+  test("the development fallback meets the enforced minimum", () => {
+    expect(authEnv.DEV_FALLBACK_SECRET.length).toBeGreaterThanOrEqual(authEnv.JWT_SECRET_MIN_LENGTH);
+  });
+});


### PR DESCRIPTION
## Description

Five JWT/storage/bootstrap messages hardcode a minimum that can drift from the enforced value. Derive their text from `JWT_SECRET_MIN_LENGTH`, preserving the single-line templates and the current validation behavior.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #672

## Changes Made

- Use the shared constant in all five messages and in the auth module documentation.
- Export the existing development fallback for its length guard, and hoist the bootstrap message so the guard checks the actual runtime value.
- Add guards for message text, single-line templates, and the fallback's minimum length.

## Testing

`bun run test:unit -t 'minimum-length message guard'`: **0 passed / 3 failed before**, **3 passed / 0 failed after**. Temporarily setting `JWT_SECRET_MIN_LENGTH` to **48** produced **2 passed / 1 failed**: all messages followed the new minimum, while the existing fallback correctly failed its length guard. Restored the constant before committing. The minimum remains 32, the fallback value is unchanged, and no cryptographic key size changes.

Full Linux validation used the repository's **unchanged CI workflow** on submitted commit `a44413edcb448f151f05e29dcc3c9562ee14cd17`: [run and logs](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34309186636).

- `bun run test:coverage`: **14,716 tests passed**, all **392 core test files** and **34 component isolation groups** passed.
- `bun run coverage:check`: **46,321 / 46,321 lines (100%)**.
- Format, lint, typecheck, knip, README/chart/channel/security drift guards, application/library builds, package type-resolution checks, Helm lint, and Go launcher checks passed.
- Browser E2E **65 passed**, subpath E2E **1 passed**, PostgreSQL functional smoke **1 passed**, packaged tarball/npx E2E **3 passed each**, Node 24/26 engine smoke passed.
- [Secret Scan, Dependency Scan, and Image Scan](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34309376137) passed. The manual secret scan fetched and scanned all fork history and branches, including this commit.

The fork run's overall status is red solely because **SonarCloud Analysis** lacks the upstream token/project access. All test/build jobs passed. CLAUDE.md explicitly excludes SonarCloud from required checks, and the upstream workflow skips it for fork PRs. Upstream required workflows still need normal maintainer approval.

Full validation ran on GitHub-hosted Linux: this Windows host cannot run the container-based checks because Docker Desktop fails at inference-manager initialization, and its native full component runner encounters SQLite cleanup `EBUSY`. No complete native-Windows pass is claimed.

## Checklist

- [x] Issue acceptance criteria checked; actual validation results recorded above.
- [x] Full tests and the 100% line-coverage gate passed on the submitted commit.
- [x] Diff reviewed; no database-provider changes requiring the provider triad.

## Additional Notes

AI-assisted implementation, review, and validation. This branch starts independently from `main` and contains only this issue's change.

<!-- codex-ci-followup-732 -->
## CI follow-up

The fork-run SonarCloud 401 is tracked in #732 and fixed by #733. The inherited condition admitted fork-owned pushes and fork-local PRs to the canonical SonarCloud project. [The dedicated CI fix run](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321083163) now succeeds: all nine executable test/build jobs pass, and SonarCloud is scoped to the canonical repository. That run tests CI fix commit `80a318b`; this PR's exact-head verification remains the original run linked above, whose nine executable jobs passed. Upstream Actions still await maintainer approval.
