### PR TITLE
feat(connections): duplicate saved connections in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ And nothing is held back. Single sign-on, ER diagrams, the AI features and the N
 - **Smart Autocomplete**: Schema-aware suggestions for tables, columns, and SQL keywords.
 - **Command Palette**: Quick access to tables, connections, saved queries, and actions with `Cmd/Ctrl+K`.
 - **Multi-Tab Workspace**: Handle parallel tasks with independent execution states.
+- **Duplicate Connections**: Open an independent `(copy)` of an editable saved connection in the connection editor, adjust its settings and save. Cancelling leaves the saved connections unchanged; administrator-managed connections cannot be duplicated.
 - **Visual EXPLAIN**: Graphical execution plans to identify performance bottlenecks.
 - **Interactive ER Diagrams**: Visual schema graph with real foreign key edges, cardinality labels, MiniMap navigation, table search/filter, compact mode, and PNG/SVG export. Automatic hierarchical layout powered by ELK.js.
 - **Schema Diff & Migration**: Compare schema snapshots or cross-connection schemas side-by-side. Color-coded diff view (added/removed/modified) with automatic migration SQL generation for PostgreSQL, MySQL, SQLite, Oracle, and SQL Server, plus ClickHouse column modifications.
@@ -762,7 +763,6 @@ Pre-configure database connections via a YAML config file so users see them imme
 **Features:**
 - Role-based access control (`admin`, `user`, `*` wildcard)
 - Hybrid model: `managed: true` (read-only, admin-controlled) or `managed: false` (editable copy for user)
-- Editable connections offer **Duplicate**: open an independent `(copy)` in the connection editor, adjust its settings and save. Cancelling leaves the saved connections unchanged; administrator-managed connections cannot be duplicated.
 - Credentials injected via `${ENV_VAR}` syntax — never stored in config file
 - Hot-reload: config changes apply within 60s without restart
 - Works with Docker, docker-compose, and Kubernetes (Helm)

--- a/README.md
+++ b/README.md
@@ -762,6 +762,7 @@ Pre-configure database connections via a YAML config file so users see them imme
 **Features:**
 - Role-based access control (`admin`, `user`, `*` wildcard)
 - Hybrid model: `managed: true` (read-only, admin-controlled) or `managed: false` (editable copy for user)
+- Editable connections offer **Duplicate**: open an independent `(copy)` in the connection editor, adjust its settings and save. Cancelling leaves the saved connections unchanged; administrator-managed connections cannot be duplicated.
 - Credentials injected via `${ENV_VAR}` syntax — never stored in config file
 - Hot-reload: config changes apply within 60s without restart
 - Works with Docker, docker-compose, and Kubernetes (Helm)

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -195,6 +195,18 @@ export default function Studio() {
   // === Modal state ===
   const [isConnectionModalOpen, setIsConnectionModalOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<DatabaseConnection | null>(null);
+  const handleDuplicateConnection = (source: DatabaseConnection) => {
+    setEditingConnection({
+      ...structuredClone(source),
+      id: newLocalId(),
+      name: `${source.name} (copy)`,
+      createdAt: new Date(),
+      // A new local connection must not be merged back into its source seed on reload.
+      seedId: undefined,
+      managed: false,
+    });
+    setIsConnectionModalOpen(true);
+  };
   const [pendingDeleteConnectionId, setPendingDeleteConnectionId] = useState<string | null>(null);
   const [isCreateTableModalOpen, setIsCreateTableModalOpen] = useState(false);
   const [showDiagram, setShowDiagram] = useState(false);
@@ -492,6 +504,7 @@ export default function Studio() {
                   setEditingConnection(c);
                   setIsConnectionModalOpen(true);
                 }}
+                onDuplicateConnection={handleDuplicateConnection}
                 onAddConnection={() => setIsConnectionModalOpen(true)}
                 onTableClick={onTableClick}
                 onGenerateSelect={tabMgr.handleGenerateSelect}
@@ -606,6 +619,7 @@ export default function Studio() {
                       setActiveMobileTab("editor");
                     }}
                     onDeleteConnection={requestDeleteConnection}
