### PR TITLE
fix: describe the full database scope in page metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,8 @@ import { Toaster } from "@/components/ui/sonner";
 
 export const metadata: Metadata = {
   title: "LibreDB Studio | Universal Database Editor",
-  description: "Manage PostgreSQL, MySQL, MongoDB, and Redis in one web-based interface.",
+  description:
+    "A self-hosted, web-based SQL IDE for PostgreSQL, MySQL, MongoDB and more, with AI-assisted queries, schema exploration, and support for SQL and NoSQL engines.",
   icons: {
     icon: [
       { url: withBasePath("/favicon.ico?v=2"), sizes: "any" },

--- a/tests/components/RootLayout.test.tsx
+++ b/tests/components/RootLayout.test.tsx
@@ -38,8 +38,14 @@ describe("RootLayout", () => {
     expect(metadata.title).toBe("LibreDB Studio | Universal Database Editor");
   });
 
-  test("exports correct metadata description", () => {
-    expect(metadata.description).toBe("Manage PostgreSQL, MySQL, MongoDB, and Redis in one web-based interface.");
+  test("describes the database scope in a search-result snippet", () => {
+    const description = metadata.description ?? "";
+    expect(description.length).toBeGreaterThanOrEqual(150);
+    expect(description.length).toBeLessThanOrEqual(160);
+    expect(description).toContain("self-hosted");
+    expect(description).toContain("SQL and NoSQL");
+    expect(description).toContain("and more");
+    expect(description).not.toMatch(/\d/);
   });
 
   test("renders children", () => {


### PR DESCRIPTION
## Description

The page description lists only four engines and undersells the product's scope. Replace it with a 158-character search snippet that describes the self-hosted SQL/NoSQL IDE without depending on a fixed engine count.

## Type of Change

- [x] Bug fix
- [x] Test addition or update

## Related Issue

Closes #675

Also addresses the duplicate report in #678 with the same change.

## Changes Made

Updated the existing RootLayout metadata test before changing the description. `bun run test:components --pass-with-no-tests -t 'RootLayout'` went from **8 passed / 1 failed** (old description length: 72) to **9 passed / 0 failed**. The test checks the requested 150-160 character length and the broader, count-independent description. `--pass-with-no-tests` is used only for this targeted local run because the unchanged isolation runner also invokes groups with no matching test names; the full CI coverage run is unfiltered. The same defect is also reported in #678; this is one shared fix.

## Testing

- Local: `bun run test:components --pass-with-no-tests -t 'RootLayout'`: 8 passed / 1 failed before the fix, then 9 passed / 0 failed. The isolation runner uses the flag only to allow groups without a matching test name.
- [Linux CI on the exact PR commit `9effd8f`](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316262456): **14,713 tests passed**, all 391 isolated core files and 34 component groups passed; **46325/46325 lines covered (100%)**. Ran the unfiltered `bun run test:coverage` and `bun run coverage:check` scripts.
- The same run passed formatting, lint, typecheck, knip, README/chart/channel/security guards, application and library builds, Helm lint, and Node 24/26 engine smoke tests.
- Playwright: **65 passed / 1 flaky (passed on retry) / 6 skipped** under the existing configuration, plus **1 subpath**, **1 PostgreSQL functional smoke**, **3 tarball**, and **3 npx** tests passed.
- [Secret Scan passed](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316351552) after fetching all fork branch history, including this commit; no leaks found.

I did not complete `bun run test` / full coverage, the Helm checks, and E2E locally on Windows: the existing SQLite cleanup hits `EBUSY`, and Docker Desktop is unavailable. The unchanged upstream workflow ran the complete coverage/test layers and the other checks above on Linux instead. SonarCloud is the sole failed job in that fork run: access to the upstream project returns **401 / Not authorized or project not found**. Upstream CI already skips SonarCloud for external fork PRs; no workflow or coverage gate was changed.

### Test Environment

LibreDB Studio 0.15.0; Windows local / Ubuntu CI; Bun 1.4.2; Node 24 (plus Node 26 smoke); Chromium and WebKit; PostgreSQL functional smoke.

## Checklist

- [x] Claimed the linked issue before editing; branch starts from `main`.
- [x] Reviewed the diff and followed the existing style.
- [x] Updated the existing regression test and verified failure before the fix.
- [x] All executable test/build jobs pass on the exact commit in Linux CI.

## Additional Notes

AI-assisted implementation and validation using Codex, disclosed in the issue claim. Only page metadata and its existing test change. No provider code changes, so the provider code/doc/test triad is not applicable. No dependent changes or screenshots are needed.

<!-- codex-ci-followup-732 -->
## CI follow-up

The fork-run SonarCloud 401 is tracked in #732 and fixed by #733. The inherited condition admitted fork-owned pushes and fork-local PRs to the canonical SonarCloud project. [The dedicated CI fix run](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321083163) now succeeds: all nine executable test/build jobs pass, and SonarCloud is scoped to the canonical repository. That run tests CI fix commit `80a318b`; this PR's exact-head verification remains the original run linked above, whose nine executable jobs passed. Upstream Actions still await maintainer approval.
