### PR TITLE
fix(ci): pin Node 24 for the unit test job and restore the launcher URL tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
+      - name: Setup Node
+        # The suite runs under Bun, but tests that spawn `bin/studio.js` get
+        # whatever `node` the image happens to ship - currently 22.x, below the
+        # launcher's own Node 24 floor, so the launcher refuses and the test
+        # dies on a bare exit 1. Pin the product's baseline instead of
+        # inheriting the runner's default (#709 was red on exactly this).
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/tests/unit/launcher-utils.test.ts
+++ b/tests/unit/launcher-utils.test.ts
@@ -586,3 +586,51 @@ describe("startupUrl", () => {
     expect(startupUrl(host, port)).toBe(expected);
   });
 });
+
+/**
+ * The pure table above covers every formatting rule; these three cases cover the
+ * wiring, that `bin/studio.js` passes the real HOSTNAME and PORT through the helper
+ * and leaves the bind address alone. They spawn the launcher, so they need an
+ * ambient `node` at or above its floor: the `Unit & Integration Tests` job pins
+ * Node 24 for exactly this reason (.github/workflows/ci.yml). Originally written by
+ * @mikevillari in #709 and removed there while that job still ran on the runner's
+ * default Node 22.
+ */
+describe("launcher startup URL", () => {
+  test.each([
+    ["0.0.0.0", "http://127.0.0.1:3000"],
+    ["::", "http://[::1]:3000"],
+    ["127.0.0.1", "http://127.0.0.1:3000"],
+  ])("prints a usable URL for %s without changing the bind address", (host, url) => {
+    const node = Bun.which("node");
+    expect(node).not.toBeNull();
+    // Below the floor the launcher refuses and exits 1, which reads here as a bare
+    // exit code with no reason. Ask the launcher's own check first so the failure
+    // arrives as its sentence instead.
+    const ambient = Bun.spawnSync([node!, "-p", "process.versions.node"]).stdout.toString().trim();
+    expect(assessNodeRuntime(ambient).message).toBeNull();
+
+    const home = fs.mkdtempSync(path.join(tempDir, "startup-"));
+    const root = path.resolve(import.meta.dir, "../..");
+    const version = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
+    const payload = path.join(home, ".libredb-studio", version, "payload");
+    fs.mkdirSync(payload, { recursive: true });
+    fs.writeFileSync(path.join(payload, "server.js"), 'console.log("BIND=" + process.env.HOSTNAME);');
+    const preload = path.join(home, "home-fixture.mjs");
+    fs.writeFileSync(
+      preload,
+      'import os from "node:os"; import { syncBuiltinESMExports } from "node:module"; ' +
+        `os.homedir = () => ${JSON.stringify(home)}; syncBuiltinESMExports();`,
+    );
+    const run = Bun.spawnSync([node!, "--import", preload, path.join(root, "bin/studio.js"), "--host", host], {
+      env: { PATH: process.env.PATH },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(run.exitCode).toBe(0);
+    const output = run.stdout.toString();
+    expect(output).toContain(`Starting LibreDB Studio ${version} on ${url}\n`);
+    expect(output).toContain(`BIND=${host}\n`);
+    expect(output.match(/^Starting LibreDB Studio ([0-9][0-9.]*) /m)?.[1]).toBe(version);
+  });
+});


### PR DESCRIPTION
## Why

The `Unit & Integration Tests` job installs Bun but never pins Node. Anything in the suite that spawns `node` therefore runs on the ubuntu-24.04 image default, currently 22.x, while the launcher's own floor is Node 24 (`assessNodeRuntime` in `bin/lib/launcher-utils.mjs`). The launcher refuses and the case dies on a bare exit 1 in about 40ms.

That is exactly why #709 shipped without its three subprocess cases. The tests were right and the job was wrong, so the fix belongs here rather than in a contributor's PR.

## What changed

- `.github/workflows/ci.yml`: pin `actions/setup-node` to Node 24 in that job, matching `engine-payload` in the same file.
- `tests/unit/launcher-utils.test.ts`: restore the three `launcher startup URL` cases from #709, credited in a comment to their author. They cover what the 12 pure `startupUrl` cases cannot, that `bin/studio.js` passes the real `HOSTNAME` and `PORT` through the helper and leaves the bind address alone.
- The restored cases ask `assessNodeRuntime` about the ambient node before spawning, so a machine below the floor fails with the launcher's own sentence rather than an unexplained exit code. The floor is read from the product, not repeated here.

## Measured

Both arms, locally:

- `PATH` pointing at Node 22.15.1: 99 pass, 3 fail, each naming `LibreDB Studio requires Node.js 24.0 or newer; this is Node 22.15.1`. This is the state CI is in today.
- Node 24.14.0: 102 pass, 0 fail.

Non-vacuity: replacing `startupUrl(env.HOSTNAME, env.PORT)` in `bin/studio.js` with the old `http://${env.HOSTNAME}:${env.PORT}` template fails all three restored cases.

Blast radius of the pin: `tests/unit/launcher-utils.test.ts` is the only file in the suite that spawns the ambient `node`. The two other subprocess tests use `process.execPath`, which is Bun.

Gates run locally: format, lint, typecheck, knip, `chart:check`, `channels:showcase:check`, `readme:check`, `security:check`, and the full `bun run test`.
