### PR TITLE
fix(monitoring): apply saved alert thresholds

### DIFF
--- a/src/components/monitoring/tabs/OverviewTab.tsx
+++ b/src/components/monitoring/tabs/OverviewTab.tsx
@@ -8,7 +8,8 @@ import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { MonitoringData } from "@/lib/db/types";
 import type { TimeSeriesPoint } from "@/lib/time-series-buffer";
-import { evaluateThreshold, getThresholdColor, DEFAULT_THRESHOLDS } from "@/lib/monitoring-thresholds";
+import { evaluateThreshold, getThresholdColor, thresholdFor } from "@/lib/monitoring-thresholds";
+import { storage } from "@/lib/storage";
 import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 import { MetricChart } from "./MetricChart";
 import { PanelUnavailable } from "../PanelUnavailable";
@@ -69,16 +70,18 @@ export function OverviewTab({ data, loading, history = [] }: OverviewTabProps) {
       ? Math.round((activeConnections / connectionLimit) * 100)
       : null;
 
-  // Evaluate thresholds. No published limit cannot be near a limit, so it scores as
-  // healthy rather than as the 0 that a missing reading would once have implied.
-  const connThreshold = evaluateThreshold(
-    connectionPercent ?? 0,
-    DEFAULT_THRESHOLDS.find((t) => t.metric === "connectionPercent")!,
-  );
-  const cacheThreshold = evaluateThreshold(
-    cacheHitRatio ?? 100,
-    DEFAULT_THRESHOLDS.find((t) => t.metric === "cacheHitRatio")!,
-  );
+  // Read storage here: storage-facade imports the defaults, so the threshold helper
+  // must stay pure to avoid a circular dependency.
+  const thresholds = storage.getThresholdConfig();
+  // An unavailable measurement stays ungraded even if a saved threshold includes zero or 100.
+  const connThreshold =
+    connectionPercent === null
+      ? "healthy"
+      : evaluateThreshold(connectionPercent, thresholdFor(thresholds, "connectionPercent"));
+  const cacheThreshold =
+    cacheHitRatio === undefined
+      ? "healthy"
+      : evaluateThreshold(cacheHitRatio, thresholdFor(thresholds, "cacheHitRatio"));
 
   // Build chart data from history. A sample with no published count is dropped
   // rather than plotted as zero - the same rule PerformanceTab.tsx's `metricSeries`

--- a/src/components/monitoring/tabs/PerformanceTab.tsx
+++ b/src/components/monitoring/tabs/PerformanceTab.tsx
@@ -8,7 +8,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import type { MonitoringData } from "@/lib/db/types";
 import type { TimeSeriesPoint } from "@/lib/time-series-buffer";
-import { evaluateThreshold, getThresholdColor, DEFAULT_THRESHOLDS } from "@/lib/monitoring-thresholds";
+import { evaluateThreshold, getThresholdColor, thresholdFor } from "@/lib/monitoring-thresholds";
+import { storage } from "@/lib/storage";
 import { CACHE_HIT_RATIO_UNAVAILABLE } from "@/lib/monitoring-cache-ratio";
 import { MetricChart } from "./MetricChart";
 import { PanelUnavailable } from "../PanelUnavailable";
@@ -138,21 +139,20 @@ export function PerformanceTab({ data, loading, history = [] }: PerformanceTabPr
     bufferPoolUsage === undefined ? undefined : { usage: bufferPoolUsage, ...getHealthStatus(bufferPoolUsage) };
   const deadlocks = performance?.deadlocks;
 
-  // Threshold evaluations. An absent metric scores "healthy" so the card border stays
-  // neutral: colouring it would rate the absence, which is what the stand-in 100 below
-  // does for the cache ratio.
-  const cacheThreshold = evaluateThreshold(
-    cacheHitRatio ?? 100,
-    DEFAULT_THRESHOLDS.find((t) => t.metric === "cacheHitRatio")!,
-  );
+  // Read storage here: storage-facade imports the defaults, so the threshold helper
+  // must stay pure to avoid a circular dependency.
+  const thresholds = storage.getThresholdConfig();
+  // An absent metric remains ungraded regardless of the saved thresholds.
+  const cacheThreshold =
+    cacheHitRatio === undefined
+      ? "healthy"
+      : evaluateThreshold(cacheHitRatio, thresholdFor(thresholds, "cacheHitRatio"));
   const bufferThreshold =
     bufferPoolUsage === undefined
       ? "healthy"
-      : evaluateThreshold(bufferPoolUsage, DEFAULT_THRESHOLDS.find((t) => t.metric === "bufferPoolUsage")!);
+      : evaluateThreshold(bufferPoolUsage, thresholdFor(thresholds, "bufferPoolUsage"));
   const deadlockThreshold =
-    deadlocks === undefined
-      ? "healthy"
-      : evaluateThreshold(deadlocks, DEFAULT_THRESHOLDS.find((t) => t.metric === "deadlocks")!);
+    deadlocks === undefined ? "healthy" : evaluateThreshold(deadlocks, thresholdFor(thresholds, "deadlocks"));
 
   // Build trend data from history. See `metricSeries` for why a missing sample is
   // dropped rather than read as a zero.

--- a/src/lib/monitoring-thresholds.ts
+++ b/src/lib/monitoring-thresholds.ts
@@ -15,6 +15,14 @@ export const DEFAULT_THRESHOLDS: ThresholdConfig[] = [
   { metric: "bufferPoolUsage", warning: 85, critical: 95, direction: "above", label: "Buffer Pool Usage" },
 ];
 
+export function thresholdFor(thresholds: ThresholdConfig[], metric: string): ThresholdConfig {
+  const config =
+    thresholds.find((threshold) => threshold.metric === metric) ??
+    DEFAULT_THRESHOLDS.find((threshold) => threshold.metric === metric);
+  if (!config) throw new Error(`Unknown monitoring metric: ${metric}`);
+  return config;
+}
+
 export function evaluateThreshold(value: number, config: ThresholdConfig): ThresholdLevel {
   if (config.direction === "above") {
     if (value >= config.critical) return "critical";

--- a/tests/components/monitoring/MonitoringDashboard.test.tsx
+++ b/tests/components/monitoring/MonitoringDashboard.test.tsx
@@ -4,6 +4,7 @@ import "../../helpers/mock-navigation";
 
 import { mock } from "bun:test";
 import { setupRechartssMock, setupFramerMotionMock } from "../../helpers/mock-monaco";
+import { DEFAULT_THRESHOLDS } from "@/lib/monitoring-thresholds";
 
 setupRechartssMock();
 setupFramerMotionMock();
@@ -53,6 +54,7 @@ mock.module("@/hooks/use-monitoring-data", () => ({
 
 mock.module("@/lib/storage", () => ({
   storage: {
+    getThresholdConfig: mock(() => DEFAULT_THRESHOLDS),
     getConnections: mock(() => [
       {
         id: "c1",

--- a/tests/components/monitoring/OverviewTab.test.tsx
+++ b/tests/components/monitoring/OverviewTab.test.tsx
@@ -79,6 +79,22 @@ describe("OverviewTab", () => {
     expect(cacheCard().className).toContain("border-hue-green");
   });
 
+  test("does not grade missing readings at saved boundaries", () => {
+    storage.saveThresholdConfig([
+      { metric: "connectionPercent", warning: 0, critical: 0, direction: "above", label: "Connections" },
+      { metric: "cacheHitRatio", warning: 100, critical: 100, direction: "below", label: "Cache" },
+    ]);
+    const base = makeData();
+    const data = {
+      ...base,
+      overview: { ...base.overview, maxConnections: 0 },
+      performance: { ...base.performance, cacheHitRatio: undefined },
+    } as MonitoringData;
+    const { getByText } = render(<OverviewTab data={data} loading={false} />);
+    expect(getByText("Connections").closest('[data-slot="card"]')!.className).toContain("border-hue-green");
+    expect(getByText("Cache Hit").closest('[data-slot="card"]')!.className).toContain("border-hue-green");
+  });
+
   test("renders skeleton while loading without data", () => {
     const { queryByText } = render(<OverviewTab data={null} loading />);
     expect(queryByText("Connections")).toBeNull();

--- a/tests/components/monitoring/OverviewTab.test.tsx
+++ b/tests/components/monitoring/OverviewTab.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
 import { OverviewTab } from "@/components/monitoring/tabs/OverviewTab";
+import { storage } from "@/lib/storage";
 import type { MonitoringData } from "@/lib/db/types";
 import type { TimeSeriesPoint } from "@/lib/time-series-buffer";
 
@@ -53,6 +54,29 @@ function makeHistory(): TimeSeriesPoint<MonitoringData>[] {
 describe("OverviewTab", () => {
   afterEach(() => {
     cleanup();
+    localStorage.removeItem("libredb_threshold_config");
+  });
+
+  test("uses saved monitoring thresholds and falls back for missing metrics", () => {
+    const data = makeData();
+    const { getByText, rerender } = render(<OverviewTab data={data} loading={false} />);
+    const connectionCard = () => getByText("Connections").closest('[data-slot="card"]')!;
+    const cacheCard = () => getByText("Cache Hit").closest('[data-slot="card"]')!;
+    expect(connectionCard().className).toContain("border-hue-green");
+    expect(cacheCard().className).toContain("border-hue-green");
+
+    storage.saveThresholdConfig([
+      { metric: "connectionPercent", warning: 5, critical: 7, direction: "above", label: "Connections" },
+      { metric: "cacheHitRatio", warning: 99, critical: 97, direction: "below", label: "Cache" },
+    ]);
+    rerender(<OverviewTab data={data} loading={false} />);
+    expect(connectionCard().className).toContain("border-hue-red");
+    expect(cacheCard().className).toContain("border-hue-red");
+
+    storage.saveThresholdConfig([]);
+    rerender(<OverviewTab data={data} loading={false} />);
+    expect(connectionCard().className).toContain("border-hue-green");
+    expect(cacheCard().className).toContain("border-hue-green");
   });
 
   test("renders skeleton while loading without data", () => {

--- a/tests/components/monitoring/PerformanceTab.test.tsx
+++ b/tests/components/monitoring/PerformanceTab.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
 import { PerformanceTab } from "@/components/monitoring/tabs/PerformanceTab";
+import { storage } from "@/lib/storage";
 import type { MonitoringData } from "@/lib/db/types";
 import type { TimeSeriesPoint } from "@/lib/time-series-buffer";
 
@@ -51,6 +52,32 @@ function makeHistory(): TimeSeriesPoint<MonitoringData>[] {
 describe("PerformanceTab", () => {
   afterEach(() => {
     cleanup();
+    localStorage.removeItem("libredb_threshold_config");
+  });
+
+  test("uses saved monitoring thresholds and falls back for missing metrics", () => {
+    const data = makeData({ deadlocks: 6 });
+    const { getAllByText, rerender } = render(<PerformanceTab data={data} loading={false} />);
+    const card = (title: string) => getAllByText(title)[0].closest('[data-slot="card"]')!;
+    expect(card("Cache Hit").className).toContain("border-hue-green");
+    expect(card("Buffer").className).toContain("border-hue-green");
+    expect(card("Deadlocks").className).toContain("border-hue-red");
+
+    storage.saveThresholdConfig([
+      { metric: "cacheHitRatio", warning: 100, critical: 99, direction: "below", label: "Cache" },
+      { metric: "bufferPoolUsage", warning: 60, critical: 64, direction: "above", label: "Buffer" },
+      { metric: "deadlocks", warning: 10, critical: 20, direction: "above", label: "Deadlocks" },
+    ]);
+    rerender(<PerformanceTab data={data} loading={false} />);
+    expect(card("Cache Hit").className).toContain("border-hue-red");
+    expect(card("Buffer").className).toContain("border-hue-red");
+    expect(card("Deadlocks").className).toContain("border-hue-green");
+
+    storage.saveThresholdConfig([]);
+    rerender(<PerformanceTab data={data} loading={false} />);
+    expect(card("Cache Hit").className).toContain("border-hue-green");
+    expect(card("Buffer").className).toContain("border-hue-green");
+    expect(card("Deadlocks").className).toContain("border-hue-red");
   });
 
   test("renders skeleton while loading without data", () => {

--- a/tests/components/monitoring/PerformanceTab.test.tsx
+++ b/tests/components/monitoring/PerformanceTab.test.tsx
@@ -80,6 +80,14 @@ describe("PerformanceTab", () => {
     expect(card("Deadlocks").className).toContain("border-hue-red");
   });
 
+  test("does not grade missing readings at saved boundaries", () => {
+    storage.saveThresholdConfig([
+      { metric: "cacheHitRatio", warning: 100, critical: 100, direction: "below", label: "Cache" },
+    ]);
+    const { getByText } = render(<PerformanceTab data={makeData({ cacheHitRatio: undefined })} loading={false} />);
+    expect(getByText("Cache Hit").closest('[data-slot="card"]')!.className).toContain("border-hue-green");
+  });
+
   test("renders skeleton while loading without data", () => {
     const { queryByText } = render(<PerformanceTab data={null} loading />);
     expect(queryByText("Cache Hit")).toBeNull();

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -30,7 +30,7 @@ FAIL=0
 # green summary line reported a group count no run had.
 # Drifted again before this line was touched: it read 30 while 32 `run_group` calls
 # existed, so every green run reported a group count no run had. 33 is the grep below.
-TOTAL_GROUPS=34
+TOTAL_GROUPS=35
 EXTRA_BUN_ARGS=("$@")
 GROUP_INDEX=0
 COVERAGE_MODE=0
@@ -282,7 +282,10 @@ run_group "Group 15/16: Remaining components" \
   tests/components/monitoring/StorageTab.test.tsx \
   tests/components/monitoring/SessionsTab.test.tsx \
   tests/components/monitoring/TablesTab.test.tsx \
-  tests/components/monitoring/QueriesTab.test.tsx \
+  tests/components/monitoring/QueriesTab.test.tsx
+
+# Read the real threshold storage without the other group's partial storage mocks.
+run_group "Group 22: Saved monitoring thresholds" \
   tests/components/monitoring/PerformanceTab.test.tsx \
   tests/components/monitoring/OverviewTab.test.tsx
 

--- a/tests/unit/lib/monitoring-thresholds.test.ts
+++ b/tests/unit/lib/monitoring-thresholds.test.ts
@@ -1,11 +1,33 @@
 import { describe, test, expect } from "bun:test";
 import {
+  thresholdFor,
   evaluateThreshold,
   getThresholdColor,
   getThresholdBadgeVariant,
   DEFAULT_THRESHOLDS,
   type ThresholdConfig,
 } from "@/lib/monitoring-thresholds";
+
+describe("thresholdFor", () => {
+  test("prefers a saved threshold over its default", () => {
+    const saved: ThresholdConfig = {
+      metric: "cacheHitRatio",
+      warning: 99,
+      critical: 97,
+      direction: "below",
+      label: "Cache Hit Ratio",
+    };
+    expect(thresholdFor([saved], "cacheHitRatio")).toBe(saved);
+  });
+
+  test.each(DEFAULT_THRESHOLDS)("falls back to the default for an omitted metric: $metric", (config) => {
+    expect(thresholdFor([], config.metric)).toBe(config);
+  });
+
+  test("rejects an unknown metric instead of returning undefined", () => {
+    expect(() => thresholdFor([], "unknown")).toThrow("Unknown monitoring metric: unknown");
+  });
+});
 
 // ============================================================================
 // evaluateThreshold — direction='above'


### PR DESCRIPTION
## Description

The admin threshold editor saved values that the monitoring tabs ignored. Overview and Performance now read the saved configuration on render and use a pure `thresholdFor` helper to fall back to the existing default for each omitted metric. Unavailable measurements remain ungraded, including with custom boundary values. Default numbers and metric keys are unchanged.

Closes #674.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Test addition or update

## Changes Made

- Keep storage reads in the components so `monitoring-thresholds.ts` does not import the storage facade that already depends on it.
- Exercise saved values and partial configurations through real storage writes in both component regressions. Give these tests their own runner group to avoid the other group's partial storage mocks; update the dashboard's existing storage mock for its child tabs.
- Cover saved-value precedence, each default fallback and rejection of unknown metric names.

## Testing

- TDD: both new component regressions failed on the original code (red border expected, green observed), then passed with the fix.
- `bun run test:components --pass-with-no-tests -t 'OverviewTab|PerformanceTab|MonitoringDashboard'`: 74 passed, 0 failed across the matching isolated groups.
- `bun run test:unit --pass-with-no-tests -t 'thresholdFor|evaluateThreshold|getThresholdColor|getThresholdBadgeVariant|DEFAULT_THRESHOLDS'`: 25 passed, 0 failed.
- Passed: `format`, `lint`, `typecheck`, `knip`, `readme:check`, `chart:check`, `channels:showcase:check`, `security:check`, production `build`, `build:lib`, and `attw`.
- Local full `bun run test` / coverage and E2E were not completed: this Windows host lacks Helm and its PostgreSQL chart dependency, Docker is unavailable, and existing SQLite cleanup tests encounter Windows file-lock errors. The official Linux CI run must verify the complete suite and 100% coverage gate.
- The initial worktree build rejected a `node_modules` junction outside its root. Production and library builds then passed from a clean checkout of the same commit with real local dependencies; no project configuration workaround was added.

The absent-reading regressions set connection limits to zero and cache ratios to undefined while saved thresholds would grade numeric stand-ins as critical. Replacing each of the three guards individually with the old nullish-coalescing stand-in makes the corresponding case fail; restoring the guards passes both cases. Production source is unchanged in this follow-up; format, lint and typecheck were rerun.

Environment: Windows, Node.js 24.18.1, Bun 1.4.2. No live database is needed for this threshold change.

## Checklist

- [x] Followed the existing style and reviewed the diff.
- [x] Added regression tests with the executable change.
- [x] Required CI test job passes the 100% line-coverage gate on commit 3c58606bbf2804a0b77fa556e6b31e25709eeca4.

## Additional Notes

AI-assisted implementation and test execution using Codex. This changes how existing settings are applied, with no new storage schema, API or dependencies. Provider triad and screenshots are not applicable; no layout is changed.


Current commit CI: [official Linux run](https://github.com/libredb/libredb-studio/actions/runs/34382251115); 20 checks passed and the two expected Image Scan / fork SonarCloud jobs were skipped.
