### PR TITLE
docs: align README environment variables with supported configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,10 +624,12 @@ Deploy your own instance of LibreDB Studio with a single click on DigitalOcean, 
 | `OIDC_ADMIN_ROLES` | ❌ | Comma-separated admin role values (default: `admin`) |
 | `OIDC_ROLE_CLAIM` | ❌ | Claim path for role (e.g. `realm_access.roles`) |
 | `OIDC_SCOPE` | ❌ | OIDC scope (default: `openid profile email`) |
-| `LLM_PROVIDER` | ❌ | AI provider: `gemini`, `openai`, `ollama` |
+| `LLM_PROVIDER` | ❌ | AI: `gemini`, `openai`, `ollama`, `custom` (self-hosted OpenAI-compatible endpoint) |
 | `LLM_API_KEY` | ❌ | API key for AI features |
 | `LLM_MODEL` | ❌ | Model name (e.g., `gemini-2.5-flash`) |
+| `LLM_API_URL` | ❌ | API URL for `ollama` and `custom`; required for `custom`, defaults to `http://localhost:11434/v1` for `ollama` |
 | `STORAGE_PROVIDER` | ❌ | Storage provider: `local` (default), `sqlite`, or `postgres` |
+| `STORAGE_SQLITE_PATH` | ❌ | SQLite file path (e.g. `/app/data/libredb-storage.db`) |
 | `STORAGE_POSTGRES_URL` | ❌ | PostgreSQL connection URL (required when `STORAGE_PROVIDER=postgres`) |
 | `SEED_CONFIG_PATH` | ❌ | Path to seed connections YAML config (see [Seed Connections](#seed-connections-pre-configured-databases)) |
 | `SEED_CACHE_TTL_MS` | ❌ | Seed config cache TTL in ms (default: `60000`) |


### PR DESCRIPTION
## Description

The README environment table omits `custom`, `LLM_API_URL`, and `STORAGE_SQLITE_PATH`. Add the missing configuration so readers can configure a self-hosted OpenAI-compatible endpoint and choose a SQLite storage file.

## Type of Change

- [x] Documentation update

## Related Issue

Closes #666

## Changes Made

The provider list and SQLite path wording follow DOCKERHUB.md. DOCKERHUB groups the four LLM variables into one row; the README retains its existing per-variable rows and explains URL selection using the actual resolver and .env.example: `custom` requires an explicit URL, while Ollama defaults to `http://localhost:11434/v1`. `bun run readme:check` passed. Documentation only; no executable lines change and the issue explicitly requires no new test.

## Testing

- Local: `bun run readme:check` passed.
- [Linux CI on the exact PR commit `496187b`](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316270610): **14,713 tests passed**, all 391 isolated core files and 34 component groups passed; **46324/46324 lines covered (100%)**. Ran the unfiltered `bun run test:coverage` and `bun run coverage:check` scripts.
- The same run passed formatting, lint, typecheck, knip, README/chart/channel/security guards, application and library builds, Helm lint, and Node 24/26 engine smoke tests.
- Playwright: **65 passed / 1 flaky (passed on retry) / 6 skipped** under the existing configuration, plus **1 subpath**, **1 PostgreSQL functional smoke**, **3 tarball**, and **3 npx** tests passed.
- [Secret Scan passed](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316351552) after fetching all fork branch history, including this commit; no leaks found.

I did not complete `bun run test` / full coverage, the Helm checks, and E2E locally on Windows: the existing SQLite cleanup hits `EBUSY`, and Docker Desktop is unavailable. The unchanged upstream workflow ran the complete coverage/test layers and the other checks above on Linux instead. SonarCloud is the sole failed job in that fork run: access to the upstream project returns **401 / Not authorized or project not found**. Upstream CI already skips SonarCloud for external fork PRs; no workflow or coverage gate was changed.

### Test Environment

LibreDB Studio 0.15.0; Windows local / Ubuntu CI; Bun 1.4.2; Node 24 (plus Node 26 smoke); Chromium and WebKit; PostgreSQL functional smoke.

## Checklist

- [x] Claimed the linked issue before editing; branch starts from `main`.
- [x] Reviewed the diff and followed the existing style.
- [x] Documentation only: the issue explicitly requires no new test.
- [x] All executable test/build jobs pass on the exact commit in Linux CI.

## Additional Notes

AI-assisted implementation and validation using Codex, disclosed in the issue claim. Only documentation changes. No provider code changes, so the provider code/doc/test triad is not applicable. No dependent changes or screenshots are needed.

<!-- codex-ci-followup-732 -->
## CI follow-up

The fork-run SonarCloud 401 is tracked in #732 and fixed by #733. The inherited condition admitted fork-owned pushes and fork-local PRs to the canonical SonarCloud project. [The dedicated CI fix run](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321083163) now succeeds: all nine executable test/build jobs pass, and SonarCloud is scoped to the canonical repository. That run tests CI fix commit `80a318b`; this PR's exact-head verification remains the original run linked above, whose nine executable jobs passed. Upstream Actions still await maintainer approval.
