### PR TITLE
docs: describe WebKit security coverage accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ bun run test:coverage
 
 - **Test runner**: `bun:test` (built-in, Jest-compatible API) with `happy-dom` for DOM environment
 - **Component isolation**: Component tests run in 6 isolated groups via `tests/run-components.sh` to prevent `mock.module()` cross-contamination
-- **E2E**: Playwright with Chromium, runs against a production build (`bun run build && bun start`)
+- **E2E**: Playwright runs the full suite on Chromium and the `security-headers` spec on WebKit (`webkit-security`), against a production build (`bun run build && bun start`)
 - **CI**: GitHub Actions runs lint + typecheck + build, unit/integration tests with coverage, E2E tests, and SonarCloud analysis
 - **Coverage**: `bun test --coverage` generates lcov reports for SonarCloud integration
 
@@ -922,10 +922,10 @@ extraEnvFrom:
 
 ### Cross-browser testing
 
-The product is a browser application, so a browser bug is a product bug. CI runs Playwright against
-desktop Chromium, which is the limit of what a headless runner sees: Safari and older WebKit
-regressions, mobile layout, and the WebKitGTK engine behind the Linux desktop build need real
-devices. This project is tested with BrowserStack.
+The product is a browser application, so a browser bug is a product bug. CI runs the full Playwright
+suite on desktop Chromium and the `security-headers` spec on WebKit (`webkit-security`). Beyond that
+one WebKit spec, Safari and older WebKit regressions, mobile layout, and the WebKitGTK engine behind
+the Linux desktop build need real devices. This project is tested with BrowserStack.
 
 ---
 
@@ -963,10 +963,10 @@ one covers and what attribution is owed in return are at
   usable without an account. Since 2026-09-01.
 
 - **[BrowserStack](https://www.browserstack.com/opensource)** — the BrowserStack
-  Open Source programme behind the cross-browser testing that runs Playwright
-  against desktop Chromium, which is the limit of what a headless runner sees:
-  Safari and older WebKit regressions, mobile layout, and the WebKitGTK engine
-  behind the Linux desktop build need real devices. Since 2026-08-31.
+  Open Source programme behind the cross-browser testing that runs the full Playwright
+  suite on desktop Chromium and the `security-headers` spec on WebKit (`webkit-security`).
+  Beyond that one WebKit spec, Safari and older WebKit regressions, mobile layout, and the
+  WebKitGTK engine behind the Linux desktop build need real devices. Since 2026-08-31.
 
 - **[Tailscale](https://tailscale.com/opensource)** — the Community on GitHub
   plan behind the private network maintainers use to reach the database probe


### PR DESCRIPTION
## Description

Three README passages imply CI only runs Chromium. Correct all three to describe the Chromium suite and the WebKit security-headers spec, naming `webkit-security` and preserving the remaining real-device limitations.

## Type of Change

- [x] Documentation update

## Related Issue

Closes #669

## Changes Made

Compared all three passages with playwright.config.ts and the CI browser-install step. The configuration still scopes `webkit-security` to security-headers.spec.ts; no broader WebKit coverage is claimed. `bun run readme:check` passed. Documentation only; no workflow or test configuration changes, and the issue explicitly excludes a new duplication guard.

## Testing

- Local: `bun run readme:check` passed.
- [Linux CI on the exact PR commit `b4f571c`](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316298123): **14,713 tests passed**, all 391 isolated core files and 34 component groups passed; **46324/46324 lines covered (100%)**. Ran the unfiltered `bun run test:coverage` and `bun run coverage:check` scripts.
- The same run passed formatting, lint, typecheck, knip, README/chart/channel/security guards, application and library builds, Helm lint, and Node 24/26 engine smoke tests.
- Playwright: **64 passed / 2 flaky (passed on retry) / 6 skipped** under the existing configuration, plus **1 subpath**, **1 PostgreSQL functional smoke**, **3 tarball**, and **3 npx** tests passed.
- [Secret Scan passed](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34316351552) after fetching all fork branch history, including this commit; no leaks found.

I did not complete `bun run test` / full coverage, the Helm checks, and E2E locally on Windows: the existing SQLite cleanup hits `EBUSY`, and Docker Desktop is unavailable. The unchanged upstream workflow ran the complete coverage/test layers and the other checks above on Linux instead. SonarCloud is the sole failed job in that fork run: access to the upstream project returns **401 / Not authorized or project not found**. Upstream CI already skips SonarCloud for external fork PRs; no workflow or coverage gate was changed.

### Test Environment

LibreDB Studio 0.15.0; Windows local / Ubuntu CI; Bun 1.4.2; Node 24 (plus Node 26 smoke); Chromium and WebKit; PostgreSQL functional smoke.

## Checklist

- [x] Claimed the linked issue before editing; branch starts from `main`.
- [x] Reviewed the diff and followed the existing style.
- [x] Documentation only: the issue explicitly requires no new test.
- [x] All executable test/build jobs pass on the exact commit in Linux CI.

## Additional Notes

AI-assisted implementation and validation using Codex, disclosed in the issue claim. Only documentation changes. No provider code changes, so the provider code/doc/test triad is not applicable. No dependent changes or screenshots are needed.

<!-- codex-ci-followup-732 -->
## CI follow-up

The fork-run SonarCloud 401 is tracked in #732 and fixed by #733. The inherited condition admitted fork-owned pushes and fork-local PRs to the canonical SonarCloud project. [The dedicated CI fix run](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321083163) now succeeds: all nine executable test/build jobs pass, and SonarCloud is scoped to the canonical repository. That run tests CI fix commit `80a318b`; this PR's exact-head verification remains the original run linked above, whose nine executable jobs passed. Upstream Actions still await maintainer approval.
