### PR TITLE
feat(audit): export filtered operations and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Standalone application only: the embedded `@libredb/studio` package carries no a
 - **Threshold Alerting**: Color-coded health indicators (healthy/warning/critical) for cache hit ratio, connection usage, deadlocks, and buffer pool utilization.
 - **Connection Pool Stats**: Live total/active/idle/waiting pool metrics with utilization progress bars.
 - **One-Click Maintenance**: Trigger `VACUUM`, `ANALYZE`, `REINDEX`, `UPDATE STATISTICS`, `DBCC CHECKDB`, and `ALTER INDEX REBUILD` per database engine.
-- **Audit Trail**: Full history of every query executed across the organization.
+- **Audit Trail**: Full history of every query executed across the organization. The admin Audit tab exports loaded operations and query history as CSV or JSON, respecting the current filters.
 
 ---
 

--- a/src/components/QueryHistory.tsx
+++ b/src/components/QueryHistory.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useMemo } from "react";
 import { storage } from "@/lib/storage";
 import { QueryHistoryItem } from "@/lib/types";
-import { csvRow } from "@/lib/export/csv";
+import { queryHistoryText } from "@/lib/export/query-history";
 import { downloadText } from "@/lib/export/download";
 import {
   CircleCheck,
@@ -100,35 +100,11 @@ export function QueryHistory({ onSelectQuery, activeConnectionId, refreshTrigger
   };
 
   const exportHistory = (format: "csv" | "json") => {
-    let content = "";
-    let mimeType = "";
-    const fileName = `query_history_${new Date().getTime()}.${format}`;
-
-    if (format === "csv") {
-      const headers = ["Executed At", "Status", "Connection", "Tab", "Execution Time (ms)", "Rows", "Query", "Error"];
-      // Every field goes through the shared writer. The query and the error message
-      // used to be the only two that were escaped, so a connection or tab name
-      // holding a comma shifted every column after it for that row.
-      const rows = filteredHistory.map((item) =>
-        csvRow([
-          item.executedAt,
-          item.status,
-          item.connectionName || item.connectionId,
-          item.tabName || "",
-          item.executionTime,
-          item.rowCount || 0,
-          item.query,
-          item.errorMessage || "",
-        ]),
-      );
-      content = [csvRow(headers), ...rows].join("\n");
-      mimeType = "text/csv";
-    } else {
-      content = JSON.stringify(filteredHistory, null, 2);
-      mimeType = "application/json";
-    }
-
-    downloadText(content, mimeType, fileName);
+    downloadText(
+      queryHistoryText(filteredHistory, format),
+      format === "csv" ? "text/csv" : "application/json",
+      `query_history_${Date.now()}.${format}`,
+    );
   };
 
   return (

--- a/src/components/admin/tabs/AuditTab.tsx
+++ b/src/components/admin/tabs/AuditTab.tsx
@@ -35,6 +35,7 @@ import { format, subDays, startOfDay } from "date-fns";
 import { useEffectiveTheme } from "@/hooks/use-effective-theme";
 import { chartTooltipStyle } from "@/lib/charts/palette";
 import { csvRow } from "@/lib/export/csv";
+import { queryHistoryText } from "@/lib/export/query-history";
 import { downloadText } from "@/lib/export/download";
 
 interface AuditExportProps {
@@ -369,26 +370,11 @@ function QueryAudit() {
   }, [history, searchQuery, statusFilter]);
 
   const exportHistory = (format: "csv" | "json") => {
-    let content: string;
-    if (format === "csv") {
-      const headers = ["Executed At", "Status", "Connection", "Tab", "Execution Time (ms)", "Rows", "Query", "Error"];
-      const rows = filteredHistory.map((item) =>
-        csvRow([
-          item.executedAt,
-          item.status,
-          item.connectionName || item.connectionId,
-          item.tabName || "",
-          item.executionTime,
-          item.rowCount || 0,
-          item.query,
-          item.errorMessage || "",
-        ]),
-      );
-      content = [csvRow(headers), ...rows].join("\n");
-    } else {
-      content = JSON.stringify(filteredHistory, null, 2);
-    }
-    downloadText(content, format === "csv" ? "text/csv" : "application/json", `query_history_${Date.now()}.${format}`);
+    downloadText(
+      queryHistoryText(filteredHistory, format),
+      format === "csv" ? "text/csv" : "application/json",
+      `query_history_${Date.now()}.${format}`,
+    );
   };
 
   const successCount = history.filter((h) => h.status === "success").length;

--- a/src/components/admin/tabs/AuditTab.tsx
+++ b/src/components/admin/tabs/AuditTab.tsx
@@ -35,6 +35,7 @@ import { format, subDays, startOfDay } from "date-fns";
 import { useEffectiveTheme } from "@/hooks/use-effective-theme";
 import { chartTooltipStyle } from "@/lib/charts/palette";
 import { csvRow } from "@/lib/export/csv";
+import { jsonText } from "@/lib/export/json";
 import { queryHistoryText } from "@/lib/export/query-history";
 import { downloadText } from "@/lib/export/download";
 
@@ -214,7 +215,7 @@ function OperationsAudit() {
       );
       content = [csvRow(headers), ...rows].join("\n");
     } else {
-      content = JSON.stringify(filteredEvents, null, 2);
+      content = jsonText(filteredEvents, 2);
     }
     downloadText(
       content,

--- a/src/components/admin/tabs/AuditTab.tsx
+++ b/src/components/admin/tabs/AuditTab.tsx
@@ -11,6 +11,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   Wrench,
   Search as SearchIcon,
   ChartColumn,
@@ -19,6 +25,7 @@ import {
   RefreshCw,
   Clock,
   Activity,
+  Download,
 } from "lucide-react";
 import type { AuditEvent } from "@/lib/audit";
 import { storage } from "@/lib/storage";
@@ -27,6 +34,29 @@ import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recha
 import { format, subDays, startOfDay } from "date-fns";
 import { useEffectiveTheme } from "@/hooks/use-effective-theme";
 import { chartTooltipStyle } from "@/lib/charts/palette";
+import { csvRow } from "@/lib/export/csv";
+import { downloadText } from "@/lib/export/download";
+
+interface AuditExportProps {
+  disabled: boolean;
+  onExport: (format: "csv" | "json") => void;
+}
+
+function AuditExport({ disabled, onExport }: AuditExportProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-8 text-xs gap-2" disabled={disabled}>
+          <Download className="w-3 h-3" /> Export
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => onExport("csv")}>Export as CSV</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onExport("json")}>Export as JSON</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
 
 export function AuditTab() {
   return (
@@ -144,6 +174,54 @@ function OperationsAudit() {
     );
   }, [events, searchQuery]);
 
+  const exportEvents = (format: "csv" | "json") => {
+    let content: string;
+    if (format === "csv") {
+      const headers = [
+        "Timestamp",
+        "Type",
+        "Action",
+        "Target",
+        "Connection",
+        "User",
+        "Result",
+        "Duration (ms)",
+        "Details",
+        "IP",
+        "Reason",
+        "Bucket",
+        "Correlation ID",
+        "ID",
+      ];
+      const rows = filteredEvents.map((event) =>
+        csvRow([
+          event.timestamp,
+          event.type,
+          event.action,
+          event.target,
+          event.connectionName,
+          event.user,
+          event.result,
+          event.duration,
+          event.details,
+          event.ip,
+          event.reason,
+          event.bucket,
+          event.correlationId,
+          event.id,
+        ]),
+      );
+      content = [csvRow(headers), ...rows].join("\n");
+    } else {
+      content = JSON.stringify(filteredEvents, null, 2);
+    }
+    downloadText(
+      content,
+      format === "csv" ? "text/csv" : "application/json",
+      `audit_operations_${Date.now()}.${format}`,
+    );
+  };
+
   const successCount = events.filter((e) => e.result === "success").length;
   const successRate = events.length > 0 ? Math.round((successCount / events.length) * 100) : 0;
 
@@ -184,6 +262,7 @@ function OperationsAudit() {
           <RefreshCw className={`w-3 h-3 mr-1.5 ${loading ? "animate-spin" : ""}`} />
           Refresh
         </Button>
+        <AuditExport disabled={loading || filteredEvents.length === 0} onExport={exportEvents} />
       </div>
 
       {/* Stats Summary */}
@@ -286,8 +365,31 @@ function QueryAudit() {
         (h) => h.query.toLowerCase().includes(q) || (h.connectionName || "").toLowerCase().includes(q),
       );
     }
-    return items.slice(0, 200);
+    return items;
   }, [history, searchQuery, statusFilter]);
