### PR TITLE
feat(masking): prefill PII presets in the pattern editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Standalone application only: the embedded `@libredb/studio` package carries no a
 ### Display Masking (Preview)
 - **Client-Side Display Layer**: Masks sensitive values in the browser UI — useful for screen sharing, demos, and reducing accidental on-screen exposure. **Not server-enforced**; query API responses still contain full values for authenticated users.
 - **Column-Name Pattern Matching**: 10 built-in patterns (email, phone, credit card, SSN, password, IP, date, financial, and more) match **result column headers** by regex. Works when the output name matches (e.g., `SELECT salary`). Aliases (`salary AS x`) and aggregates (`SUM(salary)`) are not masked today.
-- **Configurable Rules**: Admin panel to add, edit, enable/disable masking patterns. Custom patterns with regex support. Settings stored per-browser in localStorage.
+- **Configurable Rules**: Admin panel to add, edit, enable/disable masking patterns. The Add Pattern dialog offers editable email, phone, credit card and SSN presets alongside custom patterns with regex support. Settings stored per-browser in localStorage.
 - **RBAC UI Controls**: User role cannot toggle or reveal masked cells in the UI. Admin role can toggle masking and temporarily reveal individual cells (10s auto-hide).
 - **Export & Clipboard**: CSV, JSON, and SQL INSERT exports use masked display values when masking is active in the UI. This does not prevent access to raw data via the API, browser DevTools, or admin reveal.
 - **UI Coverage**: Grid, mobile card/table views, row detail sheet, and clipboard copy respect the active display mask.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Standalone application only: the embedded `@libredb/studio` package carries no a
 ### Display Masking (Preview)
 - **Client-Side Display Layer**: Masks sensitive values in the browser UI — useful for screen sharing, demos, and reducing accidental on-screen exposure. **Not server-enforced**; query API responses still contain full values for authenticated users.
 - **Column-Name Pattern Matching**: 10 built-in patterns (email, phone, credit card, SSN, password, IP, date, financial, and more) match **result column headers** by regex. Works when the output name matches (e.g., `SELECT salary`). Aliases (`salary AS x`) and aggregates (`SUM(salary)`) are not masked today.
-- **Configurable Rules**: Admin panel to add, edit, enable/disable masking patterns. The Add Pattern dialog offers editable email, phone, credit card and SSN presets alongside custom patterns with regex support. Settings stored per-browser in localStorage.
+- **Configurable Rules**: Admin panel to add, edit, enable/disable masking patterns. Email, phone, credit card and SSN presets prefill the Add Pattern form so column patterns can be adapted before saving. Custom patterns support regex. Settings stored per-browser in localStorage.
 - **RBAC UI Controls**: User role cannot toggle or reveal masked cells in the UI. Admin role can toggle masking and temporarily reveal individual cells (10s auto-hide).
 - **Export & Clipboard**: CSV, JSON, and SQL INSERT exports use masked display values when masking is active in the UI. This does not prevent access to raw data via the API, browser DevTools, or admin reveal.
 - **UI Coverage**: Grid, mobile card/table views, row detail sheet, and clipboard copy respect the active display mask.

--- a/src/components/MaskingSettings.tsx
+++ b/src/components/MaskingSettings.tsx
@@ -10,7 +10,6 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Shield, Plus, Pencil, Trash2, RotateCcw, Save, Lock } from "lucide-react";
 import { toast } from "sonner";
-import { newLocalId } from "@/lib/ids";
 import {
   type MaskingConfig,
   type MaskingPattern,
@@ -103,16 +102,11 @@ export function MaskingSettings() {
     setIsDialogOpen(true);
   }, []);
 
