### PR TITLE
refactor(llm): derive valid providers and expose direct env reads

### DIFF
--- a/src/lib/llm/utils/config.ts
+++ b/src/lib/llm/utils/config.ts
@@ -18,6 +18,8 @@ export const DEFAULT_MODELS: Record<LLMProviderType, string> = {
   custom: "gpt-3.5-turbo",
 };
 
+const VALID_PROVIDERS = Object.keys(DEFAULT_MODELS) as LLMProviderType[];
+
 export const DEFAULT_API_URLS: Record<string, string> = {
   ollama: "http://localhost:11434/v1",
   openai: "https://api.openai.com/v1",
@@ -27,20 +29,14 @@ export const DEFAULT_API_URLS: Record<string, string> = {
 // Environment Resolution
 // ============================================================================
 
-function getEnvVar(key: string): string | undefined {
-  return process.env[key];
-}
-
 function resolveProvider(): LLMProviderType {
-  const provider = getEnvVar("LLM_PROVIDER")?.toLowerCase();
+  const provider = process.env.LLM_PROVIDER?.toLowerCase();
 
   if (!provider) {
     return DEFAULT_PROVIDER;
   }
 
-  const validProviders: LLMProviderType[] = ["gemini", "openai", "ollama", "custom"];
-
-  if (!validProviders.includes(provider as LLMProviderType)) {
+  if (!VALID_PROVIDERS.includes(provider as LLMProviderType)) {
     console.error(`[LLM] Invalid provider "${provider}", falling back to "${DEFAULT_PROVIDER}"`);
     return DEFAULT_PROVIDER;
   }
@@ -49,7 +45,7 @@ function resolveProvider(): LLMProviderType {
 }
 
 function resolveApiKey(provider: LLMProviderType): string | undefined {
-  const apiKey = getEnvVar("LLM_API_KEY");
+  const apiKey = process.env.LLM_API_KEY;
 
   // Ollama doesn't require API key
   if (!apiKey && provider === "ollama") {
@@ -60,13 +56,13 @@ function resolveApiKey(provider: LLMProviderType): string | undefined {
 }
 
 function resolveModel(provider: LLMProviderType): string {
-  const model = getEnvVar("LLM_MODEL");
+  const model = process.env.LLM_MODEL;
   return model || DEFAULT_MODELS[provider];
 }
 
 function resolveApiUrl(provider: LLMProviderType): string | undefined {
   // Primary: LLM_API_URL
-  const apiUrl = getEnvVar("LLM_API_URL");
+  const apiUrl = process.env.LLM_API_URL;
   if (apiUrl) {
     return apiUrl;
   }
@@ -116,10 +112,9 @@ export function resolveConfig(overrides?: Partial<LLMConfig>): LLMConfig {
  */
 export function validateConfig(config: LLMConfig): void {
   // Validate provider
-  const validProviders: LLMProviderType[] = ["gemini", "openai", "ollama", "custom"];
-  if (!validProviders.includes(config.provider)) {
+  if (!VALID_PROVIDERS.includes(config.provider)) {
     throw new LLMConfigError(
-      `Invalid provider: ${config.provider}. Valid options: ${validProviders.join(", ")}`,
+      `Invalid provider: ${config.provider}. Valid options: ${VALID_PROVIDERS.join(", ")}`,
       config.provider,
     );
   }

--- a/tests/unit/env-documentation.test.ts
+++ b/tests/unit/env-documentation.test.ts
@@ -30,11 +30,10 @@
  *
  * What stays out of scope: a name that reaches `process.env[...]` as a function
  * argument or parameter, because resolving it needs a call graph and a regex
- * that faked one would report a name that is not a name. Two reads are in that
- * position today -- `getEnvVar("LLM_PROVIDER")` in `src/lib/llm/utils/config.ts`
- * and `process.env[envVar]` in `src/lib/seed/credential-resolver.ts` -- leaving
- * `HOSTNAME`, `MY_DB_PASSWORD` and the four `LLM_*` names undiscovered. That is
- * the whole remaining gap, not an aside.
+ * that faked one would report a name that is not a name. The only remaining
+ * read in that position is `process.env[envVar]` in
+ * `src/lib/seed/credential-resolver.ts`, leaving `HOSTNAME` and `MY_DB_PASSWORD`
+ * undiscovered. The four direct `LLM_*` reads are covered.
  */
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -175,16 +174,20 @@ describe("environment variable documentation", () => {
   });
 
   test("#609 boundary: a name reached through a function argument stays undiscovered", () => {
-    // getEnvVar("LLM_PROVIDER") in src/lib/llm/utils/config.ts and
-    // process.env[envVar] in src/lib/seed/credential-resolver.ts need a call
+    // process.env[envVar] in src/lib/seed/credential-resolver.ts needs a call
     // graph. When that stops being true, this test is the reminder to widen the
     // extractor rather than a silent gain.
     const names = new Set(readNames());
     // Control: a negative-only test passes on an empty set, so anchor it to a
     // name the extractor must always find before trusting the absences below.
     expect(names.has("JWT_SECRET")).toBe(true);
-    for (const name of ["LLM_PROVIDER", "LLM_API_KEY", "LLM_MODEL", "LLM_API_URL", "MY_DB_PASSWORD"]) {
-      expect(names.has(name)).toBe(false);
+    expect(names.has("MY_DB_PASSWORD")).toBe(false);
+  });
+
+  test("LLM configuration reads are visible to the documentation guard", () => {
+    const names = new Set(readNames());
+    for (const name of ["LLM_PROVIDER", "LLM_API_KEY", "LLM_MODEL", "LLM_API_URL"]) {
+      expect(names.has(name), name).toBe(true);
     }
   });
 

--- a/tests/unit/llm/config.test.ts
+++ b/tests/unit/llm/config.test.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_MODELS,
   DEFAULT_API_URLS,
 } from "@/lib/llm/utils/config";
-import { LLMConfigError } from "@/lib/llm/types";
+import { LLMConfigError, type LLMProviderType } from "@/lib/llm/types";
 
 // ============================================================================
 // Environment Variable Helpers
@@ -129,6 +129,22 @@ describe("resolveConfig", () => {
 // ============================================================================
 
 describe("validateConfig", () => {
+  test("accepts every provider in DEFAULT_MODELS and rejects an unknown provider", () => {
+    for (const provider of Object.keys(DEFAULT_MODELS) as LLMProviderType[]) {
+      expect(() =>
+        validateConfig({
+          provider,
+          model: DEFAULT_MODELS[provider],
+          apiKey: "test-key",
+          apiUrl: "https://example.test/v1",
+        }),
+      ).not.toThrow();
+    }
+    expect(() => validateConfig({ provider: "unknown-provider" as LLMProviderType, model: "test-model" })).toThrow(
+      LLMConfigError,
+    );
+  });
+
   test("valid gemini config with key passes", () => {
     expect(() =>
       validateConfig({


### PR DESCRIPTION
## Description

The LLM configuration duplicates its provider list and hides four environment reads from the documentation guard. Derive the provider list from `DEFAULT_MODELS` and read the four `LLM_*` variables directly, preserving resolution and validation behavior.

## Type of Change

- [x] Code refactoring

## Related Issue

Closes #673

## Changes Made

- Reuse `Object.keys(DEFAULT_MODELS)` in provider resolution, validation, and the invalid-provider message.
- Remove `getEnvVar` and update the environment guard's coverage-boundary description.
- Add a provider-validation case derived from the model map. Replace the old assertion that LLM names are undiscovered with a positive discovery assertion; dynamic seed credentials remain outside the guard.

## Testing

`bun run test:unit -t 'environment variable documentation|accepts every provider in DEFAULT_MODELS'`: **10 passed / 0 failed** after the refactor. The provider case accepts every key derived from `Object.keys(DEFAULT_MODELS)` and rejects an unknown provider; the new discovery assertion failed before the direct reads were introduced.

Mutation proof: temporarily removed all **six active/commented `LLM_MODEL=` assignments** from `.env.example`, then ran `bun run test:unit -t 'environment variable documentation'`: **8 passed / 1 failed**, reporting `LLM_MODEL` as undocumented. All six must be removed because the existing extractor intentionally accepts commented examples. Restored `.env.example` byte-for-byte; it has no diff in this PR.

Full Linux validation used the repository's **unchanged CI workflow** on submitted commit `d87c448832369537d6256f82948556bbd6737b22`: [run and logs](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34309195350).

- `bun run test:coverage`: **14,715 tests passed**, all **391 core test files** and **34 component isolation groups** passed.
- `bun run coverage:check`: **46,321 / 46,321 lines (100%)**.
- Format, lint, typecheck, knip, README/chart/channel/security drift guards, application/library builds, package type-resolution checks, Helm lint, and Go launcher checks passed.
- Browser E2E **65 passed**, subpath E2E **1 passed**, PostgreSQL functional smoke **1 passed**, packaged tarball/npx E2E **3 passed each**, Node 24/26 engine smoke passed.
- [Secret Scan, Dependency Scan, and Image Scan](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34309376137) passed. The manual secret scan fetched and scanned all fork history and branches, including this commit.

The fork run's overall status is red solely because **SonarCloud Analysis** lacks the upstream token/project access. All test/build jobs passed. CLAUDE.md explicitly excludes SonarCloud from required checks, and the upstream workflow skips it for fork PRs. Upstream required workflows still need normal maintainer approval.

Full validation ran on GitHub-hosted Linux: this Windows host cannot run the container-based checks because Docker Desktop fails at inference-manager initialization, and its native full component runner encounters SQLite cleanup `EBUSY`. No complete native-Windows pass is claimed.

## Checklist

- [x] Issue acceptance criteria checked; actual validation results recorded above.
- [x] Full tests and the 100% line-coverage gate passed on the submitted commit.
- [x] Diff reviewed; no database-provider changes requiring the provider triad.

## Additional Notes

AI-assisted implementation, review, and validation. This branch starts independently from `main` and contains only this issue's change.

<!-- codex-ci-followup-732 -->
## CI follow-up

The fork-run SonarCloud 401 is tracked in #732 and fixed by #733. The inherited condition admitted fork-owned pushes and fork-local PRs to the canonical SonarCloud project. [The dedicated CI fix run](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321083163) now succeeds: all nine executable test/build jobs pass, and SonarCloud is scoped to the canonical repository. That run tests CI fix commit `80a318b`; this PR's exact-head verification remains the original run linked above, whose nine executable jobs passed. Upstream Actions still await maintainer approval.