+
+  const exportHistory = (format: "csv" | "json") => {
+    let content: string;
+    if (format === "csv") {
+      const headers = ["Executed At", "Status", "Connection", "Tab", "Execution Time (ms)", "Rows", "Query", "Error"];
+      const rows = filteredHistory.map((item) =>
+        csvRow([
+          item.executedAt,
+          item.status,
+          item.connectionName || item.connectionId,
+          item.tabName || "",
+          item.executionTime,
+          item.rowCount || 0,
+          item.query,
+          item.errorMessage || "",
+        ]),
+      );
+      content = [csvRow(headers), ...rows].join("\n");
+    } else {
+      content = JSON.stringify(filteredHistory, null, 2);
+    }
+    downloadText(content, format === "csv" ? "text/csv" : "application/json", `query_history_${Date.now()}.${format}`);
+  };
 
   const successCount = history.filter((h) => h.status === "success").length;
   const successRate = history.length > 0 ? Math.round((successCount / history.length) * 100) : 0;
@@ -317,6 +419,7 @@ function QueryAudit() {
           <span className="mx-2">&middot;</span>
           <span className="text-success font-bold">{successRate}%</span> success
         </div>
+        <AuditExport disabled={filteredHistory.length === 0} onExport={exportHistory} />
       </div>
 
       {/* Query History Table */}
@@ -343,7 +446,7 @@ function QueryAudit() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredHistory.map((item, idx) => (
+              {filteredHistory.slice(0, 200).map((item, idx) => (
                 <TableRow key={idx} className="border-hairline hover:bg-fill">
                   <TableCell className="py-2">
                     {item.status === "success" ? (

--- a/src/lib/export/query-history.ts
+++ b/src/lib/export/query-history.ts
@@ -1,10 +1,16 @@
 import type { QueryHistoryItem } from "@/lib/types";
 import { csvRow } from "./csv";
+import { jsonText } from "./json";
 
+/** Shared record shape for the query-history panel and the admin audit tab. */
 export function queryHistoryText(items: readonly QueryHistoryItem[], format: "csv" | "json"): string {
-  if (format === "json") return JSON.stringify(items, null, 2);
+  // Keep the export path's bigint/cycle handling even though today's typed
+  // history fields are primitives. Future metadata must not break the download.
+  if (format === "json") return jsonText(items, 2);
 
   const headers = ["Executed At", "Status", "Connection", "Tab", "Execution Time (ms)", "Rows", "Query", "Error"];
+  // Every field goes through the shared CSV writer. Escaping only query/error
+  // once let commas in connection and tab names shift every following column.
   const rows = items.map((item) =>
     csvRow([
       item.executedAt,

--- a/src/lib/export/query-history.ts
+++ b/src/lib/export/query-history.ts
@@ -1,0 +1,21 @@
+import type { QueryHistoryItem } from "@/lib/types";
+import { csvRow } from "./csv";
+
+export function queryHistoryText(items: readonly QueryHistoryItem[], format: "csv" | "json"): string {
+  if (format === "json") return JSON.stringify(items, null, 2);
+
+  const headers = ["Executed At", "Status", "Connection", "Tab", "Execution Time (ms)", "Rows", "Query", "Error"];
+  const rows = items.map((item) =>
+    csvRow([
+      item.executedAt,
+      item.status,
+      item.connectionName || item.connectionId,
+      item.tabName || "",
+      item.executionTime,
+      item.rowCount || 0,
+      item.query,
+      item.errorMessage || "",
+    ]),
+  );
+  return [csvRow(headers), ...rows].join("\n");
+}

--- a/tests/components/admin/AuditTab.test.tsx
+++ b/tests/components/admin/AuditTab.test.tsx
@@ -45,6 +45,9 @@ const defaultHistory = () => [
 
 let mockHistory: ReturnType<typeof defaultHistory> = defaultHistory();
 
+const mockDownloadText = mock((_content: string, _mimeType: string, _fileName: string) => {});
+mock.module("@/lib/export/download", () => ({ downloadText: mockDownloadText }));
+
 mock.module("@/lib/storage", () => ({
   storage: {
     getHistory: mock(() => mockHistory),
@@ -79,6 +82,7 @@ describe("AuditTab", () => {
   let fetchMock: ReturnType<typeof mockGlobalFetch>;
 
   beforeEach(() => {
+    mockDownloadText.mockClear();
     mockHistory = defaultHistory();
     fetchMock = mockGlobalFetch({
       "/api/admin/audit": {
@@ -126,6 +130,110 @@ describe("AuditTab", () => {
     expect(queryByText("Operations")).not.toBeNull();
     expect(queryByText("Queries")).not.toBeNull();
     expect(queryByText("Stats")).not.toBeNull();
+  });
+
+  test.each(["csv", "json"])("exports only the filtered operations as %s", async (format) => {
+    const event = {
+      id: "audit-export",
+      timestamp: "2026-09-09T10:00:00.000Z",
+      type: "maintenance",
+      action: "VACUUM",
+      target: 'users,"archive"\n2026',
+      connectionName: "团队,DB",
+      user: "=admin",
+      result: "success",
+      duration: 0,
+      details: 'completed "safely"',
+      ip: "192.0.2.1",
+      reason: "origin_mismatch",
+      bucket: "login_client",
+      correlationId: "op-1",
+    };
+    fetchMock = mockGlobalFetch({
+      "/api/admin/audit": (req: Request) => ({
+        json: {
+          events:
+            new URL(req.url).searchParams.get("type") === "maintenance"
+              ? [event, { ...event, id: "hidden-by-search", target: "orders" }]
+              : [event, { ...event, id: "hidden-by-type", type: "kill_session", action: "KILL" }],
+        },
+      }),
+    });
+    const user = userEvent.setup();
+    const view = render(<AuditTab />);
+    await waitFor(() => expect(view.queryByText("KILL")).not.toBeNull());
+    fireEvent.keyDown(view.getByRole("combobox"), { key: "ArrowDown" });
+    fireEvent.keyDown(view.getByRole("option", { name: "Maintenance" }), { key: "Enter" });
+    await waitFor(() => expect(view.queryByText("orders")).not.toBeNull());
+    fireEvent.change(view.getByPlaceholderText("Search..."), { target: { value: "archive" } });
+    await user.click(view.getByRole("button", { name: "Export" }));
+    await user.click(view.getByRole("menuitem", { name: `Export as ${format.toUpperCase()}` }));
+    const [content, mime, fileName] = mockDownloadText.mock.calls.at(-1)!;
+    expect(fileName).toMatch(new RegExp(`^audit_operations_\\d+\\.${format}$`));
+    if (format === "json") {
+      expect(mime).toBe("application/json");
+      expect(content).toBe(JSON.stringify([event], null, 2));
+    } else {
+      expect(mime).toBe("text/csv");
+      expect(content).toBe(
+        'Timestamp,Type,Action,Target,Connection,User,Result,Duration (ms),Details,IP,Reason,Bucket,Correlation ID,ID\n2026-09-09T10:00:00.000Z,maintenance,VACUUM,"users,""archive""\n2026","团队,DB","\'=admin",success,0,"completed ""safely""",192.0.2.1,origin_mismatch,login_client,op-1,audit-export',
+      );
+    }
+  });
+
+  test.each(["csv", "json"])(
+    "exports only filtered query history as %s with the history export shape",
+    async (format) => {
+      mockHistory = [
+        { ...defaultHistory()[0], query: "SELECT 'selected'", executedAt: new Date("2026-09-09T10:00:00Z") },
+        { ...defaultHistory()[1], query: "SELECT 'selected'" },
+        { ...defaultHistory()[0], id: "h3", query: "SELECT 'hidden'" },
+      ];
+      const user = userEvent.setup();
+      const view = render(<AuditTab />);
+      await user.click(view.getByRole("tab", { name: "Queries" }));
+      fireEvent.keyDown(view.getByRole("combobox"), { key: "ArrowDown" });
+      fireEvent.keyDown(view.getByRole("option", { name: "Success" }), { key: "Enter" });
+      fireEvent.change(view.getByPlaceholderText("Search query..."), { target: { value: "selected" } });
+      await user.click(view.getByRole("button", { name: "Export" }));
+      await user.click(view.getByRole("menuitem", { name: `Export as ${format.toUpperCase()}` }));
+      const [content, mime, fileName] = mockDownloadText.mock.calls.at(-1)!;
+      expect(fileName).toMatch(new RegExp(`^query_history_\\d+\\.${format}$`));
+      if (format === "json") {
+        expect(mime).toBe("application/json");
+        expect(content).toBe(JSON.stringify([mockHistory[0]], null, 2));
+      } else {
+        expect(mime).toBe("text/csv");
+        expect(content).toBe(
+          "Executed At,Status,Connection,Tab,Execution Time (ms),Rows,Query,Error\n2026-09-09T10:00:00.000Z,success,TestDB,,10,1,SELECT 'selected',",
+        );
+      }
+    },
+  );
+
+  test("audit export is disabled while refreshing and when no filtered rows remain", async () => {
+    const view = render(<AuditTab />);
+    expect(view.getByRole("button", { name: "Export" }).hasAttribute("disabled")).toBe(true);
+    await waitFor(() => expect(view.queryByText("VACUUM")).not.toBeNull());
+    fireEvent.click(view.getByRole("button", { name: "Refresh" }));
+    expect(view.getByRole("button", { name: "Export" }).hasAttribute("disabled")).toBe(true);
+    await waitFor(() => expect(view.getByRole("button", { name: "Export" }).hasAttribute("disabled")).toBe(false));
+    fireEvent.change(view.getByPlaceholderText("Search..."), { target: { value: "missing-row" } });
+    expect(view.getByRole("button", { name: "Export" }).hasAttribute("disabled")).toBe(true);
+    expect(mockDownloadText).not.toHaveBeenCalled();
+  });
+
+  test("query export includes every matching row beyond the table display limit", async () => {
+    mockHistory = Array.from({ length: 201 }, (_, index) => ({ ...defaultHistory()[0], id: `query-${index}` }));
+    const user = userEvent.setup();
+    const view = render(<AuditTab />);
+    await user.click(view.getByRole("tab", { name: "Queries" }));
+    expect(view.container.querySelectorAll("tbody tr").length).toBe(200);
+    await user.click(view.getByRole("button", { name: "Export" }));
+    await user.click(view.getByRole("menuitem", { name: "Export as JSON" }));
+    expect(JSON.parse(mockDownloadText.mock.calls.at(-1)![0])).toHaveLength(201);
+    fireEvent.change(view.getByPlaceholderText("Search query..."), { target: { value: "no-match" } });
+    expect(view.getByRole("button", { name: "Export" }).hasAttribute("disabled")).toBe(true);
   });
 
   test("operations tab fetches audit events", async () => {

--- a/tests/unit/lib/export/query-history.test.ts
+++ b/tests/unit/lib/export/query-history.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { queryHistoryText } from "@/lib/export/query-history";
+import type { QueryHistoryItem } from "@/lib/types";
+
+const headers = "Executed At,Status,Connection,Tab,Execution Time (ms),Rows,Query,Error";
+const item: QueryHistoryItem = {
+  id: "history-1",
+  connectionId: "conn-1",
+  query: "SELECT 1;",
+  executionTime: 0,
+  status: "success",
+  executedAt: new Date("2026-09-01T10:20:30Z"),
+};
+
+describe("queryHistoryText", () => {
+  test("empty CSV retains all eight headers", () => {
+    expect(queryHistoryText([], "csv")).toBe(headers);
+  });
+
+  test("CSV keeps commas, quotes, newlines and Unicode in their original columns", () => {
+    const row = {
+      ...item,
+      connectionName: '数据库,"prod"',
+      tabName: "Tab\nOne",
+      query: 'SELECT "雪",\n42;',
+      rowCount: 2,
+      errorMessage: "failure",
+      status: "error" as const,
+    };
+    expect(queryHistoryText([row], "csv")).toBe(
+      headers + '\n2026-09-01T10:20:30.000Z,error,"数据库,""prod""","Tab\nOne",0,2,"SELECT ""雪"",\n42;",failure',
+    );
+  });
+
+  test("CSV uses the connection ID and empty optional fields while preserving zero", () => {
+    expect(queryHistoryText([item], "csv")).toBe(headers + "\n2026-09-01T10:20:30.000Z,success,conn-1,,0,0,SELECT 1;,");
+  });
+
+  test("CSV neutralizes formula prefixes in connection, tab, query and error fields", () => {
+    const row = { ...item, connectionName: "=db", tabName: "@tab", query: "+query", errorMessage: "-error" };
+    expect(queryHistoryText([row], "csv")).toBe(
+      headers + '\n2026-09-01T10:20:30.000Z,success,"\'=db","\'@tab",0,0,"\'+query","\'-error"',
+    );
+  });
+
+  test("empty JSON is an empty array", () => {
+    expect(queryHistoryText([], "json")).toBe("[]");
+  });
+
+  test("JSON preserves the complete records and dates with two-space indentation", () => {
+    expect(queryHistoryText([item], "json")).toBe(JSON.stringify([item], null, 2));
+  });
+
+  test("JSON writes bigint metadata without throwing", () => {
+    const row = { ...item, extra: { large: BigInt("9007199254740993") } };
+    expect(JSON.parse(queryHistoryText([row], "json"))[0].extra.large).toBe("9007199254740993");
+  });
+
+  test("JSON names cyclic metadata and retains the rest of the record", () => {
+    const extra: { self?: unknown } = {};
+    extra.self = extra;
+    const row = { ...item, extra };
+    expect(JSON.parse(queryHistoryText([row], "json"))[0]).toEqual({
+      ...item,
+      executedAt: item.executedAt.toISOString(),
+      extra: { self: "[Circular]" },
+    });
+  });
+});


### PR DESCRIPTION
## Description

The admin Audit tab can now export its filtered Operations and Queries as CSV or JSON. Operations exports use the rows returned for the active type filter plus the current search; export is disabled during a refresh so an old response cannot be downloaded under a new filter. Query exports apply status and search filters to the full loaded history, while the table retains its existing 200-row display limit.

Closes #691.

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation update
- [x] Test addition or update

## Changes Made

Both QueryHistory and QueryAudit call `queryHistoryText(items, format)` in `src/lib/export/query-history.ts`, so query-history CSV headers, fallback values and JSON formatting have a single implementation using the shared `csvRow` writer. The existing dropdown and `downloadText` path handle downloads. Operation CSV includes the audit identity, result, timing and investigation fields already present on each event. No endpoint or audit access policy changes.

Both JSON export branches use the shared `jsonText` serializer. The extracted module carries the CSV escaping rationale and has its own unit suite, including bigint and cyclic metadata regressions.

## Testing

- TDD: five new export/filter cases failed because Export was absent before implementation.
- `bun run test:unit --isolate --pass-with-no-tests -t 'queryHistoryText|jsonText'`: 21 passed, 0 failed. The bigint and cycle cases fail before replacing the direct JSON serialization.
- `bun run test:components --pass-with-no-tests -t 'AuditTab|QueryHistory|query export includes every matching row'`: 49 matching tests passed, 0 failed, including six new regressions. The existing tests exercise both export surfaces through the shared writer after the review refactor.
- Covered both formats and both row types, combined type/search and status/search filters, CSV commas/quotes/newlines/Unicode, formula neutralization, zero duration, disabled export during refresh or an empty result, and all 201 matching queries despite a 200-row table.
- Passed locally: `format`, `lint`, `typecheck`, `knip`, `readme:check`, `chart:check`, `channels:showcase:check`, `security:check`, production `build`, `build:lib` and `attw`.
- Full local `bun run test` / coverage and E2E were not completed: Windows host lacks Helm/chart dependencies, Docker is unavailable, and existing SQLite cleanup tests encounter Windows file-lock errors. Official Linux CI must verify the full suite and 100% line-coverage gate.

Environment: Windows, Node.js 24.18.1, Bun 1.4.2. Both builds ran from a clean checkout of the submitted commit with real local dependencies.

## Checklist

- [x] Reviewed the diff and reused the existing export infrastructure.
- [x] Added regression tests and updated README.
- [x] Required CI test job passed the 100% line-coverage gate; all 20 checks passed on a184a67 (2 normal fork skips). Verified [CI run](https://github.com/libredb/libredb-studio/actions/runs/34391869887).

## Additional Notes

AI-assisted implementation and test execution using Codex. Operations exports cover the currently loaded API result (the existing request limit is 200); this does not add server pagination or archival export. No new dependencies or provider changes.
