### PR TITLE
fix(ci): add job timeouts to workflows

### DIFF
--- a/.github/workflows/azure-marketplace-package.yml
+++ b/.github/workflows/azure-marketplace-package.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/do-packer-build.yml
+++ b/.github/workflows/do-packer-build.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: deploy/digitalocean/droplet

--- a/.github/workflows/flatpak-smoke.yml
+++ b/.github/workflows/flatpak-smoke.yml
@@ -50,6 +50,7 @@ jobs:
   appimage:
     name: Build AppImage (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +151,7 @@ jobs:
     name: Repack as Flatpak (${{ matrix.flatpak_arch }})
     needs: appimage
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
     # The GNOME major of this image MUST match runtime-version in the manifest.
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50

--- a/.github/workflows/integration-check.yml
+++ b/.github/workflows/integration-check.yml
@@ -13,6 +13,7 @@ jobs:
   integration-rules:
     name: Platform Integration Rules
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,6 +29,7 @@ jobs:
     if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'libredb-studio-')
     name: Validate
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -78,6 +79,7 @@ jobs:
   publish:
     name: Publish to NPM
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: validate
     permissions:
       contents: read
@@ -157,6 +159,7 @@ jobs:
     needs: publish
     if: inputs.dry_run != true
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       actions: write
     steps:

--- a/.github/workflows/npx-engine-smoke.yml
+++ b/.github/workflows/npx-engine-smoke.yml
@@ -38,7 +38,7 @@ jobs:
     name: bare npx on Node ${{ matrix.node-version }} (${{ matrix.expect }})
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/npx-engine-smoke.yml
+++ b/.github/workflows/npx-engine-smoke.yml
@@ -38,6 +38,7 @@ jobs:
     name: bare npx on Node ${{ matrix.node-version }} (${{ matrix.expect }})
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -44,6 +44,7 @@ jobs:
   build-and-push:
     name: Build and Push Operator Image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -175,6 +175,7 @@ jobs:
     needs: build-and-push
     if: needs.build-and-push.outputs.skip != 'true' && needs.build-and-push.outputs.submittable == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -252,7 +252,7 @@ jobs:
     # (their manifests point at this exact asset) and npx on win32.
     needs: guard
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     defaults:
       run:
         # Git Bash: keeps the packaging scripts single-source with the POSIX

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -70,6 +70,7 @@ jobs:
     # patterns above; this guard re-checks anyway for workflow_dispatch runs.
     name: Validate release version
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -129,6 +130,7 @@ jobs:
     # stopped publishing.
     name: Resolve channel automation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: true
     outputs:
       docker_hub_mirror: ${{ steps.flags.outputs.docker_hub_mirror }}
@@ -161,6 +163,7 @@ jobs:
     name: Ensure draft release
     needs: guard
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:
@@ -200,6 +203,7 @@ jobs:
           - runner: macos-14
             platform: darwin-arm64
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -248,6 +252,7 @@ jobs:
     # (their manifests point at this exact asset) and npx on win32.
     needs: guard
     runs-on: windows-latest
+    timeout-minutes: 20
     defaults:
       run:
         # Git Bash: keeps the packaging scripts single-source with the POSIX
@@ -378,6 +383,7 @@ jobs:
     name: Attach artifacts to release
     needs: [guard, build, windows-package, draft, channels]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       # SLSA build provenance (issue #123): id-token mints the OIDC identity
@@ -510,6 +516,7 @@ jobs:
     # one-command regeneration from the immutable digest.
     needs: [guard, draft]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write
@@ -694,6 +701,7 @@ jobs:
     # amd64 runner, and attach the packages to the release.
     needs: [guard, build, draft]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       # SLSA build provenance (issue #123) - one attestation per matrix arch.
@@ -862,6 +870,7 @@ jobs:
     # release - so a release missing either would strand that path.
     needs: [guard, build, draft]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     permissions:
       contents: write
       # SLSA build provenance (issue #123). Users run the AppImage directly and
@@ -983,6 +992,7 @@ jobs:
             runner: ubuntu-24.04-arm
             tarball_arch: arm64
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     steps:
       - name: Check Snap Store availability
         id: snapstore
@@ -1107,6 +1117,7 @@ jobs:
     name: Verify assets and publish release
     needs: [guard, publish, sbom, linux-packages, desktop-appimage, snap]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -1179,6 +1190,7 @@ jobs:
     name: Dispatch npm and Docker publish
     needs: [guard, publish-release]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       # gh workflow run calls the Actions API, and an explicit permissions
       # block disables every scope it does not name.
@@ -1221,6 +1233,7 @@ jobs:
     # had published fine. See docs/DISTRIBUTION.md ("Windows").
     needs: [guard, publish-release, channels]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check Chocolatey availability
         id: choco
@@ -1351,6 +1364,7 @@ jobs:
     # detection of its own).
     needs: [guard, publish-release, channels]
     runs-on: windows-latest
+    timeout-minutes: 15
     steps:
       - name: Check winget submission availability
         id: winget

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   update-sponsors:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
 