-  const addPreset = useCallback((preset: MaskingPattern) => {
-    const pattern: MaskingPattern = {
-      ...preset,
-      id: `custom-${newLocalId()}`,
-      columnPatterns: [...preset.columnPatterns],
-      enabled: true,
-      isBuiltin: false,
-    };
-    setConfig((prev) => ({ ...prev, patterns: [...prev.patterns, pattern] }));
-    setIsDialogOpen(false);
+  const prefillPreset = useCallback((preset: MaskingPattern) => {
+    setEditName(preset.name);
+    setEditMaskType(preset.maskType);
+    setEditColumnPatterns(preset.columnPatterns.join("\n"));
+    setEditCustomMask(preset.customMask || "");
   }, []);
 
   const handleDialogSave = useCallback(() => {
@@ -364,21 +358,21 @@ export function MaskingSettings() {
           <div className="space-y-4 py-4">
             {isNewPattern && (
               <div className="space-y-2">
-                <p className="text-xs font-medium text-fg-secondary">Add from preset</p>
+                <p className="text-xs font-medium text-fg-secondary">Start from a preset</p>
                 <div className="flex flex-wrap gap-2">
                   {MASKING_PRESETS.map((preset) => (
                     <Button
                       key={preset.id}
                       variant="outline"
                       size="sm"
-                      aria-label={`Add ${preset.name} preset`}
-                      onClick={() => addPreset(preset)}
+                      aria-label={`Use ${preset.name} preset`}
+                      onClick={() => prefillPreset(preset)}
                     >
                       {preset.name}
                     </Button>
                   ))}
                 </div>
-                <p className="text-xs text-fg-muted">Adds an editable copy, or fill in a custom pattern below.</p>
+                <p className="text-xs text-fg-muted">Review and edit the column patterns before saving.</p>
               </div>
             )}
             <div className="space-y-2">

--- a/src/components/MaskingSettings.tsx
+++ b/src/components/MaskingSettings.tsx
@@ -10,6 +10,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Shield, Plus, Pencil, Trash2, RotateCcw, Save, Lock } from "lucide-react";
 import { toast } from "sonner";
+import { newLocalId } from "@/lib/ids";
 import {
   type MaskingConfig,
   type MaskingPattern,
@@ -33,6 +34,10 @@ const ALL_MASK_TYPES: MaskType[] = [
   "financial",
   "custom",
 ];
+
+const MASKING_PRESETS = DEFAULT_MASKING_CONFIG.patterns.filter((pattern) =>
+  ["email", "phone", "card", "ssn"].includes(pattern.maskType),
+);
 
 export function MaskingSettings() {
   const [config, setConfig] = useState<MaskingConfig>(() => loadMaskingConfig());
@@ -96,6 +101,18 @@ export function MaskingSettings() {
     setEditCustomMask("");
     setIsNewPattern(true);
     setIsDialogOpen(true);
+  }, []);
+
+  const addPreset = useCallback((preset: MaskingPattern) => {
+    const pattern: MaskingPattern = {
+      ...preset,
+      id: `custom-${newLocalId()}`,
+      columnPatterns: [...preset.columnPatterns],
+      enabled: true,
+      isBuiltin: false,
+    };
+    setConfig((prev) => ({ ...prev, patterns: [...prev.patterns, pattern] }));
+    setIsDialogOpen(false);
   }, []);
 
   const handleDialogSave = useCallback(() => {
@@ -345,6 +362,25 @@ export function MaskingSettings() {
             <DialogTitle>{isNewPattern ? "Add Masking Pattern" : "Edit Masking Pattern"}</DialogTitle>
           </DialogHeader>
           <div className="space-y-4 py-4">
+            {isNewPattern && (
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-fg-secondary">Add from preset</p>
+                <div className="flex flex-wrap gap-2">
+                  {MASKING_PRESETS.map((preset) => (
+                    <Button
+                      key={preset.id}
+                      variant="outline"
+                      size="sm"
+                      aria-label={`Add ${preset.name} preset`}
+                      onClick={() => addPreset(preset)}
+                    >
+                      {preset.name}
+                    </Button>
+                  ))}
+                </div>
+                <p className="text-xs text-fg-muted">Adds an editable copy, or fill in a custom pattern below.</p>
+              </div>
+            )}
             <div className="space-y-2">
               <label htmlFor="masking-pattern-name" className="text-xs font-medium text-fg-secondary">
                 Name

--- a/tests/components/MaskingSettings.test.tsx
+++ b/tests/components/MaskingSettings.test.tsx
@@ -3,7 +3,7 @@ import { mockToastSuccess, mockToastError } from "../helpers/mock-sonner";
 import "../helpers/mock-navigation";
 
 import { mock } from "bun:test";
-import { DEFAULT_MASKING_CONFIG, type MaskingConfig } from "@/lib/data-masking";
+import { DEFAULT_MASKING_CONFIG, detectSensitiveColumnsFromConfig, type MaskingConfig } from "@/lib/data-masking";
 
 // Build mock config that matches the shape from the real module
 const mockConfig = {
@@ -35,9 +35,10 @@ const mockConfig = {
 // Keep the real preset definitions before replacing persistence for this isolated group.
 const realDefaults = DEFAULT_MASKING_CONFIG;
 const presetConfig = structuredClone(realDefaults);
+const detectColumns = detectSensitiveColumnsFromConfig;
 
 const mockSaveMaskingConfig = mock((_config: MaskingConfig) => {});
-const mockLoadMaskingConfig = mock(() => structuredClone(mockConfig));
+const mockLoadMaskingConfig = mock((): MaskingConfig => structuredClone(mockConfig));
 
 mock.module("@/lib/data-masking", () => ({
   loadMaskingConfig: mockLoadMaskingConfig,
@@ -410,15 +411,22 @@ describe("MaskingSettings", () => {
   // ── handleDialogSave — validation ────────────────────────────────────
 
   test.each(["Email", "Phone", "Credit Card", "SSN"])(
-    "adds an editable %s preset without changing existing patterns",
+    "prefills an editable %s preset before creating a pattern",
     (name) => {
       const preset = presetConfig.patterns.find((pattern) => pattern.name === name)!;
       const { container, baseElement } = render(<MaskingSettings />);
       const view = within(container);
       fireEvent.click(view.getByText("Add Pattern"));
-      fireEvent.click(within(baseElement).getByRole("button", { name: `Add ${preset.name} preset` }));
-      expect(within(baseElement).queryByText("Add Masking Pattern")).toBeNull();
+      fireEvent.click(within(baseElement).getByRole("button", { name: `Use ${preset.name} preset` }));
+      expect(within(baseElement).queryByText("Add Masking Pattern") !== null).toBe(true);
+      expect((within(baseElement).getByLabelText("Name") as HTMLInputElement).value).toBe(preset.name);
+      expect((within(baseElement).getByLabelText("Column Patterns (one per line)") as HTMLTextAreaElement).value).toBe(
+        preset.columnPatterns.join("\n"),
+      );
+      expect(within(baseElement).getByLabelText("Mask Type").textContent).toContain(preset.maskType);
+      expect(container.querySelectorAll(".lucide-pencil").length).toBe(2);
       expect(mockSaveMaskingConfig).not.toHaveBeenCalled();
+      fireEvent.click(within(baseElement).getByRole("button", { name: "Save" }));
       fireEvent.click(view.getByText("Save Config"));
 
       const saved = mockSaveMaskingConfig.mock.calls.at(-1)![0];
@@ -437,7 +445,7 @@ describe("MaskingSettings", () => {
 
       const editButtons = container.querySelectorAll(".lucide-pencil");
       fireEvent.click(editButtons[editButtons.length - 1].closest("button")!);
-      expect(within(baseElement).queryByText("Add from preset")).toBeNull();
+      expect(within(baseElement).queryByText("Start from a preset")).toBeNull();
       fireEvent.change(within(baseElement).getByLabelText("Name"), { target: { value: "Team pattern" } });
       fireEvent.change(within(baseElement).getByLabelText("Column Patterns (one per line)"), {
         target: { value: "team_contact" },
@@ -455,20 +463,41 @@ describe("MaskingSettings", () => {
     },
   );
 
-  test("adding the same preset twice creates independently removable patterns", () => {
+  test("switching presets then cancelling leaves the real default patterns unchanged", () => {
+    mockLoadMaskingConfig.mockImplementation(() => structuredClone(presetConfig));
     const { container, baseElement } = render(<MaskingSettings />);
     const view = within(container);
-    for (let i = 0; i < 2; i++) {
-      fireEvent.click(view.getByText("Add Pattern"));
-      fireEvent.click(within(baseElement).getByRole("button", { name: "Add Email preset" }));
+    fireEvent.click(view.getByText("Add Pattern"));
+    for (const name of ["Email", "Phone"]) {
+      fireEvent.click(within(baseElement).getByRole("button", { name: `Use ${name} preset` }));
+      expect((within(baseElement).getByLabelText("Name") as HTMLInputElement).value).toBe(name);
+      expect(container.querySelectorAll(".lucide-pencil").length).toBe(presetConfig.patterns.length);
     }
+    fireEvent.click(within(baseElement).getByRole("button", { name: "Cancel" }));
+    fireEvent.click(view.getByText("Save Config"));
+    expect(mockSaveMaskingConfig.mock.calls.at(-1)![0]).toEqual(presetConfig);
+  });
+
+  test("adapting a preset from the real defaults masks a new column without shadowing the builtin", () => {
+    mockLoadMaskingConfig.mockImplementation(() => structuredClone(presetConfig));
+    const { container, baseElement } = render(<MaskingSettings />);
+    const view = within(container);
+    fireEvent.click(view.getByText("Add Pattern"));
+    fireEvent.click(within(baseElement).getByRole("button", { name: "Use Email preset" }));
+    fireEvent.change(within(baseElement).getByLabelText("Name"), { target: { value: "Billing contact" } });
+    fireEvent.change(within(baseElement).getByLabelText("Column Patterns (one per line)"), {
+      target: { value: "billing_contact" },
+    });
+    fireEvent.click(within(baseElement).getByRole("button", { name: "Save" }));
     fireEvent.click(view.getByText("Save Config"));
     const saved = mockSaveMaskingConfig.mock.calls.at(-1)![0];
-    expect(new Set(saved.patterns.map((pattern) => pattern.id)).size).toBe(4);
-    const deleteButtons = container.querySelectorAll("button.text-danger");
-    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
-    fireEvent.click(view.getByText("Save Config"));
-    expect(mockSaveMaskingConfig.mock.calls.at(-1)![0].patterns).toEqual(saved.patterns.slice(0, -1));
+    expect(saved.patterns.slice(0, -1)).toEqual(presetConfig.patterns);
+    const matches = detectColumns(["email", "user_email", "contact_email", "billing_contact"], saved);
+    expect(matches.get("email")?.id).toBe("builtin-email");
+    expect(matches.get("user_email")?.id).toBe("builtin-email");
+    expect(matches.get("contact_email")?.id).toBe("builtin-email");
+    expect(matches.get("billing_contact")?.id).toBe(saved.patterns.at(-1)!.id);
+    expect(matches.get("billing_contact")?.isBuiltin).toBe(false);
   });
 
   test("dialog save with empty name shows error toast", () => {

--- a/tests/components/MaskingSettings.test.tsx
+++ b/tests/components/MaskingSettings.test.tsx
@@ -3,6 +3,7 @@ import { mockToastSuccess, mockToastError } from "../helpers/mock-sonner";
 import "../helpers/mock-navigation";
 
 import { mock } from "bun:test";
+import { DEFAULT_MASKING_CONFIG, type MaskingConfig } from "@/lib/data-masking";
 
 // Build mock config that matches the shape from the real module
 const mockConfig = {
@@ -31,7 +32,11 @@ const mockConfig = {
   },
 };
 
-const mockSaveMaskingConfig = mock(() => {});
+// Keep the real preset definitions before replacing persistence for this isolated group.
+const realDefaults = DEFAULT_MASKING_CONFIG;
+const presetConfig = structuredClone(realDefaults);
+
+const mockSaveMaskingConfig = mock((_config: MaskingConfig) => {});
 const mockLoadMaskingConfig = mock(() => structuredClone(mockConfig));
 
 mock.module("@/lib/data-masking", () => ({
@@ -403,6 +408,68 @@ describe("MaskingSettings", () => {
   });
 
   // ── handleDialogSave — validation ────────────────────────────────────
+
+  test.each(["Email", "Phone", "Credit Card", "SSN"])(
+    "adds an editable %s preset without changing existing patterns",
+    (name) => {
+      const preset = presetConfig.patterns.find((pattern) => pattern.name === name)!;
+      const { container, baseElement } = render(<MaskingSettings />);
+      const view = within(container);
+      fireEvent.click(view.getByText("Add Pattern"));
+      fireEvent.click(within(baseElement).getByRole("button", { name: `Add ${preset.name} preset` }));
+      expect(within(baseElement).queryByText("Add Masking Pattern")).toBeNull();
+      expect(mockSaveMaskingConfig).not.toHaveBeenCalled();
+      fireEvent.click(view.getByText("Save Config"));
+
+      const saved = mockSaveMaskingConfig.mock.calls.at(-1)![0];
+      expect(saved.patterns.slice(0, 2)).toEqual(mockConfig.patterns);
+      expect(saved.roleSettings).toEqual(mockConfig.roleSettings);
+      const added = saved.patterns.at(-1)!;
+      expect(added).toMatchObject({
+        name: preset.name,
+        maskType: preset.maskType,
+        columnPatterns: preset.columnPatterns,
+        enabled: true,
+        isBuiltin: false,
+      });
+      expect(added.id).not.toBe(preset.id);
+      expect(added.columnPatterns).not.toBe(preset.columnPatterns);
+
+      const editButtons = container.querySelectorAll(".lucide-pencil");
+      fireEvent.click(editButtons[editButtons.length - 1].closest("button")!);
+      expect(within(baseElement).queryByText("Add from preset")).toBeNull();
+      fireEvent.change(within(baseElement).getByLabelText("Name"), { target: { value: "Team pattern" } });
+      fireEvent.change(within(baseElement).getByLabelText("Column Patterns (one per line)"), {
+        target: { value: "team_contact" },
+      });
+      fireEvent.click(within(baseElement).getByRole("button", { name: "Save" }));
+      fireEvent.click(view.getByText("Save Config"));
+      const edited = mockSaveMaskingConfig.mock.calls.at(-1)![0];
+      expect(edited.patterns.at(-1)).toMatchObject({
+        id: added.id,
+        name: "Team pattern",
+        columnPatterns: ["team_contact"],
+      });
+      expect(edited.patterns.slice(0, 2)).toEqual(mockConfig.patterns);
+      expect(realDefaults).toEqual(presetConfig);
+    },
+  );
+
+  test("adding the same preset twice creates independently removable patterns", () => {
+    const { container, baseElement } = render(<MaskingSettings />);
+    const view = within(container);
+    for (let i = 0; i < 2; i++) {
+      fireEvent.click(view.getByText("Add Pattern"));
+      fireEvent.click(within(baseElement).getByRole("button", { name: "Add Email preset" }));
+    }
+    fireEvent.click(view.getByText("Save Config"));
+    const saved = mockSaveMaskingConfig.mock.calls.at(-1)![0];
+    expect(new Set(saved.patterns.map((pattern) => pattern.id)).size).toBe(4);
+    const deleteButtons = container.querySelectorAll("button.text-danger");
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+    fireEvent.click(view.getByText("Save Config"));
+    expect(mockSaveMaskingConfig.mock.calls.at(-1)![0].patterns).toEqual(saved.patterns.slice(0, -1));
+  });
 
   test("dialog save with empty name shows error toast", () => {
     const { container, baseElement } = render(<MaskingSettings />);


### PR DESCRIPTION
## Description

The Add Pattern dialog offers Email, Phone, Credit Card and SSN starting points. Selecting one prefills the name, mask type, column expressions and custom mask, leaving the form open so the user can adapt the expressions before saving through the existing flow.

Closes #685.

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation and test updates

## Changes Made

Reuse the four definitions in `DEFAULT_MASKING_CONFIG`. Preset selection only changes form fields; it does not append a pattern. Existing built-ins, their first-match behavior, validation and the normal Save / Save Config controls remain intact. README documents the prefill behavior.

## Testing

- TDD: the original preset cases failed before implementation; six revised cases also failed against the immediate-append version before the review fix.
- `bun run test:components --pass-with-no-tests -t 'MaskingSettings'`: 41 matching tests passed, 0 failed (40 settings cases and one existing admin case).
- Covers all four presets, no creation before Save, subsequent editing, source-pattern preservation, switching and cancelling from the real ten-pattern default configuration, and adapting an Email preset to a new column. The latter calls the real detector to check that built-in columns still resolve to the original and the new column resolves to the custom rule.
- Passed locally: `format`, `lint`, `typecheck`, `knip`, `readme:check`, `chart:check`, `channels:showcase:check`, `security:check`, production `build`, `build:lib` and `attw`.
- Full local tests / coverage and E2E were not completed: the Windows host lacks Helm/chart dependencies, Docker is unavailable, and existing SQLite cleanup tests encounter Windows file-lock errors. Official Linux CI verifies the full suite and 100% line-coverage gate.

Environment: Windows, Node.js 24.18.1, Bun 1.4.2. Both builds ran from a clean checkout of commit `7ae66c8aa0b8139bbda669b898d9d3ee0dd435dd` with real local dependencies.

## Checklist

- [x] Reviewed the diff and followed the existing component style.
- [x] Added regression tests and updated documentation.
- [x] Required CI test job passes the 100% line-coverage gate on commit 7ae66c8aa0b8139bbda669b898d9d3ee0dd435dd.

## Additional Notes

AI-assisted implementation and test execution using Codex. No new dependencies, storage schema, server behavior or provider changes. Reusing an unchanged preset retains existing first-match behavior; the form exposes the expressions for adaptation before creating a rule.


Current commit CI: [official Linux run](https://github.com/libredb/libredb-studio/actions/runs/34386232251); 20 checks passed and the two expected Image Scan / fork SonarCloud jobs were skipped.