+                    onDuplicateConnection={handleDuplicateConnection}
                     onAddConnection={() => setIsConnectionModalOpen(true)}
                   />
                 </div>

--- a/src/components/sidebar/ConnectionItem.tsx
+++ b/src/components/sidebar/ConnectionItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DatabaseConnection, ENVIRONMENT_LABELS } from "@/lib/types";
-import { Lock, Trash2, Pencil } from "lucide-react";
+import { Lock, Trash2, Pencil, Copy } from "lucide-react";
 import { getDBIcon } from "@/lib/db-ui-config";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -12,6 +12,7 @@ interface ConnectionItemProps {
   onSelect: (conn: DatabaseConnection) => void;
   onDelete: (id: string) => void;
   onEdit?: (conn: DatabaseConnection) => void;
+  onDuplicate?: (conn: DatabaseConnection) => void;
 }
 
 export const ConnectionItem = React.memo(function ConnectionItem({
@@ -20,6 +21,7 @@ export const ConnectionItem = React.memo(function ConnectionItem({
   onSelect,
   onDelete,
   onEdit,
+  onDuplicate,
 }: ConnectionItemProps) {
   return (
     <motion.div
@@ -80,6 +82,19 @@ export const ConnectionItem = React.memo(function ConnectionItem({
             }}
           >
             <Pencil strokeWidth={1.5} className="w-3 h-3" />
+          </button>
+        )}
+        {!conn.managed && onDuplicate && (
+          <button
+            className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-brand-tint/20 hover:text-brand"
+            aria-label="Duplicate connection"
+            title="Duplicate connection"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDuplicate(conn);
+            }}
+          >
+            <Copy strokeWidth={1.5} className="w-3 h-3" />
           </button>
         )}
         {!conn.managed && (

--- a/src/components/sidebar/ConnectionsList.tsx
+++ b/src/components/sidebar/ConnectionsList.tsx
@@ -9,6 +9,7 @@ interface ConnectionsListProps {
   onSelectConnection: (conn: DatabaseConnection) => void;
   onDeleteConnection: (id: string) => void;
   onEditConnection?: (conn: DatabaseConnection) => void;
+  onDuplicateConnection?: (conn: DatabaseConnection) => void;
   onAddConnection: () => void;
 }
 
@@ -18,6 +19,7 @@ export function ConnectionsList({
   onSelectConnection,
   onDeleteConnection,
   onEditConnection,
+  onDuplicateConnection,
   onAddConnection,
 }: ConnectionsListProps) {
   return (
@@ -46,6 +48,7 @@ export function ConnectionsList({
               onSelect={onSelectConnection}
               onDelete={onDeleteConnection}
               onEdit={onEditConnection}
+              onDuplicate={onDuplicateConnection}
             />
           ))
         )}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -21,6 +21,7 @@ interface SidebarProps {
   onSelectConnection: (connection: DatabaseConnection) => void;
   onDeleteConnection: (id: string) => void;
   onEditConnection?: (conn: DatabaseConnection) => void;
+  onDuplicateConnection?: (conn: DatabaseConnection) => void;
   onAddConnection: () => void;
   onTableClick?: (tableName: string) => void;
   onGenerateSelect?: (tableName: string) => void;
@@ -44,6 +45,7 @@ export function Sidebar({
   onSelectConnection,
   onDeleteConnection,
   onEditConnection,
+  onDuplicateConnection,
   onAddConnection,
   onTableClick,
   onGenerateSelect,
@@ -97,6 +99,7 @@ export function Sidebar({
             onSelectConnection={onSelectConnection}
             onDeleteConnection={onDeleteConnection}
             onEditConnection={onEditConnection}
+            onDuplicateConnection={onDuplicateConnection}
             onAddConnection={onAddConnection}
           />
 

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -303,6 +303,9 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
             ...(caCert ? { caCert } : {}),
             ...(clientCert ? { clientCert } : {}),
             ...(clientKey ? { clientKey } : {}),
+            ...(editConnection?.ssl?.mode === sslMode && editConnection.ssl.rejectUnauthorized !== undefined
+              ? { rejectUnauthorized: editConnection.ssl.rejectUnauthorized }
+              : {}),
           }
         : undefined;
 
@@ -316,6 +319,12 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
           ...(sshAuthMethod === "password" ? { password: sshPassword } : {}),
           ...(sshAuthMethod === "privateKey" ? { privateKey: sshPrivateKey } : {}),
           ...(sshPassphrase ? { passphrase: sshPassphrase } : {}),
+          // A pinned host key belongs to this SSH endpoint, not to a replacement bastion.
+          ...(editConnection?.sshTunnel?.host === sshHost &&
+          editConnection.sshTunnel.port === (parseInt(sshPort) || 22) &&
+          editConnection.sshTunnel.hostKeyFingerprint
+            ? { hostKeyFingerprint: editConnection.sshTunnel.hostKeyFingerprint }
+            : {}),
         }
       : undefined;
 
@@ -349,7 +358,10 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       ...(addressedFields.has("schema") && schema ? { schema } : {}),
       createdAt: editConnection?.createdAt || new Date(),
       environment,
-      color: ENVIRONMENT_COLORS[environment],
+      color:
+        editConnection?.color && (editConnection.environment ?? "local") === environment
+          ? editConnection.color
+          : ENVIRONMENT_COLORS[environment],
       ...(sslConfig ? { ssl: sslConfig } : {}),
       ...(sshConfig ? { sshTunnel: sshConfig } : {}),
       ...(getDBConfig(type).showConnectionStringToggle && mongoConnectionMode === "connectionString"

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -30,13 +30,14 @@ import { newLocalId } from "@/lib/ids";
  * A `Record<keyof DatabaseConnection, ...>` rather than a list of names to copy, for
  * the reason `connection-secrets.ts` gives about credentials: the failure mode of a
  * list is silence, and silence is exactly how this bug survived. A field added to
- * `DatabaseConnection` now fails `bun run typecheck` until someone decides whether the
- * editor owns it.
+ * `DatabaseConnection`, `SSLConfig` or `SSHTunnelConfig` now fails `bun run typecheck`
+ * until someone decides whether the editor owns it.
  *
  * `edited` is not "always written" — the form omits a value it has none for, which is
  * how turning TLS or the tunnel off actually clears them. It means the FORM decides.
+ * `conditional` is preserved only while the related form setting remains unchanged.
  */
-type FieldOwnership = "edited" | "preserved";
+type FieldOwnership = "edited" | "preserved" | "conditional";
 
 const FIELD_OWNERSHIP: Record<keyof DatabaseConnection, FieldOwnership> = {
   id: "edited",
@@ -50,7 +51,8 @@ const FIELD_OWNERSHIP: Record<keyof DatabaseConnection, FieldOwnership> = {
   schema: "edited",
   connectionString: "edited",
   createdAt: "edited",
-  color: "edited",
+  // Preserve a custom color while the environment is unchanged; otherwise use its palette.
+  color: "conditional",
   environment: "edited",
   ssl: "edited",
   sshTunnel: "edited",
@@ -65,19 +67,39 @@ const FIELD_OWNERSHIP: Record<keyof DatabaseConnection, FieldOwnership> = {
   agentPassword: "preserved",
 };
 
-const PRESERVED_KEYS = (Object.keys(FIELD_OWNERSHIP) as (keyof DatabaseConnection)[]).filter(
-  (key) => FIELD_OWNERSHIP[key] === "preserved",
-);
+const SSL_OWNERSHIP: Record<keyof SSLConfig, FieldOwnership> = {
+  mode: "edited",
+  caCert: "edited",
+  clientCert: "edited",
+  clientKey: "edited",
+  rejectUnauthorized: "preserved",
+};
+
+const SSH_TUNNEL_OWNERSHIP: Record<keyof SSHTunnelConfig, FieldOwnership> = {
+  enabled: "edited",
+  host: "edited",
+  port: "edited",
+  username: "edited",
+  authMethod: "edited",
+  password: "edited",
+  privateKey: "edited",
+  passphrase: "edited",
+  hostKeyFingerprint: "preserved",
+};
 
 /** What survives an edit untouched. Empty for a new connection, which has no past. */
-function preservedFields(source: DatabaseConnection | null | undefined): Partial<DatabaseConnection> {
+function preservedFields<T extends object>(
+  source: T | null | undefined,
+  ownership: Record<keyof T, FieldOwnership>,
+): Partial<T> {
   if (!source) return {};
-  const carried: Record<string, unknown> = {};
-  for (const key of PRESERVED_KEYS) {
+  const carried: Partial<T> = {};
+  for (const key of Object.keys(ownership) as (keyof T)[]) {
+    if (ownership[key] !== "preserved") continue;
     const value = source[key];
     if (value !== undefined) carried[key] = value;
   }
-  return carried as Partial<DatabaseConnection>;
+  return carried;
 }
 
 interface UseConnectionFormProps {
@@ -303,9 +325,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
             ...(caCert ? { caCert } : {}),
             ...(clientCert ? { clientCert } : {}),
             ...(clientKey ? { clientKey } : {}),
-            ...(editConnection?.ssl?.mode === sslMode && editConnection.ssl.rejectUnauthorized !== undefined
-              ? { rejectUnauthorized: editConnection.ssl.rejectUnauthorized }
-              : {}),
+            ...(editConnection?.ssl?.mode === sslMode ? preservedFields(editConnection.ssl, SSL_OWNERSHIP) : {}),
           }
         : undefined;
 
@@ -320,10 +340,8 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
           ...(sshAuthMethod === "privateKey" ? { privateKey: sshPrivateKey } : {}),
           ...(sshPassphrase ? { passphrase: sshPassphrase } : {}),
           // A pinned host key belongs to this SSH endpoint, not to a replacement bastion.
-          ...(editConnection?.sshTunnel?.host === sshHost &&
-          editConnection.sshTunnel.port === (parseInt(sshPort) || 22) &&
-          editConnection.sshTunnel.hostKeyFingerprint
-            ? { hostKeyFingerprint: editConnection.sshTunnel.hostKeyFingerprint }
+          ...(editConnection?.sshTunnel?.host === sshHost && editConnection.sshTunnel.port === (parseInt(sshPort) || 22)
+            ? preservedFields(editConnection.sshTunnel, SSH_TUNNEL_OWNERSHIP)
             : {}),
         }
       : undefined;
@@ -345,8 +363,8 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     const addressedFields = new Set<string>(getDBConfig(type).connectionFields);
 
     return {
-      // First, so a form-owned field always wins; nothing below is preserved.
-      ...preservedFields(editConnection),
+      // First, so a form-owned field always wins.
+      ...preservedFields(editConnection, FIELD_OWNERSHIP),
       id: editConnection?.id || newLocalId(),
       name: name || `${type}-connection`,
       type,

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -466,6 +466,7 @@ mock.module("@/components/ui/resizable", () => {
 // The dynamic import resolves against the mock registry instead.
 
 const { default: Studio } = await import("@/components/Studio");
+import type { DatabaseConnection } from "@/lib/types";
 
 // =============================================================================
 // Test data
@@ -819,6 +820,65 @@ describe("Studio", () => {
   });
 
   // --- onAddConnection ---
+  test.each(["desktop", "mobile"])("duplicate opens a detached copy in the %s connection editor", (surface) => {
+    const source: DatabaseConnection = {
+      ...pgConn,
+      type: "postgres",
+      createdAt: new Date(0),
+      managed: false,
+      seedId: "sample",
+      host: "db.example.test",
+      port: 5432,
+      user: "fixture_user",
+      password: "fixture_password",
+      database: "app",
+      color: "#123456",
+      environment: "development",
+      group: "team",
+      agentUser: "agent_ro",
+      agentPassword: "fixture_agent",
+      ssl: { mode: "verify-full", caCert: "fixture-ca" },
+      sshTunnel: {
+        enabled: true,
+        host: "bastion.example.test",
+        port: 22,
+        username: "ops",
+        authMethod: "password",
+        password: "fixture_ssh",
+      },
+    };
+    const original = structuredClone(source);
+    render(<Studio />);
+    if (surface === "mobile") {
+      act(() => (capturedMobileNavProps.onTabChange as (tab: string) => void)("database"));
+    }
+    const props = surface === "mobile" ? capturedConnectionsListProps : capturedSidebarProps;
+    act(() => (props.onDuplicateConnection as (conn: DatabaseConnection) => void)(source));
+    const copy = capturedConnectionModalProps.editConnection as DatabaseConnection;
+    expect(capturedConnectionModalProps.isOpen).toBe(true);
+    expect(copy.id).not.toBe(source.id);
+    expect(copy).toEqual({
+      ...source,
+      id: copy.id,
+      name: `${source.name} (copy)`,
+      createdAt: copy.createdAt,
+      seedId: undefined,
+      managed: false,
+    });
+    expect(copy.createdAt.getTime()).toBeGreaterThan(source.createdAt.getTime());
+    expect(copy.ssl).not.toBe(source.ssl);
+    expect(copy.sshTunnel).not.toBe(source.sshTunnel);
+    expect(mockStorageSaveConnection).not.toHaveBeenCalled();
+    act(() => (capturedConnectionModalProps.onClose as () => void)());
+    expect(mockStorageSaveConnection).not.toHaveBeenCalled();
+    act(() => (props.onDuplicateConnection as (conn: DatabaseConnection) => void)(source));
+    const secondCopy = capturedConnectionModalProps.editConnection as DatabaseConnection;
+    expect(secondCopy.id).not.toBe(copy.id);
+    act(() => (capturedConnectionModalProps.onConnect as (conn: DatabaseConnection) => void)(secondCopy));
+    expect(mockStorageSaveConnection).toHaveBeenCalledWith(secondCopy);
+    expect(source).toEqual(original);
+  });
+
   test("onAddConnection opens connection modal", () => {
     render(<Studio />);
     const fn = capturedSidebarProps.onAddConnection as () => void;

--- a/tests/components/sidebar/ConnectionItem.test.tsx
+++ b/tests/components/sidebar/ConnectionItem.test.tsx
@@ -188,6 +188,39 @@ describe("ConnectionItem", () => {
     expect(defaultOnSelect).toHaveBeenCalledTimes(0);
   });
 
+  test("duplicate requests an independent connection without selecting or deleting the source", () => {
+    const onDuplicate = mock(() => {});
+    const view = render(
+      <ConnectionItem
+        connection={mockPostgresConnection}
+        isActive={false}
+        onSelect={defaultOnSelect}
+        onDelete={defaultOnDelete}
+        onEdit={defaultOnEdit}
+        onDuplicate={onDuplicate}
+      />,
+    );
+    fireEvent.click(view.getByRole("button", { name: "Duplicate connection" }));
+    expect(onDuplicate).toHaveBeenCalledWith(mockPostgresConnection);
+    expect(defaultOnSelect).not.toHaveBeenCalled();
+    expect(defaultOnDelete).not.toHaveBeenCalled();
+    expect(defaultOnEdit).not.toHaveBeenCalled();
+  });
+
+  test("duplicate is absent for managed connections and hosts without a duplication handler", () => {
+    const props = {
+      connection: { ...mockPostgresConnection, managed: true },
+      isActive: false,
+      onSelect: defaultOnSelect,
+      onDelete: defaultOnDelete,
+      onDuplicate: mock(() => {}),
+    };
+    const view = render(<ConnectionItem {...props} />);
+    expect(view.queryByRole("button", { name: "Duplicate connection" })).toBeNull();
+    view.rerender(<ConnectionItem {...props} connection={mockPostgresConnection} onDuplicate={undefined} />);
+    expect(view.queryByRole("button", { name: "Duplicate connection" })).toBeNull();
+  });
+
   test("onDelete fires on delete button click with stopPropagation", () => {
     const { container } = render(
       <ConnectionItem

--- a/tests/components/sidebar/ConnectionsList.test.tsx
+++ b/tests/components/sidebar/ConnectionsList.test.tsx
@@ -70,6 +70,21 @@ import { mockPostgresConnection, mockMySQLConnection } from "../../fixtures/conn
 // =============================================================================
 
 describe("ConnectionsList", () => {
+  test("passes duplicate requests to the connection editor", () => {
+    const onDuplicateConnection = mock(() => {});
+    const view = render(
+      <ConnectionsList
+        connections={[mockPostgresConnection]}
+        activeConnection={null}
+        onSelectConnection={mock(() => {})}
+        onDeleteConnection={mock(() => {})}
+        onAddConnection={mock(() => {})}
+        onDuplicateConnection={onDuplicateConnection}
+      />,
+    );
+    fireEvent.click(view.getByRole("button", { name: "Duplicate connection" }));
+    expect(onDuplicateConnection).toHaveBeenCalledWith(mockPostgresConnection);
+  });
   const defaultOnSelect = mock(() => {});
   const defaultOnDelete = mock(() => {});
   const defaultOnEdit = mock(() => {});

--- a/tests/components/sidebar/Sidebar.test.tsx
+++ b/tests/components/sidebar/Sidebar.test.tsx
@@ -3,10 +3,12 @@ import "../../helpers/mock-sonner";
 import "../../helpers/mock-navigation";
 
 import { mock } from "bun:test";
+let capturedDuplicateHandler: unknown;
 
 // Mock child components to isolate Sidebar logic
 mock.module("@/components/sidebar/ConnectionsList", () => ({
   ConnectionsList: (props: Record<string, unknown>) => {
+    capturedDuplicateHandler = props.onDuplicateConnection;
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const React = require("react");
     const connections = props.connections as Array<Record<string, unknown>> | undefined;
@@ -185,15 +187,18 @@ describe("Sidebar", () => {
 
   test("passes correct props to ConnectionsList", () => {
     const connections = [mockPostgresConnection, mockMySQLConnection];
+    const onDuplicateConnection = mock(() => {});
     const props = createDefaultProps({
       connections,
       activeConnection: mockPostgresConnection,
+      onDuplicateConnection,
     });
     const { getByTestId } = render(<Sidebar {...props} />);
 
     const connList = getByTestId("connections-list");
     expect(connList.getAttribute("data-connections-count")).toBe("2");
     expect(connList.getAttribute("data-active-connection")).toBe(mockPostgresConnection.id);
+    expect(capturedDuplicateHandler).toBe(onDuplicateConnection);
   });
 
   /**

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -535,6 +535,71 @@ describe("useConnectionForm", () => {
 
   // ── handleConnect calls onConnect on successful test ───────────────────────
 
+  test.each(["unchanged", "tls", "host", "port", "environment"])(
+    "saving a copy preserves applicable connection settings: %s",
+    async (changed) => {
+      const source: DatabaseConnection = {
+        id: "independent-copy",
+        name: "Team (copy)",
+        type: "postgres",
+        host: "db.example.test",
+        port: 5432,
+        user: "fixture_user",
+        password: "fixture_password",
+        database: "app",
+        createdAt: new Date(0),
+        color: "#123456",
+        environment: "development",
+        group: "team",
+        agentUser: "agent_ro",
+        agentPassword: "fixture_agent",
+        ssl: {
+          mode: "require",
+          rejectUnauthorized: true,
+          caCert: "fixture-ca",
+          clientCert: "fixture-cert",
+          clientKey: "fixture-key",
+        },
+        sshTunnel: {
+          enabled: true,
+          host: "bastion.example.test",
+          port: 22,
+          username: "ops",
+          authMethod: "password",
+          password: "fixture_ssh",
+          hostKeyFingerprint: "SHA256:fixture-host-fingerprint",
+        },
+      };
+      const original = structuredClone(source);
+      const onConnect = mock((_connection: DatabaseConnection) => {});
+      const { result } = renderHook(() =>
+        useConnectionForm({
+          ...defaultProps,
+          editConnection: source,
+          onConnect,
+          onTestConnection: async () => ({ success: true }),
+        }),
+      );
+      act(() => {
+        if (changed === "tls") result.current.setSSLMode("verify-full");
+        if (changed === "host") result.current.setSSHHost("new-bastion.example.test");
+        if (changed === "port") result.current.setSSHPort("2222");
+        if (changed === "environment") result.current.setEnvironment("production");
+      });
+      await act(async () => {
+        await result.current.handleConnect();
+      });
+      const saved = onConnect.mock.calls[0][0];
+      expect(saved.ssl?.rejectUnauthorized).toBe(changed === "tls" ? undefined : true);
+      expect(saved.sshTunnel?.hostKeyFingerprint).toBe(
+        changed === "host" || changed === "port" ? undefined : source.sshTunnel?.hostKeyFingerprint,
+      );
+      if (changed === "unchanged") expect(saved).toEqual(source);
+      if (changed === "environment") expect(saved.color).not.toBe(source.color);
+      expect(source).toEqual(original);
+    },
+  );
+
   test("handleConnect calls onConnect on successful test", async () => {
     mockGlobalFetch({
       "/api/db/test-connection": { ok: true, json: { success: true, latency: 10 } },


### PR DESCRIPTION
## Description

Editable saved connections now offer Duplicate beside Edit and Delete. It opens an independent `(copy)` in the existing connection editor on desktop and mobile. Nothing is persisted until the existing test-and-save flow succeeds; cancelling leaves the source and saved list unchanged.

Closes #692.

## Type of Change

- [x] New feature (non-breaking)
- [x] Bug fix in the copy's save path
- [x] Documentation and test updates

## Changes Made

- Deep-copy the complete connection, generate a new local ID and creation time, and detach seed provenance so the copy is not deduplicated away on reload. Settings, including nested TLS/SSH and agent credentials, reach the editor intact.
- Keep the action unavailable for administrator-managed connections and hosts that do not provide a duplication handler. The embedded workspace therefore gains no nonfunctional connection-management control.
- Preserve custom color and unedited TLS verification overrides / SSH host-key fingerprints through the form's save path. Without this, a correctly prefilled copy silently lost these settings when saved. Changing environment uses its palette color; changing TLS mode clears the old override; changing SSH host or port clears the old endpoint's pin. Existing disable-TLS/tunnel behavior is retained.
- Declare color as conditionally preserved and use exhaustive `Record<keyof T, ...>` ownership maps for the connection and nested TLS/SSH fields. Adding a new field now requires an explicit editor ownership decision.
- Document the action in README's general features.

## Testing

- TDD: five component/passthrough assertions and five form-preservation cases failed before the fix.
- `bun run test:components --pass-with-no-tests -t 'Studio|ConnectionItem|ConnectionsList|Sidebar|ConnectionModal'`: 386 matching tests passed, 0 failed across the isolated groups.
- `bun run test:hooks --pass-with-no-tests -t 'useConnectionForm'`: 84 passed, 0 failed.
- Regressions exercise desktop/mobile duplication, cancellation, explicit save, repeated unique IDs, independent nested settings, unchanged source, seed detachment, managed/host restrictions, and unchanged versus edited TLS/SSH/environment settings.
- Passed locally: `format`, `lint`, `typecheck`, `knip`, `readme:check`, `chart:check`, `channels:showcase:check`, `security:check`, production `build`, `build:lib` and `attw`.
- Full local `bun run test` / coverage and E2E were not completed: Windows host lacks Helm/chart dependencies, Docker is unavailable, and existing SQLite cleanup tests encounter Windows file-lock errors. Official Linux CI must verify the full suite and 100% line-coverage gate.

Environment: Windows, Node.js 24.18.1, Bun 1.4.2. Both builds ran from a clean checkout of the submitted commit with real local dependencies. Connection probes in the regression tests use synthetic credentials and mocked responses.

## Checklist

- [x] Reviewed the diff and followed existing connection/storage flows.
- [x] Added regression tests and updated documentation.
- [x] Required CI test job passed the 100% line-coverage gate; all 20 checks passed on 09b6816 (2 normal fork skips). Verified [CI run](https://github.com/libredb/libredb-studio/actions/runs/34391702491).

## Additional Notes

AI-assisted implementation and test execution using Codex. No new dependencies, storage schema or provider changes. The save-path preservation also applies to ordinary edits, which is why the existing form tests were included in validation.