--- a/tests/unit/workflow-timeouts.test.ts
+++ b/tests/unit/workflow-timeouts.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+const WORKFLOWS = join(import.meta.dir, "../../.github/workflows");
+
+// These limits use recent successful runs as a baseline, with extra room for
+// runner variation and the external registries or services each job touches.
+// Keeping the full matrix here also makes a newly added job fail until its
+// expected runtime has been considered.
+const EXPECTED_TIMEOUTS: Record<string, Record<string, number>> = {
+  "azure-marketplace-package.yml": { package: 10 },
+  "codeql.yml": { analyze: 15 },
+  "do-packer-build.yml": { build: 30 },
+  "flatpak-smoke.yml": { appimage: 30, flatpak: 20 },
+  "integration-check.yml": { "integration-rules": 10 },
+  "npm-publish.yml": { validate: 25, publish: 15, "dispatch-smoke": 5 },
+  "npx-engine-smoke.yml": { "npx-smoke": 15 },
+  "operator-release.yml": { "build-and-push": 30 },
+  "release-artifacts.yml": {
+    guard: 5,
+    channels: 10,
+    draft: 5,
+    build: 20,
+    "windows-package": 20,
+    publish: 15,
+    sbom: 15,
+    "linux-packages": 20,
+    "desktop-appimage": 30,
+    snap: 30,
+    "publish-release": 10,
+    "dispatch-downstream": 5,
+    chocolatey: 15,
+    winget: 15,
+  },
+  "update-sponsors.yml": { "update-sponsors": 5 },
+};
+
+interface WorkflowJob {
+  "timeout-minutes"?: unknown;
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+function readTimeouts(file: string): Record<string, unknown> {
+  const workflow = parseYaml(readFileSync(join(WORKFLOWS, file), "utf8")) as Workflow;
+  return Object.fromEntries(
+    Object.entries(workflow.jobs ?? {}).map(([job, definition]) => [job, definition["timeout-minutes"]]),
+  );
+}
+
+describe("workflow job timeouts", () => {
+  test.each(Object.entries(EXPECTED_TIMEOUTS))("%s has a deliberate timeout for every job", (file, expected) => {
+    expect(readTimeouts(file)).toEqual(expected);
+  });
+
+  test("uses limits sized for different kinds of work", () => {
+    const values = Object.values(EXPECTED_TIMEOUTS).flatMap(Object.values);
+    expect(new Set(values).size).toBeGreaterThan(1);
+  });
+});

--- a/tests/unit/workflow-timeouts.test.ts
+++ b/tests/unit/workflow-timeouts.test.ts
@@ -16,14 +16,14 @@ const EXPECTED_TIMEOUTS: Record<string, Record<string, number>> = {
   "flatpak-smoke.yml": { appimage: 30, flatpak: 20 },
   "integration-check.yml": { "integration-rules": 10 },
   "npm-publish.yml": { validate: 25, publish: 15, "dispatch-smoke": 5 },
-  "npx-engine-smoke.yml": { "npx-smoke": 15 },
-  "operator-release.yml": { "build-and-push": 30 },
+  "npx-engine-smoke.yml": { "npx-smoke": 30 },
+  "operator-release.yml": { "build-and-push": 30, "submit-catalogs": 30 },
   "release-artifacts.yml": {
     guard: 5,
     channels: 10,
     draft: 5,
     build: 20,
-    "windows-package": 20,
+    "windows-package": 30,
     publish: 15,
     sbom: 15,
     "linux-packages": 20,
@@ -54,7 +54,7 @@ function readTimeouts(file: string): Record<string, unknown> {
 
 describe("workflow job timeouts", () => {
   test.each(Object.entries(EXPECTED_TIMEOUTS))("%s has a deliberate timeout for every job", (file, expected) => {
-    expect(readTimeouts(file)).toEqual(expected);
+    expect(readTimeouts(file)).toStrictEqual(expected);
   });
 
   test("uses limits sized for different kinds of work", () => {


### PR DESCRIPTION
## Description

Adds explicit, job-specific timeouts to the ten GitHub Actions workflow files identified in #684. The timeout values are based on each job’s workload and recent successful run times, with appropriate headroom.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Related Issue

Closes #684

## Changes Made

- Added explicit `timeout-minutes` values to all 26 jobs across the ten affected workflow files.
- Sized the limits from 5 to 30 minutes according to each job’s workload, recent run time, and external service dependencies.
- Added a regression test that verifies every targeted job has its expected timeout and prevents newly added jobs from omitting one.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [x] All existing tests pass

### Test Environment

- **LibreDB Studio Version**: 0.14.1
- **Browser**: N/A
- **OS**: macOS (Apple Silicon)
- **Node.js/Bun Version**: Node.js 24.20.0 / Bun 1.4.2
- **Database Type**: N/A

Commands completed successfully:

- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bun run knip`
- `bun run readme:check`
- `bun run chart:check`
- `bun run channels:showcase:check`
- `bun run security:check`
- `bun run test`
- `bun run test:coverage`
- `bun run coverage:check`
- `bun run build`

Coverage remained at 100%: 46,171/46,171 lines.

## Screenshots (if applicable)

N/A — this change only affects GitHub Actions workflow configuration.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The required CI test job passes the **100% line-coverage gate** (`bun run test:coverage` and `bun run coverage:check`)
- [ ] If I changed `src/lib/db/providers/`, I updated the matching `docs/providers/` documentation and `tests/integration/db/` tests in the same PR (provider triad)
- [ ] Any dependent changes have been merged and published

## Additional Notes

Documentation and the provider triad are not applicable because this PR only changes GitHub Actions configuration and its regression test. There are no dependent changes.