### PR TITLE
docs: correct the external-engine count and source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for Claude Code in this repo — conventions, rules, and gotchas only. 
 
 ## Project Overview
 
-Web-based SQL IDE for cloud-native teams: 17 engines — the `DatabaseType` union in [`src/lib/types.ts`](src/lib/types.ts) is the list, never a prose enumeration — plus AI query assistance. It runs **two ways** — standalone Next.js app and published npm package — and the two render different chrome, so a UI change verified in one is not verified in the other.
+Web-based SQL IDE for cloud-native teams: sixteen external engines, plus the embedded LibreDB store — `EXTERNAL_DATABASE_TYPES` in [`src/lib/db/compatibility.ts`](src/lib/db/compatibility.ts) is the external-engine list, never a prose enumeration — plus AI query assistance. It runs **two ways** — standalone Next.js app and published npm package — and the two render different chrome, so a UI change verified in one is not verified in the other.
 
 ## Branching & PRs
 


### PR DESCRIPTION
## Description

The project overview counts the embedded LibreDB store as an external engine. State sixteen external engines plus the embedded store and point at `EXTERNAL_DATABASE_TYPES` in compatibility.ts for the published list.

## Type of Change

- [x] Documentation update

## Related Issue

Closes #667

## Changes Made

Checked the sixteen-entry external list and the EXTERNAL record's single false entry (`libredb`). The overview no longer says `17 engines`, uses the correct source pointer, and retains `never a prose enumeration`. `bun run readme:check` passed. Documentation only; the issue explicitly requires no new test.

## Testing

- Local: `bun run readme:check` passed.
- [Linux CI on the exact PR commit `3db1f4c`](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316278613): **14,713 tests passed**, all 391 isolated core files and 34 component groups passed; **46324/46324 lines covered (100%)**. Ran the unfiltered `bun run test:coverage` and `bun run coverage:check` scripts.
- The same run passed formatting, lint, typecheck, knip, README/chart/channel/security guards, application and library builds, Helm lint, and Node 24/26 engine smoke tests.
- Playwright: **65 passed / 1 flaky (passed on retry) / 6 skipped** under the existing configuration, plus **1 subpath**, **1 PostgreSQL functional smoke**, **3 tarball**, and **3 npx** tests passed.
- [Secret Scan passed](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316351552) after fetching all fork branch history, including this commit; no leaks found.

I did not complete `bun run test` / full coverage, the Helm checks, and E2E locally on Windows: the existing SQLite cleanup hits `EBUSY`, and Docker Desktop is unavailable. The unchanged upstream workflow ran the complete coverage/test layers and the other checks above on Linux instead. SonarCloud is the sole failed job in that fork run: access to the upstream project returns **401 / Not authorized or project not found**. Upstream CI already skips SonarCloud for external fork PRs; no workflow or coverage gate was changed.

### Test Environment

LibreDB Studio 0.15.0; Windows local / Ubuntu CI; Bun 1.4.2; Node 24 (plus Node 26 smoke); Chromium and WebKit; PostgreSQL functional smoke.

## Checklist

- [x] Claimed the linked issue before editing; branch starts from `main`.
- [x] Reviewed the diff and followed the existing style.
- [x] Documentation only: the issue explicitly requires no new test.
- [x] All executable test/build jobs pass on the exact commit in Linux CI.

## Additional Notes

AI-assisted implementation and validation using Codex, disclosed in the issue claim. Only documentation changes. No provider code changes, so the provider code/doc/test triad is not applicable. No dependent changes or screenshots are needed.

<!-- codex-ci-followup-732 -->
## CI follow-up

The fork-run SonarCloud 401 is tracked in #732 and fixed by #733. The inherited condition admitted fork-owned pushes and fork-local PRs to the canonical SonarCloud project. [The dedicated CI fix run](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321083163) now succeeds: all nine executable test/build jobs pass, and SonarCloud is scoped to the canonical repository. That run tests CI fix commit `80a318b`; this PR's exact-head verification remains the original run linked above, whose nine executable jobs passed. Upstream Actions still await maintainer approval.
