### PR TITLE
docs: correct the Koyeb deployment flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,11 +648,11 @@ For a reverse-proxy path such as `/tools/libredb`, build with `BASE_PATH` and fo
 
 ### Koyeb
 
-1. **Fork this repository**
-2. **Connect to Koyeb**: [app.koyeb.com](https://app.koyeb.com) → New → Blueprint
-3. **Select your forked repo** and Koyeb will auto-detect `koyeb.yaml`
-4. **Set Environment Variables** in Koyeb Dashboard:
-5. **Deploy!**
+1. Use the **Deploy to Koyeb** button under [One-Click Deploy](#one-click-deploy) to run the prebuilt `ghcr.io/libredb/libredb-studio:latest` image.
+2. Set a strong `JWT_SECRET` (32+ characters) and real `ADMIN_PASSWORD` / `USER_PASSWORD` in the deploy form before launching. Koyeb cannot auto-generate secrets; the prefilled values are placeholders.
+3. For connections to survive redeploys, set `STORAGE_PROVIDER=postgres` and `STORAGE_POSTGRES_URL` to a Koyeb managed Postgres or Neon connection string. The button defaults to `STORAGE_PROVIDER=local`, which keeps connection metadata in the browser.
+
+See [`deploy/koyeb/`](deploy/koyeb/) for the complete setup and storage options.
 
 ### Railway
 


### PR DESCRIPTION
## Description

The Koyeb steps describe a nonexistent Blueprint file and leave secret setup unfinished. Replace them with the existing deploy-button flow and the documented credentials and storage options.

## Type of Change

- [x] Documentation update

## Related Issue

Closes #668

## Changes Made

Every replacement claim was checked against deploy/koyeb/README.md: GHCR latest image, manually supplied credentials, local browser storage by default, and PostgreSQL storage for redeploy persistence. The Koyeb block links to the existing deploy button and detailed guide and no longer refers to forking or koyeb.yaml. `bun run readme:check` passed. Documentation only; no cloud deployment was performed and the issue explicitly requires no new test.

## Testing

- Local: `bun run readme:check` passed.
- [Linux CI on the exact PR commit `b38d279`](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316289011): **14,713 tests passed**, all 391 isolated core files and 34 component groups passed; **46324/46324 lines covered (100%)**. Ran the unfiltered `bun run test:coverage` and `bun run coverage:check` scripts.
- The same run passed formatting, lint, typecheck, knip, README/chart/channel/security guards, application and library builds, Helm lint, and Node 24/26 engine smoke tests.
- Playwright: **65 passed / 1 flaky (passed on retry) / 6 skipped** under the existing configuration, plus **1 subpath**, **1 PostgreSQL functional smoke**, **3 tarball**, and **3 npx** tests passed.
- [Secret Scan passed](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316351552) after fetching all fork branch history, including this commit; no leaks found.

I did not complete `bun run test` / full coverage, the Helm checks, and E2E locally on Windows: the existing SQLite cleanup hits `EBUSY`, and Docker Desktop is unavailable. The unchanged upstream workflow ran the complete coverage/test layers and the other checks above on Linux instead. SonarCloud is the sole failed job in that fork run: access to the upstream project returns **401 / Not authorized or project not found**. Upstream CI already skips SonarCloud for external fork PRs; no workflow or coverage gate was changed.

### Test Environment

LibreDB Studio 0.15.0; Windows local / Ubuntu CI; Bun 1.4.2; Node 24 (plus Node 26 smoke); Chromium and WebKit; PostgreSQL functional smoke.

## Checklist

- [x] Claimed the linked issue before editing; branch starts from `main`.
- [x] Reviewed the diff and followed the existing style.
- [x] Documentation only: the issue explicitly requires no new test.
- [x] All executable test/build jobs pass on the exact commit in Linux CI.

## Additional Notes

AI-assisted implementation and validation using Codex, disclosed in the issue claim. Only documentation changes. No provider code changes, so the provider code/doc/test triad is not applicable. No dependent changes or screenshots are needed.

<!-- codex-ci-followup-732 -->
## CI follow-up

The fork-run SonarCloud 401 is tracked in #732 and fixed by #733. The inherited condition admitted fork-owned pushes and fork-local PRs to the canonical SonarCloud project. [The dedicated CI fix run](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321083163) now succeeds: all nine executable test/build jobs pass, and SonarCloud is scoped to the canonical repository. That run tests CI fix commit `80a318b`; this PR's exact-head verification remains the original run linked above, whose nine executable jobs passed. Upstream Actions still await maintainer approval.
