### PR TITLE
fix: add support and private security-reporting issue contacts

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and support
+    url: https://github.com/libredb/libredb-studio/discussions
+    about: Ask configuration and usage questions in GitHub Discussions.
+  - name: Report a security vulnerability privately
+    url: https://github.com/libredb/libredb-studio/blob/main/SECURITY.md#reporting-a-vulnerability
+    about: Follow the security policy for private reporting. Do not open a public issue.

--- a/tests/unit/issue-template-config.test.ts
+++ b/tests/unit/issue-template-config.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parse } from "yaml";
+
+const ROOT = path.resolve(import.meta.dir, "../..");
+const readConfig = () => parse(readFileSync(path.join(ROOT, ".github/ISSUE_TEMPLATE/config.yml"), "utf8"));
+
+describe("issue template contacts", () => {
+  test("keeps blank issues available explicitly", () => {
+    expect(readConfig().blank_issues_enabled).toBe(true);
+  });
+
+  test("routes questions to Discussions and vulnerabilities to the private reporting policy", () => {
+    const links = readConfig().contact_links;
+    expect(links).toHaveLength(2);
+    expect(links.map((link: { url: string }) => link.url)).toEqual([
+      "https://github.com/libredb/libredb-studio/discussions",
+      "https://github.com/libredb/libredb-studio/blob/main/SECURITY.md#reporting-a-vulnerability",
+    ]);
+    for (const link of links) {
+      expect(link.name.trim().length).toBeGreaterThan(0);
+      expect(link.about.trim().length).toBeGreaterThan(0);
+    }
+    const securityPolicy = readFileSync(path.join(ROOT, "SECURITY.md"), "utf8");
+    expect(securityPolicy).toContain("## Reporting a Vulnerability");
+    expect(securityPolicy).toContain("Please do not report security vulnerabilities through public GitHub issues.");
+  });
+});


### PR DESCRIPTION
## Description

The issue chooser provides no route to Discussions or the private vulnerability-reporting policy. Add both contact links and explicitly set **`blank_issues_enabled: true`**, preserving the current availability of blank issues.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #682

## Changes Made

- Add `.github/ISSUE_TEMPLATE/config.yml` with Discussions and SECURITY.md's reporting-section links.
- Put the private-reporting warning in the security contact's name/description.
- Validate the YAML with the existing parser and guard its destinations, labels, blank-issue setting, and security-policy anchor.

## Testing

`bun run test:unit -t 'issue template contacts'`: **0 passed / 2 failed before** the configuration existed, **2 passed / 0 failed after**. Verified that Discussions is enabled upstream and that SECURITY.md contains the linked reporting heading and private-disclosure guidance. The GitHub-hosted chooser will use this configuration after it lands on the default branch.

Full Linux validation used the repository's **unchanged CI workflow** on submitted commit `9939e20f7025596b26e1df9999050b65308872ce`: [run and logs](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34309201592).

- `bun run test:coverage`: **14,715 tests passed**, all **392 core test files** and **34 component isolation groups** passed.
- `bun run coverage:check`: **46,324 / 46,324 lines (100%)**.
- Format, lint, typecheck, knip, README/chart/channel/security drift guards, application/library builds, package type-resolution checks, Helm lint, and Go launcher checks passed.
- Browser E2E **65 passed**, subpath E2E **1 passed**, PostgreSQL functional smoke **1 passed**, packaged tarball/npx E2E **3 passed each**, Node 24/26 engine smoke passed.
- [Secret Scan, Dependency Scan, and Image Scan](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34309376137) passed. The manual secret scan fetched and scanned all fork history and branches, including this commit.

The fork run's overall status is red solely because **SonarCloud Analysis** lacks the upstream token/project access. All test/build jobs passed. CLAUDE.md explicitly excludes SonarCloud from required checks, and the upstream workflow skips it for fork PRs. Upstream required workflows still need normal maintainer approval.

Full validation ran on GitHub-hosted Linux: this Windows host cannot run the container-based checks because Docker Desktop fails at inference-manager initialization, and its native full component runner encounters SQLite cleanup `EBUSY`. No complete native-Windows pass is claimed.

## Checklist

- [x] Issue acceptance criteria checked; actual validation results recorded above.
- [x] Full tests and the 100% line-coverage gate passed on the submitted commit.
- [x] Diff reviewed; no database-provider changes requiring the provider triad.

## Additional Notes

AI-assisted implementation, review, and validation. This branch starts independently from `main` and contains only this issue's change.

<!-- codex-ci-followup-732 -->
## CI follow-up

The fork-run SonarCloud 401 is tracked in #732 and fixed by #733. The inherited condition admitted fork-owned pushes and fork-local PRs to the canonical SonarCloud project. [The dedicated CI fix run](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321083163) now succeeds: all nine executable test/build jobs pass, and SonarCloud is scoped to the canonical repository. That run tests CI fix commit `80a318b`; this PR's exact-head verification remains the original run linked above, whose nine executable jobs passed. Upstream Actions still await maintainer approval.
