### PR TITLE
fix(ci): scope SonarCloud scans to the canonical repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,8 +556,11 @@ jobs:
     # run is yours, Actions secrets come back, and the analysis is both
     # possible and wanted. PR #394 is the worked example - red while Dependabot
     # owned it, green on the very next human push to the same branch.
+    # The SonarCloud project belongs to the canonical repository; fork-owned
+    # runs cannot authenticate to it, including pushes and fork-local PRs.
     if: >-
-      github.actor != 'dependabot[bot]'
+      github.repository == 'libredb/libredb-studio'
+      && github.actor != 'dependabot[bot]'
       && (github.event.pull_request.head.repo.full_name == github.repository
         || github.event_name == 'push')
     runs-on: ubuntu-latest

--- a/tests/unit/sonarcloud-workflow.test.ts
+++ b/tests/unit/sonarcloud-workflow.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { runInNewContext } from "node:vm";
+import { parse } from "yaml";
+
+const workflow = parse(readFileSync(join(import.meta.dir, "../../.github/workflows/ci.yml"), "utf8")) as {
+  jobs: { sonarcloud: { if: string } };
+};
+const canonical = "libredb/libredb-studio";
+const fork = "contributor/libredb-studio";
+
+describe("SonarCloud workflow", () => {
+  test.each([
+    ["canonical push", canonical, "push", "", "contributor", true],
+    ["canonical pull request", canonical, "pull_request", canonical, "contributor", true],
+    ["fork push", fork, "push", "", "contributor", false],
+    ["external pull request", canonical, "pull_request", fork, "contributor", false],
+    ["fork-local pull request", fork, "pull_request", fork, "contributor", false],
+    ["Dependabot push", canonical, "push", "", "dependabot[bot]", false],
+    ["Dependabot pull request", canonical, "pull_request", canonical, "dependabot[bot]", false],
+  ])("%s", (_name, repository, eventName, headRepository, actor, expected) => {
+    // The guard uses string comparisons and boolean operators shared by Actions and JavaScript.
+    const actual = runInNewContext(
+      workflow.jobs.sonarcloud.if,
+      {
+        github: {
+          repository,
+          event_name: eventName,
+          actor,
+          head_ref: "dependabot/update-package",
+          event: { pull_request: { head: { repo: { full_name: headRepository } } } },
+        },
+      },
+      { timeout: 100 },
+    );
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Description

A push inside a fork satisfies the existing SonarCloud condition, but `sonar-project.properties` targets the upstream project. A PR inside that fork also satisfies the same-repository condition. Both fail with HTTP 401 when the fork has no credentials for the upstream project, after the executable test/build jobs pass.

Limit the upstream-targeting job to `libredb/libredb-studio`, retaining the existing external-PR and Dependabot exclusions. Human pushes and same-repository PRs in the canonical repository still run the scan.

## Type of Change

- [x] Bug fix
- [x] Test addition or update

## Related Issue

Closes #732

## Changes Made

- Add one repository predicate to the SonarCloud job condition, with its reason.
- Exercise the actual YAML condition in seven event/repository/actor cases. The human PR context uses a Dependabot-named branch to preserve the actor-based behavior introduced in #397.

## Testing

- Local regression: `bun run test:unit --pass-with-no-tests -t 'SonarCloud workflow'` went from **5 passed / 2 failed** (fork push and fork-local PR) to **7 passed / 0 failed**.
- Biome formatting and `git diff --check` passed.
- [Full Linux CI succeeded](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321083163) on the exact PR commit `80a318b5f2b835780d4272490e3c8c999775ea46`: all nine executable test/build jobs passed, including the unfiltered coverage run and 100% line-coverage gate, lint/typecheck/build, Helm, Node 24/26 engine smoke, channel E2E, browser/subpath E2E, and PostgreSQL functional smoke. SonarCloud is correctly skipped in this fork. The coverage run reports **14,720 passed**, with all 392 core files and 34 component groups passing, and **46,324/46,324 lines covered (100%)**. Browser E2E reports **65 passed / 1 flaky (passed on retry) / 6 skipped** under the existing configuration; subpath and PostgreSQL each pass 1 test, and tarball/npx each pass 3.
- [Secret Scan passed](https://github.com/2160039878-cyber/libredb-studio/actions/runs/34321125856) on the same commit.

Full coverage, Helm checks, and E2E run in Linux CI because this Windows host has the previously observed SQLite cleanup `EBUSY` and an unavailable Docker Desktop daemon. The filtered local command is only the regression check; the CI coverage command is unfiltered.

### Test Environment

LibreDB Studio 0.15.0; Bun 1.4.2; Windows local / Ubuntu CI; Node 24, with Node 26 engine smoke.

## Checklist

- [x] Opened the linked issue before editing and branched from main.
- [x] Reviewed the diff and verified regression failures before the fix.
- [x] No dependencies added; no provider changes, so the provider triad does not apply.

## Additional Notes

AI-assisted implementation and validation using Codex, disclosed in the issue. This changes the scope of the upstream-specific scan; the executable test jobs, 100% coverage gate, scan failure behavior, and canonical-repository scans keep their existing requirements.
