### PR TITLE
fix(elasticsearch): support fieldMultiValueLeniency for array columns

### DIFF
--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -628,13 +628,13 @@ column ([§6](#6-schema-introspection)) — and the fork *allows* the container 
 deliberately not branched on, because a starter query that works on one product and fails on the other
 is worse than one that works on both.
 
-**A multi-valued field is projected as one value.** On the pinned 9.1.4 image, `SELECT tags FROM
-arrprobe` is HTTP 400 without `field_multi_value_leniency` and HTTP 200 with it, returning the first
-value in source order. The sharp edge is that matching and display are different operations:
-`SELECT tags FROM arrprobe WHERE tags = 'alpha'` matches every measured row but can display `zebra`,
-so the value shown is not necessarily the value that satisfied the predicate. The transport enables
-that option for Elasticsearch SQL requests; cursor paging preserves it, so later cursor-only pages do
-not need to resend the option.
+**Multi-valued fields are selectable, but the projected value is lossy.** Measured on 9.1.4:
+`SELECT tags FROM arrprobe` is HTTP 400 unless SQL field leniency is enabled, so the provider sets
+`field_multi_value_leniency` on Elasticsearch queries. The result still contains only one element
+rather than the complete array. The important trap is that filtering sees the whole field while
+projection does not: `SELECT tags FROM arrprobe WHERE tags = 'alpha'` matched the row while
+displaying `zebra` for `tags`. The value shown in the grid therefore is not necessarily the value that
+satisfied the predicate. A 1200-document probe also confirmed that the setting survives cursor paging.
 
 ### 5.5 The `prepareQuery()` override: there is no second page
 

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -628,6 +628,14 @@ column ([§6](#6-schema-introspection)) — and the fork *allows* the container 
 deliberately not branched on, because a starter query that works on one product and fails on the other
 is worse than one that works on both.
 
+**A multi-valued field is projected as one value.** On the pinned 9.1.4 image, `SELECT tags FROM
+arrprobe` is HTTP 400 without `field_multi_value_leniency` and HTTP 200 with it, returning the first
+value in source order. The sharp edge is that matching and display are different operations:
+`SELECT tags FROM arrprobe WHERE tags = 'alpha'` matches every measured row but can display `zebra`,
+so the value shown is not necessarily the value that satisfied the predicate. The transport enables
+that option for Elasticsearch SQL requests; cursor paging preserves it, so later cursor-only pages do
+not need to resend the option.
+
 ### 5.5 The `prepareQuery()` override: there is no second page
 
 Measured: `SELECT customer FROM probe_orders LIMIT 2 OFFSET 1` is HTTP 400,

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -621,6 +621,10 @@ where `elasticsearch` is `"standard"` (a backslash there is data).
 than a mapped field and because the same statement is not portable to the sibling type-id
 ([§6](#6-schema-introspection)).
 
+**Multi-valued fields stay arrays here.** On the pinned 3.8.0 image, `SELECT tags FROM arrprobe`
+returns the whole array with no extra request option. That is deliberately asymmetric with
+Elasticsearch 9.1.4, which needs `field_multi_value_leniency` and projects one value instead.
+
 **Block comments do not nest**, same as upstream: `SELECT /* a /* b */ 1 AS a` is HTTP 200, so the
 first `*/` closed the run.
 

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -621,9 +621,9 @@ where `elasticsearch` is `"standard"` (a backslash there is data).
 than a mapped field and because the same statement is not portable to the sibling type-id
 ([§6](#6-schema-introspection)).
 
-**Multi-valued fields stay arrays here.** On the pinned 3.8.0 image, `SELECT tags FROM arrprobe`
-returns the whole array with no extra request option. That is deliberately asymmetric with
-Elasticsearch 9.1.4, which needs `field_multi_value_leniency` and projects one value instead.
+**Multi-valued fields stay multi-valued.** Measured on 3.8.0: `SELECT tags FROM arrprobe`
+returns the complete array in the result cell with an ordinary SQL request. No additional query option
+is required.
 
 **Block comments do not nest**, same as upstream: `SELECT /* a /* b */ 1 AS a` is HTTP 200, so the
 first `*/` closed the run.

--- a/src/lib/db/providers/sql/search/http-transport.ts
+++ b/src/lib/db/providers/sql/search/http-transport.ts
@@ -281,7 +281,7 @@ interface SearchDialectSpec {
   readonly sqlPath: string;
   readonly sqlQuery: string;
   /** Whether SQL should tolerate multi-valued fields. Elasticsearch supports this request option. */
-  readonly fieldMultiValueLeniency?: boolean;
+  readonly fieldMultiValueLeniency: boolean;
   /** The success envelope's declared-columns key. */
   readonly columnsKey: string;
   /**
@@ -361,6 +361,7 @@ const DIALECTS: Readonly<Record<SearchDialectId, SearchDialectSpec>> = Object.fr
     label: "OpenSearch",
     sqlPath: "/_plugins/_sql",
     sqlQuery: "",
+    fieldMultiValueLeniency: false,
     columnsKey: "schema",
     aliasKey: "alias",
     rowsKey: "datarows",
@@ -884,7 +885,7 @@ export class SearchHttpTransport implements SearchTransport {
         signal,
         JSON.stringify({
           query: sql,
-          ...(this.spec.fieldMultiValueLeniency === true ? { field_multi_value_leniency: true } : {}),
+          ...(this.spec.fieldMultiValueLeniency ? { field_multi_value_leniency: true } : {}),
         }),
       ),
     );

--- a/src/lib/db/providers/sql/search/http-transport.ts
+++ b/src/lib/db/providers/sql/search/http-transport.ts
@@ -280,6 +280,8 @@ interface SearchDialectSpec {
   /** The SQL endpoint, and the query string it needs (empty when it needs none). */
   readonly sqlPath: string;
   readonly sqlQuery: string;
+  /** Whether SQL should tolerate multi-valued fields. Elasticsearch supports this request option. */
+  readonly fieldMultiValueLeniency?: boolean;
   /** The success envelope's declared-columns key. */
   readonly columnsKey: string;
   /**
@@ -321,6 +323,7 @@ const DIALECTS: Readonly<Record<SearchDialectId, SearchDialectSpec>> = Object.fr
     label: "Elasticsearch",
     sqlPath: "/_sql",
     sqlQuery: "format=json",
+    fieldMultiValueLeniency: true,
     columnsKey: "columns",
     // Elasticsearch folds the alias into `name`, so there is no separate member.
     aliasKey: null,
@@ -875,7 +878,16 @@ export class SearchHttpTransport implements SearchTransport {
   public async query(sql: string, signal?: AbortSignal): Promise<SearchQueryResult> {
     const path = `${this.spec.sqlPath}${this.spec.sqlQuery === "" ? "" : `?${this.spec.sqlQuery}`}`;
 
-    const first = asRecord(await this.request(path, signal, JSON.stringify({ query: sql })));
+    const first = asRecord(
+      await this.request(
+        path,
+        signal,
+        JSON.stringify({
+          query: sql,
+          ...(this.spec.fieldMultiValueLeniency === true ? { field_multi_value_leniency: true } : {}),
+        }),
+      ),
+    );
     if (first === null) throw unreadableBody(this.spec, "a SQL result");
 
     const result = toQueryResult(this.spec, first);

--- a/tests/integration/db/elasticsearch-provider.test.ts
+++ b/tests/integration/db/elasticsearch-provider.test.ts
@@ -57,6 +57,10 @@ const CONNECT_PROBE = "SELECT 1";
 /** Both the endpoint path and the query string are product-specific (measured). */
 const SQL_PATH = "/_sql?format=json";
 
+const SQL_QUERY_OPTIONS = {
+  field_multi_value_leniency: true,
+} as const;
+
 function makeConnection(overrides: Partial<DatabaseConnection> = {}): DatabaseConnection {
   return {
     id: "es-1",
@@ -1056,6 +1060,20 @@ describe("ElasticsearchProvider lifecycle", () => {
 // ============================================================================
 
 describe("ElasticsearchProvider query", () => {
+  test("queries a multi-valued event_subindustry keyword field with SQL leniency enabled", async () => {
+    const provider = await connectProvider();
+    overrideSql(ok('{"columns":[{"name":"event_subindustry","type":"keyword"}],"rows":[["Healthcare"]]}'));
+
+    const result = await provider.query("SELECT event_subindustry FROM probe_orders");
+
+    expect(result.rows).toEqual([{ event_subindustry: "Healthcare" }]);
+    expect(result.fields).toEqual(["event_subindustry"]);
+    expect(sqlRequests()[1].body).toEqual({
+      query: "SELECT event_subindustry FROM probe_orders",
+      ...SQL_QUERY_OPTIONS,
+    });
+  });
+
   test("returns the rows, the declared column order and a measured duration", async () => {
     // The duration is this process's measurement of the exchange, because neither
     // answer carries any server-side timing at all - it is the only number in
@@ -1211,7 +1229,10 @@ describe("ElasticsearchProvider query", () => {
 
     const paging = sqlRequests().slice(1);
     expect(paging).toHaveLength(2);
-    expect(paging[0].body).toEqual({ query: "SELECT k, COUNT(*) FROM probe_buckets GROUP BY k" });
+    expect(paging[0].body).toEqual({
+      query: "SELECT k, COUNT(*) FROM probe_buckets GROUP BY k",
+      ...SQL_QUERY_OPTIONS,
+    });
     expect(paging[1].body).toEqual({ cursor: AGGREGATION_CURSOR });
     // Nothing else was asked: no /_sql/close, because no cursor was left holding.
     expect(pathsSent()).toEqual([SQL_PATH, SQL_PATH, SQL_PATH]);
@@ -1268,7 +1289,10 @@ describe("ElasticsearchProvider query", () => {
 
     // The whole shape, so a count smuggled in under any name would fail here.
     expect(Object.keys(result).sort()).toEqual(["columnTypes", "executionTime", "fields", "rowCount", "rows"]);
-    expect(sqlRequests()[1].body).toEqual({ query: "SELECT id FROM probe_orders" });
+    expect(sqlRequests()[1].body).toEqual({
+      query: "SELECT id FROM probe_orders",
+      ...SQL_QUERY_OPTIONS,
+    });
   });
 
   test("arms one deadline per statement, and it is the client's alone", async () => {

--- a/tests/integration/db/opensearch-provider.test.ts
+++ b/tests/integration/db/opensearch-provider.test.ts
@@ -896,6 +896,7 @@ describe("OpenSearchProvider query", () => {
     // engine, so a connected transport is evidence that the type-id names the
     // product actually listening.
     expect(sqlWith("SELECT 1")).toBe("SELECT 1");
+    expect(sentBodies[0]).toEqual({ query: "SELECT 1" });
     expect(sentPaths).toEqual(["/_plugins/_sql"]);
   });
 


### PR DESCRIPTION
## Description

Enable fieldMultiValueLeniency.

Note that with this option enabled, for array fields, only one value is returned. This is a limitation outlined here:

- https://www.elastic.co/docs/reference/query-languages/sql/sql-limitations#array-type-of-fields

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Related Issue

Resolves #722

## Changes Made

- enable fieldMultiValueLeniency

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass (for elastic search)

### Test Environment
- **LibreDB Studio Version**: 0.15.0
- **Browser**: Zen
- **OS**: MacOS
- **Node.js/Bun Version**: Bun v1.0
- **Database Type**: Elastic Search

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published


