### PR TITLE
fix(storage): flush pending debounced writes on unmount instead of discarding them

### DIFF
--- a/src/hooks/use-storage-sync.ts
+++ b/src/hooks/use-storage-sync.ts
@@ -244,6 +244,18 @@ export function useStorageSync(): StorageSyncState {
   useEffect(() => {
     mountedRef.current = true;
     return () => {
+      // A pending debounce is a mutation that exists ONLY in localStorage — the
+      // server has never seen it. Clearing the timer without flushing used to
+      // drop it outright, and worse: the next mount's pullFromServer() then
+      // overwrote localStorage with server data, destroying the write forever.
+      // Flushing here sends it before teardown; the flush's own failure branch
+      // re-queues what it can't deliver, and its `!mountedRef.current` guard
+      // already keeps a failed post-teardown flush from arming stray timers.
+      // Guarded on server mode: in local mode the queue is always empty and
+      // appFetch would be pointless work.
+      if (serverModeRef.current && pendingCollectionsRef.current.size > 0) {
+        flushPendingRef.current();
+      }
       mountedRef.current = false;
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
       if (retryTimerRef.current) clearTimeout(retryTimerRef.current);

--- a/tests/isolated/use-storage-sync.test.ts
+++ b/tests/isolated/use-storage-sync.test.ts
@@ -632,6 +632,71 @@ describe("useStorageSync", () => {
       expect(attempts).toBe(1);
     });
 
+    /**
+     * An edit inside the debounce window when the user navigates away used to
+     * be dropped silently: the cleanup cleared the timer without flushing, and
+     * the next mount's pull overwrote localStorage with server data — the
+     * write was gone forever. The cleanup must send whatever is pending.
+     */
+    test("a pending debounced write is flushed on unmount, not discarded", async () => {
+      localStorage.setItem("libredb_server_migrated", "true");
+      let connectionsAttempts = 0;
+      const fetchMock = mockGlobalFetch({
+        "/api/storage/config": { ok: true, status: 200, json: { provider: "postgres", serverMode: true } },
+        "/api/storage/migrate": { ok: true, status: 200, json: { ok: true, migrated: [] } },
+        "/api/storage/connections": () => {
+          connectionsAttempts += 1;
+          return { ok: true, status: 200, json: { ok: true } };
+        },
+        "/api/storage": { ok: true, status: 200, json: {} },
+      });
+
+      const { result, unmount } = renderHook(() => useStorageSync());
+      await waitFor(() => {
+        expect(result.current.isServerMode).toBe(true);
+      });
+
+      // Edit lands inside the 500ms debounce window; unmount before it fires.
+      act(() => {
+        window.dispatchEvent(new CustomEvent("libredb-storage-change", { detail: { collection: "connections" } }));
+      });
+      unmount();
+
+      // The cleanup's flush is async: give it time to land before asserting.
+      await waitFor(
+        () => {
+          expect(connectionsAttempts).toBeGreaterThanOrEqual(1);
+        },
+        { timeout: 2000 },
+      );
+      expect(calledPaths(fetchMock)).toContain("/api/storage/connections");
+    });
+
+    /**
+     * Nothing queued means the cleanup must not fire a pointless PUT — the
+     * flush is conditional on a non-empty pending set.
+     */
+    test("unmount with nothing pending does not push", async () => {
+      localStorage.setItem("libredb_server_migrated", "true");
+      const fetchMock = mockGlobalFetch({
+        "/api/storage/config": { ok: true, status: 200, json: { provider: "postgres", serverMode: true } },
+        "/api/storage/migrate": { ok: true, status: 200, json: { ok: true, migrated: [] } },
+        "/api/storage/connections": { ok: true, status: 200, json: { ok: true } },
+        "/api/storage": { ok: true, status: 200, json: {} },
+      });
+
+      const { result, unmount } = renderHook(() => useStorageSync());
+      await waitFor(() => {
+        expect(result.current.isServerMode).toBe(true);
+      });
+
+      unmount();
+
+      // Long enough that a spurious flush (or its 500ms debounce) would land.
+      await new Promise((r) => setTimeout(r, 1200));
+      expect(calledPaths(fetchMock)).not.toContain("/api/storage/connections");
+    });
+
     test("sets syncError on push failure", async () => {
       localStorage.setItem("libredb_server_migrated", "true");
 


### PR DESCRIPTION
### WARNING CORE_CAPABILITIES

## Summary

The `useStorageSync` unmount cleanup cleared the debounce timer without flushing, and `pendingCollectionsRef` — a per-mount `useRef` — was dropped with the component. An edit made within the 500ms debounce window of navigating away existed only in localStorage; the next mount's `pullFromServer()` then unconditionally overwrote localStorage with server data, destroying the write permanently and silently.

## Fix

The cleanup now flushes whatever is pending before tearing down:

- Guarded on `serverModeRef` — in local mode the queue is always empty and the PUT would be pointless work.
- Guarded on a non-empty pending set — no spurious push when nothing is queued.
- A failed post-teardown flush still re-queues its collections (existing behavior), and the existing `!mountedRef.current` guard already keeps it from arming stray retry timers — so the previous fix for the dead-hook retry loop is unaffected.

## Test plan

- [x] New: `a pending debounced write is flushed on unmount, not discarded` — edit dispatched inside the debounce window, unmount, assert the PUT lands
- [x] New: `unmount with nothing pending does not push` — asserts the flush is conditional
- [x] Existing `a push that fails after unmount does not leave a timer running` still passes (in-flight push ≠ pending push; no double-send)

Found during a broader code review of the storage sync layer; no issue existed yet for it.