### PR TITLE
fix(storage): share one in-flight provider initialization across concurrent first calls

### DIFF
--- a/src/lib/storage/factory.ts
+++ b/src/lib/storage/factory.ts
@@ -9,6 +9,15 @@ import { withCredentialEncryption } from "./encrypting-provider";
 
 let _provider: ServerStorageProvider | null = null;
 let _initialized = false;
+/**
+ * The in-flight initialization, if any. The first caller to arrive when no
+ * provider exists starts exactly one build+initialize and every concurrent
+ * caller awaits the SAME promise — otherwise two overlapping first requests
+ * (e.g. the page-load `GET /api/storage` racing a `PUT /api/storage/[collection]`)
+ * each construct and initialize a provider, and the second assignment silently
+ * overwrites the first mid-initialize, leaking its connections.
+ */
+let _initPromise: Promise<ServerStorageProvider | null> | null = null;
 
 export type StorageProviderType = "local" | "sqlite" | "postgres";
 
@@ -52,35 +61,52 @@ export async function getStorageProvider(): Promise<ServerStorageProvider | null
 
   if (_provider && _initialized) return _provider;
 
-  // Credential encryption is installed HERE, at the one choke point every storage route goes
-  // through, rather than inside the providers. Three call sites obtain a provider, all under
-  // src/app/api/storage/, and all of them call this function - so there is no route-level way to
-  // reach an unencrypted store, and a provider added later inherits the control by construction.
-  switch (providerType) {
-    case "sqlite": {
-      const { SQLiteStorageProvider } = await import("./providers/sqlite");
-      _provider = withCredentialEncryption(new SQLiteStorageProvider());
-      break;
-    }
-    case "postgres": {
-      const { PostgresStorageProvider } = await import("./providers/postgres");
-      _provider = withCredentialEncryption(new PostgresStorageProvider());
-      break;
-    }
-  }
+  // Concurrent first callers share one build+initialize: the promise is
+  // memoized the moment the first caller starts it, so there is no window in
+  // which a second caller can fall through and build a duplicate provider.
+  if (_initPromise) return _initPromise;
 
-  if (_provider && !_initialized) {
-    await _provider.initialize();
-    _initialized = true;
-  }
+  _initPromise = (async () => {
+    // Credential encryption is installed HERE, at the one choke point every storage route goes
+    // through, rather than inside the providers. Three call sites obtain a provider, all under
+    // src/app/api/storage/, and all of them call this function - so there is no route-level way to
+    // reach an unencrypted store, and a provider added later inherits the control by construction.
+    switch (providerType) {
+      case "sqlite": {
+        const { SQLiteStorageProvider } = await import("./providers/sqlite");
+        _provider = withCredentialEncryption(new SQLiteStorageProvider());
+        break;
+      }
+      case "postgres": {
+        const { PostgresStorageProvider } = await import("./providers/postgres");
+        _provider = withCredentialEncryption(new PostgresStorageProvider());
+        break;
+      }
+    }
 
-  return _provider;
+    if (_provider && !_initialized) {
+      await _provider.initialize();
+      _initialized = true;
+    }
+
+    return _provider;
+  })();
+
+  // A failed initialization must not be memoized: the next request should
+  // retry from scratch rather than await a rejected promise forever.
+  try {
+    return await _initPromise;
+  } catch (error) {
+    _initPromise = null;
+    throw error;
+  }
 }
 
 /**
  * Close and reset the singleton provider. Used for testing/cleanup.
  */
 export async function closeStorageProvider(): Promise<void> {
+  _initPromise = null;
   if (_provider) {
     await _provider.close();
     _provider = null;

--- a/tests/isolated/factory-singleton.test.ts
+++ b/tests/isolated/factory-singleton.test.ts
@@ -92,6 +92,43 @@ describe("factory: getStorageProvider", () => {
     expect(mockInitialize).toHaveBeenCalledTimes(1);
   });
 
+  /**
+   * Two requests can arrive before the first has finished initializing — the
+   * page-load GET /api/storage races a PUT /api/storage/[collection]. Before
+   * the in-flight promise was memoized, both fell through the
+   * `_provider && _initialized` check, each constructed a provider, and the
+   * second assignment overwrote the first mid-initialize: two initialize()
+   * calls, a duplicated provider, and a leaked connection pool.
+   */
+  test("concurrent first calls share one provider and one initialize()", async () => {
+    process.env.STORAGE_PROVIDER = "sqlite";
+
+    const [first, second] = await Promise.all([getStorageProvider(), getStorageProvider()]);
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first).toBe(second);
+    // Exactly one build+initialize, no matter how many callers raced.
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The memoized promise must not outlive a failure: a rejected initialize
+   * that stayed cached would make every later request await the same dead
+   * promise forever, turning one transient DB outage into a permanent one.
+   */
+  test("a failed initialize is not memoized — the next call retries from scratch", async () => {
+    process.env.STORAGE_PROVIDER = "sqlite";
+    mockInitialize.mockRejectedValueOnce(new Error("DB init failed"));
+
+    await expect(getStorageProvider()).rejects.toThrow("DB init failed");
+
+    mockInitialize.mockClear();
+    const provider = await getStorageProvider();
+    expect(provider).not.toBeNull();
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+  });
+
   test("propagates error when initialize() throws", async () => {
     process.env.STORAGE_PROVIDER = "sqlite";
     mockInitialize.mockRejectedValueOnce(new Error("DB init failed"));


### PR DESCRIPTION
## Summary

`getStorageProvider()` had an initialization race: it checked `_provider && _initialized`, then awaited a dynamic `import()` and `initialize()` before setting the flag. Two overlapping first requests — e.g. the page-load `GET /api/storage` racing a `PUT /api/storage/[collection]` — both fell through the check, each constructed and initialized a provider, and the second assignment overwrote the first mid-initialize. Result: `initialize()` ran twice, a duplicated (encrypted-wrapper) provider was created, and the orphaned provider's connections were leaked.

## Fix

The in-flight initialization promise is memoized: the first caller starts exactly one build+initialize, and every concurrent caller awaits the same promise. A rejected `initialize()` is un-memoized so a transient DB outage doesn't become a permanent one (the next request retries from scratch instead of awaiting a dead promise forever). `closeStorageProvider()` also resets the memo so tests/cleanup keep working.

## Test plan

- [x] New: `concurrent first calls share one provider and one initialize()` — `Promise.all` of two first calls asserts a single instance and a single `initialize()`
- [x] New: `a failed initialize is not memoized — the next call retries from scratch`
- [x] Existing singleton/close suites in `tests/isolated/factory-singleton.test.ts` still pass unchanged

Found during a broader code review of the storage layer; no issue existed yet for it.