### PR TITLE
feat(agent): thirty models, and the three refusals that were holding two of them back

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1668,7 +1668,7 @@ denial cannot be re-fed to the model as though the SQL were malformed.
 
 ## Supported models
 
-Twenty-eight models run every agent surface. Each cleared all six — Investigate, Optimize, Assess, Operate,
+Thirty models run every agent surface. Each cleared all six — Investigate, Optimize, Assess, Operate,
 Analyze and Plan — five consecutive times, at the turn limit the product ships, which is 30 of 30
 runs.
 
@@ -1694,7 +1694,7 @@ not cover, are all under [`docs/llms/`](llms/README.md).
 
 
 Nothing prevents another model from being configured — the capability probe below decides what any
-given endpoint can do, and there is no allow-list in the code. What the twenty-eight have is a measurement.
+given endpoint can do, and there is no allow-list in the code. What the thirty have is a measurement.
 
 ## The model side
 

--- a/docs/llms/README.md
+++ b/docs/llms/README.md
@@ -8,10 +8,10 @@ writes beautiful prose about a database and never calls a tool answers nothing h
 question these pages answer is not what a model knows but what it DOES on a run, and every figure
 comes from a run whose ledger is on disk.
 
-**Twenty-eight models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
-Operate, Analyze and Plan — five consecutive times: 840 runs, 840 passes.
+**Thirty models are supported.** Each cleared all six surfaces — Investigate, Optimize, Assess,
+Operate, Analyze and Plan — five consecutive times: 900 runs, 900 passes.
 
-Twenty-one of the twenty-eight cleared them at the 90-second per-turn limit the product ships. Seven carry a
+Twenty-two of the thirty cleared them at the 90-second per-turn limit the product ships. Eight carry a
 150-second limit of their own — `qwen3.5:9b`, `gemma4:12b`, `gemma4:31b`, `nemotron-3.5-lightning:30b`,
 `nemotron-3-nano:30b`, `muse-glimmer:latest` and `qwen3.6:27b` — because one turn of theirs does
 not fit inside 90 while every other surface does. The limit stays 90 for every other model, and
@@ -50,7 +50,7 @@ each page says what its model needed.
 
 The durations are from one machine and are comparable with each other rather than portable: every
 figure was taken the same way, on the same database, through the same six surfaces. What they are
-for is choosing between these twenty-eight — the fastest reaches the same verdicts as the slowest in
+for is choosing between these thirty — the fastest reaches the same verdicts as the slowest in
 an eighteenth of the time.
 
 One page per model version. Sizes are rows inside it, because `ollama pull qwen3:4b` is how a

--- a/docs/llms/gemini/gemini-3.5.md
+++ b/docs/llms/gemini/gemini-3.5.md
@@ -1,7 +1,7 @@
 # gemini-3.5
 
 Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
-runs. The one hosted model on this list, measured exactly as the twenty-seven local ones were.
+runs. The one hosted model on this list, measured exactly as the twenty-nine local ones were.
 
 ## What it does, and how long it takes
 

--- a/docs/llms/methodology.md
+++ b/docs/llms/methodology.md
@@ -30,7 +30,7 @@ Each model was asked one question per surface, the same wording for every model,
 | Analyze | "Which part of the company costs us the most in salary?" |
 | Plan | "What tables are in this database and how do they relate to each other?" |
 
-Twenty-eight models, six surfaces, five runs: **840 runs, and all 840 passed.**
+Thirty models, six surfaces, five runs: **900 runs, and all 900 passed.**
 
 A run passes only when its goal verdict is `answered`. A run that ends `succeeded` having
 answered nothing is a failure here, and the ledger names which bar it missed.
@@ -105,9 +105,9 @@ one, and each page says what its model needed.
 
 ## Driven through the interface as well
 
-The 840 runs above were opened over HTTP. A separate sweep drove ten of the models through the
+The 900 runs above were opened over HTTP. A separate sweep drove ten of the models through the
 product's own rail — log in, pick the sample connection, type the objective, press Start, wait
-for the run to finish on screen — one run per surface: **57 of 60 passed.** Ten, not twenty-eight:
+for the run to finish on screen — one run per surface: **57 of 60 passed.** Ten, not thirty:
 that sweep was run when ten models were supported and has not been repeated, and the twelve added
 since are measured over HTTP only. Saying "all of them" would have described a sweep nobody ran.
 

--- a/docs/llms/qwen/qwen3.5.md
+++ b/docs/llms/qwen/qwen3.5.md
@@ -1,6 +1,6 @@
 # qwen3.5
 
-`ollama pull qwen3.5:<size>` · sizes supported: 4b, 9b
+`ollama pull qwen3.5:<size>` · sizes supported: 4b, 9b, 27b
 
 Every size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30
 runs.
@@ -13,11 +13,22 @@ Seconds are the median of the runs that passed, per surface.
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | **4b** | 3.4 GB | 5s | 41s | 21s | 7s | 34s | 1s | **11s** | 2:47 |
 | **9b** | 5.8 GB | 31s | 31s | 52s | 21s | 26s | 1:38 | **33s** | 1:38 |
+| **27b** | 17 GB | 78s | 91s | 149s | 41s | 66s | 48s | **78s** | 2:29 |
 
 Every cell is 5/5, so the table says how long rather than whether.
 
 The 4b is three times the 9b's speed at two thirds of its disk, which is not the direction size
 usually runs. Its tail is the price: 2:47 against the 9b's 1:38.
+
+**The 27b is the one that asked for nothing.** It cleared all six surfaces on its first attempt at
+the compiled defaults, the whole model in 52 minutes, with not one setting spent — the only size in
+this family whose row in `measured-profiles.json` carries no departure from the defaults at all. It
+is also the slowest of the three, and both facts are worth stating together: what a model costs in
+seconds and what it costs in configuration are separate questions, and this one answers them in
+opposite directions.
+
+Its optimize cell is the figure to notice. Three other models measured the same week could not open
+that surface at any setting; this one took it 5/5 unaided.
 
 ## What it needs that the defaults do not give it
 

--- a/docs/llms/qwen/qwen3.6.md
+++ b/docs/llms/qwen/qwen3.6.md
@@ -1,8 +1,8 @@
 # qwen3.6
 
-`ollama pull qwen3.6:<size>` · sizes supported: 27b
+`ollama pull qwen3.6:<size>` · sizes supported: 27b, 35b
 
-The size listed here runs **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
+Both sizes run **all six agent surfaces**, five consecutive times each: 30 of 30 runs.
 Every cell it used to lose, it lost to the clock and to nothing else — and moving the clock did
 not only win those cells, it made the ones that already passed measurably faster.
 
@@ -13,9 +13,18 @@ Seconds are the median of the runs that passed, per surface.
 | Size | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median | Slowest |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | qwen3.6:27b | 17 GB | 26s | 238s | 216s | 68s | 82s | 20s | **82s** | 4:12 |
+| qwen3.6:35b | 22 GB | 8s | 19s | 18s | 7s | 13s | 2s | **13s** | 0:29 |
 
-Optimize and assess are the two dear cells: a passing assessment here runs three and a half
+Optimize and assess are the 27b's two dear cells: a passing assessment there runs three and a half
 minutes. Plan at 20 seconds is the same cell that used to time out at 90, five times over.
+
+**The larger size is the faster one, by six times, and that is the finding worth carrying out of
+this page.** The 35b is five gigabytes bigger and its median run is 13 seconds against the 27b's
+82. Nothing about the weights explains that; the settings do. Both carry the same pair of
+reasoning suppressions, and the 35b spends none of its turn thinking on either surface class,
+while the 27b's figures were taken before the agent-side suppression was added to it. Size is a
+poor predictor of speed here compared with whether a model is being asked to think in a place the
+run cannot use.
 
 ## What it needs that the defaults do not give it
 
@@ -42,6 +51,19 @@ a second read of the same cell at the same setting gave 5/5. The table reports t
 consecutive passes, and the outlier is recorded here rather than dropped: this cell sits closest
 to its limit of any in the model, and a reader running it on a slower machine should expect the
 loss the second pass did not repeat.
+
+### `qwen3.6:35b`
+
+**the 27b's set, taken whole.** This size was measured with exactly what its sibling ships —
+`suppressPlanReasoning`, `suppressAgentReasoning` and a 150-second turn limit — and that was not a
+guess carried over: optimize had refused to close across three sweeps and four separate levers,
+reading 4/5, 3/5, 4/5, 3/5, 4/5 and 2/5, with every loss a `model-timeout` at 200 to 350 seconds
+having already called two or three tools. Raising the turn ceiling alone did not do it. The pair
+did, on the first reading, and the runs fell from 200-350 seconds to 13-29.
+
+**The other five cells were then read again under it.** They had locked without the agent-side
+suppression, which reaches all five agent surfaces — so none of them had been measured under what
+ships. All five held at 5/5, and the table above reports those runs rather than the earlier ones.
 
 **It is one of the six models that cannot be loaded without a context bound.** Every figure here
 was taken with `OLLAMA_CONTEXT_LENGTH=32768` on the server; unbounded it asks for more memory than

--- a/docs/llms/setup.md
+++ b/docs/llms/setup.md
@@ -7,12 +7,12 @@ are environment variables read at server startup, which is how everything else i
 is configured. It keeps the choice with whoever operates the server rather than turning it into
 a permission to grant, revoke and audit per user.
 
-Twenty-eight models are supported — every one of them clears all six agent surfaces five consecutive
+Thirty models are supported — every one of them clears all six agent surfaces five consecutive
 times. They are listed with their measured durations in the [index](README.md).
 
 ## A local model, through Ollama
 
-Twenty-seven of the twenty-eight run locally, with no key and no traffic leaving the machine.
+Twenty-nine of the thirty run locally, with no key and no traffic leaving the machine.
 
 ```bash
 # macOS
@@ -38,7 +38,7 @@ where is in [`../AGENT_DATA_FLOW.md`](../AGENT_DATA_FLOW.md).
 
 ## A hosted model
 
-One of the twenty-eight is hosted, and it is configured the same way with one line more:
+One of the thirty is hosted, and it is configured the same way with one line more:
 
 ```bash
 LLM_PROVIDER=gemini

--- a/scripts/agent-model-e2e.sh
+++ b/scripts/agent-model-e2e.sh
@@ -19,7 +19,7 @@ MODELS=("$@")
 if [ ${#MODELS[@]} -eq 0 ]; then
   # Fastest first, so the run reports something early, and the hosted model last because it needs
   # its own environment file swapped in rather than a line rewritten.
-  MODELS=(qwen2.5:7b cogito:14b ministral-3:8b granite4.1:8b ministral-3:14b qwen2.5:14b qwen3.5:4b qwen2.5-coder:14b qwen2.5:32b cogito:32b granite4.2:8b granite4.1:30b ornith:9b ornith:35b qwen3.5:9b qwen3:8b gemma4:12b gemma4:26b gemma4:31b qwen3:14b nemotron3:33b nemotron-3.5-lightning:30b nemotron-3-nano:30b qwen3.6:27b qwen3.8:latest muse-glimmer:latest qwen3:4b gemini-3.5-flash-lite)
+  MODELS=(qwen2.5:7b cogito:14b ministral-3:8b granite4.1:8b ministral-3:14b qwen2.5:14b qwen3.5:4b qwen2.5-coder:14b qwen2.5:32b cogito:32b granite4.2:8b granite4.1:30b ornith:9b ornith:35b qwen3.5:9b qwen3:8b gemma4:12b gemma4:26b gemma4:31b qwen3:14b nemotron3:33b nemotron-3.5-lightning:30b nemotron-3-nano:30b qwen3.6:27b qwen3.6:35b qwen3.5:27b qwen3.8:latest muse-glimmer:latest qwen3:4b gemini-3.5-flash-lite)
 fi
 
 # Watchable by default: the browser opens on screen and every click is visible, and a video of

--- a/src/components/agent/timeline.ts
+++ b/src/components/agent/timeline.ts
@@ -79,6 +79,7 @@ const GUIDANCE_HEADLINE: Record<Extract<AgentRunEvent, { kind: "guidance-issued"
   "turn-cut-off": "A turn ran long and was cut; asked again",
   "report-reserve": "Told this is its last turn",
   "unread-stop": "Asked to read the database itself",
+  "tool-call-unreadable": "Told its tool call could not be read",
   /*
     The three notices delivered INSTEAD of running a call. They reach a reader through the
     `call-held` entry that records the hold, which is where the rail shows them — one entry

--- a/src/lib/agent/execution-policy.ts
+++ b/src/lib/agent/execution-policy.ts
@@ -430,6 +430,26 @@ export const AGENT_REPORT_RESERVE_MS = 20_000;
 export const AGENT_TRANSPORT_TURN_RETRIES = 2;
 
 /**
+ * How many times a run may be told a tool call of its own could not be parsed.
+ *
+ * A COUNT rather than a flag, and that is a correction. This bound shipped as "once per run" on
+ * the argument that a model which hears the sentence and writes the same unparseable arguments
+ * again is not rescued by hearing it twice. Measured on `gpt-oss:20b`, the argument is wrong in
+ * the way that matters: of ten runs, four met the fault, and of those four TWO heard the sentence
+ * once and went on to answer — while the other two heard it, met the fault a second time later in
+ * the run, and were ended `model-unavailable` by this bound rather than by anything the model did.
+ *
+ * The sentence works when it is allowed to be said. What the flag actually encoded was the
+ * assumption that the mistake happens once, and a long run of a reasoning model makes it more than
+ * once — in different turns, over different arguments.
+ *
+ * Two, matching `AGENT_TRANSPORT_TURN_RETRIES`, and free on the same argument every recovery here
+ * rests on: the alternative is the throw, so the run is over either way and the turn cannot cost a
+ * pass. A model that cannot comply after two still fails fast.
+ */
+export const AGENT_UNREADABLE_TOOL_CALL_ANSWERS = 2;
+
+/**
  * How many statements that FAILED AT THE DATABASE a run may try to repair.
  *
  * Policy denials and approval requirements deliberately do not consume one — they

--- a/src/lib/agent/investigation.ts
+++ b/src/lib/agent/investigation.ts
@@ -45,7 +45,7 @@
 
 import { createHash } from "node:crypto";
 import { logger } from "@/lib/logger";
-import { isRetryableError } from "@/lib/llm/types";
+import { isRetryableError, isToolCallParseError } from "@/lib/llm/types";
 import { type ModelMessage, Output, type ToolSet, streamText, tool } from "ai";
 import { z } from "zod";
 import {
@@ -91,6 +91,7 @@ import {
   AGENT_MODEL_TURN_TIMEOUT_MS,
   AGENT_REPORT_RESERVE_MS,
   AGENT_TRANSPORT_TURN_RETRIES,
+  AGENT_UNREADABLE_TOOL_CALL_ANSWERS,
   AGENT_REPORT_RESERVE_TURNS,
   AGENT_WORKFLOW_BUDGETS,
 } from "./execution-policy";
@@ -2467,6 +2468,7 @@ export function guidanceDelivered(events: readonly AgentRunEvent[]): Readonly<Re
     "present-before-report": 0,
     "cite-what-you-read": 0,
     "compare-before-report": 0,
+    "tool-call-unreadable": 0,
   };
   for (const event of events) {
     if (event.kind === "guidance-issued") counts[event.notice] += 1;
@@ -2679,6 +2681,18 @@ export async function runInvestigation(
     const delivered = guidanceDelivered(record.events);
     /** Whether this RUN has already answered a stop that read nothing; see `retryUnreadStop`. */
     let unreadStopRetried = delivered["unread-stop"] > 0;
+    /**
+     * Whether this RUN has already been told a tool call of its own could not be parsed.
+     *
+     * Read off the ledger like every other bound here (B51), because it is a property of the RUN
+     * and a second drive of the same run has already spent what it spent.
+     *
+     * A COUNT rather than a flag, and that is a correction this repository measured on itself.
+     * See `AGENT_UNREADABLE_TOOL_CALL_ANSWERS`: the fault recurs within a single run, in different
+     * turns and over different arguments, and the runs that met it twice were ended by the bound
+     * rather than by the model.
+     */
+    let unreadableToolCallAnswers = delivered["tool-call-unreadable"];
     const priorProgress = describePriorProgress(record);
     if (priorProgress !== null) messages.push({ role: "user", content: priorProgress });
 
@@ -3359,8 +3373,36 @@ export async function runInvestigation(
           Bounded by the run's own clock and by a small count, so a provider that is genuinely down
           still ends the run — with its own error, finally meaning it.
         */
+        /*
+          A tool call the ENDPOINT could not parse, which the re-ask above cannot reach.
+
+          Both arrive here as `LLMStreamError` and only one of them is an accident. A broken frame
+          is worth the identical bytes a second time; arguments the provider failed to read are
+          not, and sending them again asks the model to repeat itself. Measured on `gpt-oss:20b`,
+          database-assessment: three runs, six re-asks between them, six identical failures, every
+          run dead seventeen seconds into a 630-second budget with four tools already called.
+
+          The endpoint hands back what it could not read, so the fault is known and specific — a
+          reasoning model writing its thinking into the argument field with valid JSON after it —
+          and Studio was throwing that away and ending the run without saying anything.
+
+          Free, because the alternative is the throw below: the run is over either way, so the turn
+          cannot cost a pass. Once per run, and the second one ends it.
+        */
+        if (
+          isToolCallParseError(error) &&
+          unreadableToolCallAnswers < AGENT_UNREADABLE_TOOL_CALL_ANSWERS &&
+          turns < maxTurns &&
+          resources.deadline.remainingMs() > 0
+        ) {
+          unreadableToolCallAnswers += 1;
+          messages.push({ role: "user", content: notice(BASELINE_NOTICES.unreadableToolCall) });
+          await issueGuidance("tool-call-unreadable");
+          return null;
+        }
         if (
           !isRetryableError(error) ||
+          isToolCallParseError(error) ||
           transportRetries >= AGENT_TRANSPORT_TURN_RETRIES ||
           resources.deadline.remainingMs() <= 0
         ) {

--- a/src/lib/agent/model-tuning/measured-profiles.json
+++ b/src/lib/agent/model-tuning/measured-profiles.json
@@ -542,6 +542,30 @@
       }
     },
     {
+      "id": "qwen3.5:27b",
+      "measured": "6/6 locked, 30/30, AT THE COMPILED DEFAULTS - every cell on its first attempt, the whole model in 52 minutes, and not one setting spent. Investigate 78s, optimize 91s, assess 149s, operate 41s, analyze 66s, plan 48s (medians of the passing runs), a 78-second median. Its optimize cell is worth naming: three other models measured the same week could not open that surface at all, and this one took it 5/5 unaided. Chosen by the family rule rather than by a probe - qwen3.5 has 4b and 9b on this list at 30/30 - which is how every model that ever reached 30/30 got here: on the defaults, with nought to two settings.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": true,
+        "suppressPlanReasoning": false,
+        "refusalExamples": false
+      },
+      "rationale": {
+        "retryUnreadStop": [
+          "Recorded as what it was driven with rather than as a preference. It was measured on a build where `answersUnreadStop` sends the drive's own sentence to a model with no entry, so the runs behind these numbers had it; stating it keeps the entry true after the entry itself exists.",
+          "Nothing else here departs from the defaults, and the entry states them anyway - a shared value is what has twice cost this repository a cell it had already won."
+        ]
+      }
+    },
+    {
       "id": "qwen3.5:4b",
       "measured": "6/6 locked, 30/30. Five surfaces cleared at the shipped defaults and were never touched; plan was the whole of the work and took two separate fixes. At the defaults its plan turns ended model-timeout with a zero-event ledger - the turn spent thinking, and plan mode holds no tools, so thinking time is the only thing that can fail. suppressPlanReasoning turned every one of those into a finished turn and the cell moved 0/5 to 1/5. The remaining four losses were not settings at all: the run wrote a correct refusal, naming the two views whose columns the inventory cannot derive and asking the one question that would unblock it, and opened it `NO STATEMENT AT ALL:` - a phrase this product's own planning rule put in front of the marker it was teaching. With that wording corrected the cell read 5/5 on its first pass. LOCKED but MARGINAL on data-analysis, and a later sweep is why that is written here: the same cell re-read 3/5 on a second sitting, its two losses `answer-uncited` and `no-answer`. The passing runs answer in two or three tool calls and the losing ones wander to ten and eleven, so the cell turns on whether the run settles early rather than on any setting. Recorded rather than re-measured away, because a figure that reads steadier than the model is worse than one that says where it is thin.",
       "settings": {
@@ -626,6 +650,45 @@
           "A later Ollama - 0.33.0, against the 0.32.13 the figures above were taken on - took this model's optimize cell from 5/5 to 1/5, and the losses carry the thinking signature: one tool called, then the whole turn spent before the clock ends it, at 182 to 299 seconds.",
           "Measured on origin/main as well, where this model has no entry at all and runs on the compiled defaults: 1/5 there too. So the engine moved it and no setting here did.",
           "With the switch the cell reads 5/5 at 76 seconds against 311 - it is not merely recovered, it is four times faster than the runs that were passing before."
+        ]
+      }
+    },
+    {
+      "id": "qwen3.6:35b",
+      "measured": "6/6 locked, 30/30, with the set its 27b sibling already ships. Investigate 8s, optimize 19s, assess 18s, operate 7s, analyze 13s, plan 2s (medians of the passing runs) - a 13-second median, six times faster than the 27b's 82s despite being five gigabytes larger, because a model that is not thinking through its turns finishes them. Its optimize cell was the whole of the work: it read 4/5, 3/5, 4/5, 3/5, 4/5 and 2/5 across three sweeps and four separate levers, every loss a model-timeout at 200 to 350 seconds with two or three tools already called. Raising the turn ceiling alone did not close it. The set below did, on the first reading, and the five cells that had locked without it were then read AGAIN under it rather than inherited - suppressAgentReasoning reaches all five agent surfaces, so not one of them had been measured under what ships.",
+      "settings": {
+        "sampling": {
+          "temperature": 0,
+          "topP": 1
+        },
+        "unreportedCallCeiling": 12,
+        "reportReminderLimit": 1,
+        "planStatementRetries": 0,
+        "presentReminderLimit": 1,
+        "retryEmptyTurn": false,
+        "retryUnreadStop": true,
+        "suppressPlanReasoning": true,
+        "refusalExamples": false,
+        "turnTimeoutMs": 150000,
+        "suppressAgentReasoning": true
+      },
+      "rationale": {
+        "suppressAgentReasoning": [
+          "The measured difference, and it is not marginal: optimize went from 2-4/5 to 5/5 and its runs fell from 200-350 seconds to 13-29. Every loss before it was a model-timeout with tools already called - the model was working and the clock was cutting the turn it was working in.",
+          "Taken from the 27b sibling rather than invented. That model ships this exact set and is on this list at 30/30; the family rule is the only predictor on this board with evidence behind it, and this is the second model it has been right about.",
+          "The five agent cells were re-read under it. A cell measured without a setting the profile carries is not a measurement of what ships, which cost this repository a sweep on gemma4:31b."
+        ],
+        "suppressPlanReasoning": [
+          "Its sibling's plan setting, kept for the same reason the pair is taken whole: plan reads 2s under it, the fastest plan turn measured on any model here.",
+          "Reaches plan turns only - investigation.ts reads it where the mode is not agent - so it explains nothing about the five agent cells and is recorded separately from the switch that does."
+        ],
+        "turnTimeoutMs": [
+          "Kept from the sibling's set, and it alone was measured insufficient here: with the ceiling at 150000 and the model still thinking, optimize read 4/5 then 2/5. It is what the passing runs were taken under, so it is what ships.",
+          "The default stays 90000 for every model that does not ask for more, because it is a promise about how long a person waits."
+        ],
+        "retryUnreadStop": [
+          "Recorded as what it was driven with rather than as a preference. Every run behind these numbers was taken on a build where a model with no entry is sent the drive's own sentence for a stop that read nothing; once the model HAS an entry, the entry has to say so or the numbers stop describing the runs that produced them.",
+          "It changes nothing about this model's behaviour and is stated for the reason every default here is stated: a shared value is what has twice cost this repository a cell it had already won."
         ]
       }
     },

--- a/src/lib/agent/models/index.ts
+++ b/src/lib/agent/models/index.ts
@@ -177,8 +177,9 @@ export function retriesUnreadStop(modelId: string): boolean {
  * drive saying anything — `mistral-small3.1:24b` 51, `granite3.3:8b` 41, `mistral:7b` 40,
  * `gpt-oss:20b` 18, a hundred and ten of them on `investigation`, the first surface a model meets.
  *
- * A measured model is untouched: all twenty-eight profiles state the field, so no shipped model's
- * turn count moves.
+ * A measured model is untouched. All twenty-eight profiles stated the field when the two were
+ * split, so not one shipped model's turn count moved on the day this landed; thirty state it now,
+ * and the three that say `true` say it because that is what their runs were taken under.
  */
 export function answersUnreadStop(modelId: string): boolean {
   return resolve(modelId, "retryUnreadStop") ?? true;

--- a/src/lib/agent/models/notices.ts
+++ b/src/lib/agent/models/notices.ts
@@ -55,4 +55,9 @@ export const BASELINE_NOTICES: AgentNotices = Object.freeze({
     "Read it yourself. Call inspect_schema for the tables and their columns, and inspect_plan for how a statement will run, then call compose_report with what you found.",
     CITATION_RULE,
   ].join(" "),
+  unreadableToolCall: [
+    "Your last tool call could not be read: this server's model endpoint refused to parse its arguments, so no tool ran and nothing about it reached this run.",
+    "The arguments of a tool call must be a JSON object and nothing else. Do not write your reasoning, a sentence, or a code fence in the argument field — send only the object, starting at its opening brace.",
+    "Make the call again, arguments only.",
+  ].join(" "),
 });

--- a/src/lib/agent/models/profile.ts
+++ b/src/lib/agent/models/profile.ts
@@ -255,6 +255,14 @@ export interface AgentNotices {
   readonly presentBeforeReport: string;
   /** A run that stopped without calling anything, having asked for what it could have read. */
   readonly unreadStop: string;
+  /**
+   * A tool call the ENDPOINT could not parse, handed back to the model that wrote it.
+   *
+   * The one failure here that is not the drive's judgement of a turn but the provider's: the
+   * arguments did not parse, so no call was made and no ledger entry exists. Re-sending the same
+   * request produces the same failure, which is why this is a sentence rather than a retry.
+   */
+  readonly unreadableToolCall: string;
 }
 
 /**

--- a/src/lib/agent/models/profile.ts
+++ b/src/lib/agent/models/profile.ts
@@ -103,8 +103,9 @@ export interface AgentModelProfile {
    * it, and overruling a measurement is twice how this repository has handed back cells it had
    * won. What is NOT obeyed is an absent entry, which is not a measurement: the drive asks
    * `answersUnreadStop`, not `retriesUnreadStop`, and that resolver offers the turn to a model
-   * nobody has measured. All twenty-eight shipped entries state this field, so no shipped model's
-   * turn count moved when the two were split.
+   * nobody has measured. All twenty-eight shipped entries stated this field when the two were
+   * split, so no shipped model's turn count moved then; thirty state it now, three of them `true`
+   * — which is a record of what their runs were driven with, not a preference.
    *
    * It SUBSUMES `retryEmptyTurn`, and that is a property of the gate rather than of the name.
    * The condition is "called nothing", with no test on what was said, so an empty completion

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -1996,7 +1996,37 @@ function parseToolInput<T>(
   const parsed = schema.safeParse(input);
   return parsed.success
     ? { ok: true, value: parsed.data }
-    : { ok: false, problems: describeIssues(parsed.error.issues) };
+    : { ok: false, problems: describeIssues(parsed.error.issues, input) };
+}
+
+/**
+ * The TYPE that arrived where a type was expected, read off the arguments the tool was handed.
+ *
+ * The other half of a comparison this layer was only ever stating one side of, and by a wide
+ * margin the largest single refusal measured here. Across twelve hours of sweeps `compose_report`
+ * was declined 1530 times and ONE issue is 1110 of them — `claims: expected array` — with models
+ * from three vendors sending the same bytes again after reading it. They are not ignoring the
+ * message: a model that serialized `claims` as a JSON STRING agrees with "expected array", because
+ * what it sent IS an array as far as it can tell. Nothing in the sentence contradicts it.
+ *
+ * Bounded by the rule the message already carries and stated in `describeIssues`: what crosses
+ * over is server-authored — the path, and the type or rule — and never the VALUE. A type is
+ * structural in exactly the way a field name is. `string` is not the model's text; it is the
+ * shape of it, which is the thing the model got wrong and the one thing it was not told.
+ *
+ * Read from the input rather than from the issue because Zod 4 no longer carries `received`.
+ * `null` is named as itself: `typeof null` is `object`, which would send a model looking for a
+ * field it did not omit.
+ */
+function arrivedAt(input: unknown, path: readonly PropertyKey[]): string {
+  let value: unknown = input;
+  for (const key of path) {
+    if (value === null || typeof value !== "object") return "nothing";
+    value = (value as Record<PropertyKey, unknown>)[key];
+  }
+  if (value === null) return "null";
+  if (value === undefined) return "nothing";
+  return Array.isArray(value) ? "array" : typeof value;
 }
 
 /**
@@ -2022,10 +2052,11 @@ function parseToolInput<T>(
  * Three at most, because a model that got the shape wrong is not helped by a fourth, and a
  * long list read as prose is how a refusal becomes another wall.
  */
-function describeIssues(issues: readonly z.core.$ZodIssue[]): string {
+function describeIssues(issues: readonly z.core.$ZodIssue[], input: unknown): string {
   const named = issues.slice(0, 3).map((issue) => {
     const where = issue.path.length === 0 ? "the arguments object" : issue.path.join(".");
-    if (issue.code === "invalid_type") return `${where}: expected ${issue.expected}`;
+    if (issue.code === "invalid_type")
+      return `${where}: expected ${issue.expected}, received ${arrivedAt(input, issue.path)}`;
     if (issue.code === "unrecognized_keys") return `${where}: remove ${issue.keys.join(", ")}`;
     /*
       A closed set is named, because "invalid value" was not something a model could act on.

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -654,6 +654,12 @@ export type AgentGuidanceNotice =
    */
   | "unread-stop"
   /**
+   * A tool call the model endpoint could not parse, answered rather than re-sent.
+   * Delivered as a `user` message; once per run, because a model that cannot comply
+   * with it should still fail fast.
+   */
+  | "tool-call-unreadable"
+  /**
    * A `compose_report` on an answering workflow with a presentable read and no
    * presentation. Delivered as a TOOL RESULT instead of running the call, so it rides
    * the `call-held` entry; bounded by the model's own `presentReminderLimit`.

--- a/src/lib/llm/types.ts
+++ b/src/lib/llm/types.ts
@@ -171,3 +171,25 @@ export function isRetryableError(error: unknown): boolean {
   // Rate limit and stream errors may be retryable
   return true;
 }
+
+/**
+ * Whether the endpoint refused the model's TOOL CALL because it could not parse it.
+ *
+ * A distinction `isRetryableError` cannot draw and must not: both arrive as `LLMStreamError`, and
+ * a broken frame genuinely is worth sending the same bytes again. This one is not. The endpoint
+ * read the model's arguments, failed on them, and hands the raw text back — so re-sending the
+ * identical request asks the model to make the identical mistake, which is what it does.
+ *
+ * Measured on `gpt-oss:20b`, database-assessment: three runs, each re-asked the full two allowed
+ * times, six attempts, six identical failures, the run ending seventeen seconds into a
+ * 630-second budget with four tools already called. The endpoint's own message is
+ * `error parsing tool call: raw='<the model's text>', err=<why>` — a reasoning model writing its
+ * thinking into the argument field with valid JSON after it.
+ *
+ * Matched on the endpoint's wording, which is narrow on purpose. The alternative — treating every
+ * stream error as a model fault — would stop re-asking the broken frames that the re-ask above
+ * was measured to rescue.
+ */
+export function isToolCallParseError(error: unknown): boolean {
+  return error instanceof LLMStreamError && /parsing tool call/i.test(error.message);
+}

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -3108,6 +3108,119 @@ describe("the run loop is bounded", () => {
       // One turn only: the second scripted entry is never reached.
       expect(script.turns).toHaveLength(1);
     });
+
+    /*
+      The other half, and the reason the re-ask above is not enough on its own.
+
+      A broken frame is an accident: the same bytes sent again land. A tool call the ENDPOINT
+      could not parse is not an accident, and re-sending byte-identical bytes asks the model to
+      make the same mistake a second time. Measured on `gpt-oss:20b`, database-assessment, on the
+      build this branch carries: three runs, each re-asked the full two allowed times, six
+      attempts, all six dead the same way, and the run ended `model-unavailable` seventeen seconds
+      into a 630-second budget having called four tools.
+
+      The endpoint says exactly what is wrong and hands back the model's own text:
+
+          error parsing tool call: raw='We need to answer: "Where is this database's data
+          incomplete or surprising?" ... First, profile salary.{"depth":"basic","table":"salary"}'
+          err=invalid character 'W' looking for beginning of value
+
+      A reasoning model writing its thinking into the argument field, with valid JSON after it.
+      Studio holds that sentence, throws it away, and ends the run without telling the model
+      anything — which is the shape this repository has now corrected five times.
+
+      Free, on the same argument as every other recovery here: the alternative is the throw two
+      lines below, so the run is already over. The turn cannot cost a pass.
+    */
+    test("a tool call the endpoint could not read is answered, not re-sent unchanged", async () => {
+      const b = boot(freshDataDir());
+      const run = await startRun(b);
+      const unreadable = () => {
+        throw new LLMStreamError(
+          `error parsing tool call: raw='We need to answer. First, profile salary.{"depth":"basic","table":"salary"}', err=invalid character 'W' looking for beginning of value`,
+          "openai",
+        );
+      };
+      // The call that could not be read, then the same work done readably.
+      const script = scriptedModel(unreadable, callsTool("inspect_schema", { schema: "public" }), reportOn());
+
+      const result = await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: b.resources,
+      });
+
+      // Three turns: the unreadable call, the read it makes once told, and the report. Not the
+      // four a run spends re-sending the identical bytes twice before dying.
+      expect(script.turns).toHaveLength(3);
+      const events = await eventsOf(b.store, run.runId);
+      expect(events.filter((event) => event.kind === "guidance-issued").map((event) => event.notice)).toContain(
+        "tool-call-unreadable",
+      );
+      // The sentence names the fault, so the model has something to do differently.
+      expect(script.turns[1]?.transcript).toContain("could not be read");
+      expect(result.stopReason).toBe("report-composed");
+    });
+
+    test("a SECOND unreadable call is answered too, because the fault recurs within one run", async () => {
+      /*
+        The correction to this bound, measured rather than argued.
+
+        It shipped as once per run on the reasoning that a model which hears the sentence and
+        writes the same unparseable arguments again is not rescued by hearing it twice. On
+        `gpt-oss:20b` that is wrong in the way that matters: of ten runs four met the fault, TWO
+        heard the sentence once and went on to answer, and the other two met it a SECOND time
+        later in the run and were ended `model-unavailable` by the bound rather than by anything
+        the model did. Both endings are on the ledger as `failed / model-unavailable` after
+        exactly one `tool-call-unreadable`.
+
+        The sentence works when it is allowed to be said. What the flag encoded was the assumption
+        that the mistake happens once; a long run of a reasoning model makes it more than once, in
+        different turns and over different arguments.
+      */
+      const b = boot(freshDataDir());
+      const run = await startRun(b);
+      const unreadable = () => {
+        throw new LLMStreamError("error parsing tool call: raw='thinking'", "openai");
+      };
+      const script = scriptedModel(
+        unreadable,
+        callsTool("inspect_schema", { schema: "public" }),
+        // The same fault again, turns later and over different arguments.
+        unreadable,
+        reportOn(),
+      );
+
+      const result = await runInvestigation(run.runId, {
+        service: b.service,
+        model: await modelOver(script.fetch),
+        resources: b.resources,
+      });
+
+      const notices = (await eventsOf(b.store, run.runId))
+        .filter((event) => event.kind === "guidance-issued")
+        .map((event) => event.notice);
+      expect(notices.filter((notice) => notice === "tool-call-unreadable")).toHaveLength(2);
+      expect(result.stopReason).toBe("report-composed");
+    });
+
+    test("a third ends the run, so a model that cannot comply still fails fast", async () => {
+      const b = boot(freshDataDir());
+      const run = await startRun(b);
+      const unreadable = () => {
+        throw new LLMStreamError("error parsing tool call: raw='thinking'", "openai");
+      };
+      // Told twice and unable to act on it, which is the case the bound exists for.
+      const script = scriptedModel(unreadable, unreadable, unreadable, unreadable, unreadable, unreadable);
+
+      await expect(
+        runInvestigation(run.runId, {
+          service: b.service,
+          model: await modelOver(script.fetch),
+          resources: b.resources,
+        }),
+      ).rejects.toThrow(/parsing tool call/);
+    });
   });
 
   describe("a turn the ceiling cut is given back, because the RUN still has its time", () => {

--- a/tests/isolated/agent-investigation.test.ts
+++ b/tests/isolated/agent-investigation.test.ts
@@ -3558,7 +3558,7 @@ describe("a run that stops having read nothing is told to read it itself", () =>
     The drive holds a sentence written for exactly this ending — "Read it yourself. Call
     inspect_schema for the tables and their columns, and inspect_plan for how a statement will
     run" — and for a while sent it only to a model whose profile asked for it. One profile of
-    twenty-eight does, and a model nobody has measured has no profile at all, so the model most
+    thirty does, and a model nobody has measured has no profile at all, so the model most
     in need of the sentence was the one guaranteed not to receive it.
 
     Measured across the sweep behind 0.14.1: three hundred runs ended `model-stopped` with
@@ -3573,7 +3573,7 @@ describe("a run that stops having read nothing is told to read it itself", () =>
     was withholding was a sentence on a run already lost.
 
     This is the fourth setting found in this shape and the second corrected. A measured profile
-    is still obeyed: all twenty-eight state the field, so no shipped model's turn count moves.
+    is still obeyed: every shipped entry states the field, so no model's turn count moved on it.
   */
   test("a model NOBODY has measured is told to read, because the sentence is the server's own", async () => {
     const b = boot(freshDataDir());

--- a/tests/security/route-auth.test.ts
+++ b/tests/security/route-auth.test.ts
@@ -102,6 +102,14 @@ mock.module("@/lib/llm/types", () => ({
       error instanceof MockLLMSafetyError ||
       error instanceof MockLLMConfigError
     ) && error instanceof MockLLMError,
+  /*
+    The same reason, one export later. `investigation.ts` imports this beside `isRetryableError`,
+    so omitting it takes the module down for every importer exactly as omitting that one did —
+    which is the failure this comment was written after, repeated because the note said what had
+    happened and not that the NEXT export would do it too.
+  */
+  isToolCallParseError: (error: unknown): boolean =>
+    error instanceof MockLLMStreamError && /parsing tool call/i.test(error.message),
 }));
 
 const { guardRoute } = await import("@/lib/api/require-session");

--- a/tests/unit/lib/agent/model-profiles.test.ts
+++ b/tests/unit/lib/agent/model-profiles.test.ts
@@ -146,8 +146,8 @@ describe("sampling is decided per model, defaulting to deterministic", () => {
   test("a stop that read nothing is answered for a model nobody has measured, and not against one who has", () => {
     /*
       The same distinction, on the other setting that carries it. `retriesUnreadStop` reads the
-      shipped document, where all twenty-eight entries state the field and one — `nemotron3:33b` —
-      states `true`; `answersUnreadStop` is what the drive asks, and it separates a stated `false`
+      shipped document, where all thirty entries state the field and three — `nemotron3:33b`,
+      `qwen3.5:27b` and `qwen3.6:35b` — state `true`; `answersUnreadStop` is what the drive asks, and it separates a stated `false`
       from no entry at all. The gate behind it fires only where the run called no tool, so it is
       reachable only on a run that has already earned `no-report` and cannot cost a pass.
     */

--- a/tests/unit/lib/agent/model-resolution-table.test.ts
+++ b/tests/unit/lib/agent/model-resolution-table.test.ts
@@ -154,6 +154,19 @@ const RESOLVED: ResolvedRow[] = [
     turnTimeoutMs: undefined,
   },
   {
+    // Six cells on the first attempt with NOT ONE setting spent, which is what the whole table is
+    // for: the row is short because the model asked for nothing.
+    id: "qwen3.5:27b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    retriesUnreadStop: true,
+    refusalExamples: false,
+    turnTimeoutMs: undefined,
+  },
+  {
     id: "qwen3.5:9b",
     unreportedCallCeiling: 12,
     reportReminderLimit: 1,
@@ -173,6 +186,21 @@ const RESOLVED: ResolvedRow[] = [
     planStatementRetries: 0,
     presentReminderLimit: 1,
     retriesEmptyTurn: false,
+    refusalExamples: false,
+    suppressesPlanReasoning: true,
+    suppressesAgentReasoning: true,
+    turnTimeoutMs: 150_000,
+  },
+  {
+    // Its 27b sibling's set, taken whole and then re-measured under: optimize went from 2-4/5 to
+    // 5/5 and the runs fell from 200-350 seconds to 13-29.
+    id: "qwen3.6:35b",
+    unreportedCallCeiling: 12,
+    reportReminderLimit: 1,
+    planStatementRetries: 0,
+    presentReminderLimit: 1,
+    retriesEmptyTurn: false,
+    retriesUnreadStop: true,
     refusalExamples: false,
     suppressesPlanReasoning: true,
     suppressesAgentReasoning: true,
@@ -496,7 +524,7 @@ describe("every resolver's answer, pinned before the profiles moved", () => {
   test("the table covers every registered model, so a new one cannot arrive unpinned", () => {
     const pinned = new Set(RESOLVED.map((row) => row.id));
     for (const id of Object.keys(modelProfiles())) expect(pinned.has(id)).toBe(true);
-    expect(Object.keys(modelProfiles())).toHaveLength(28);
+    expect(Object.keys(modelProfiles())).toHaveLength(30);
   });
 });
 
@@ -558,8 +586,10 @@ describe("what each model records about the runs that earned its settings", () =
     "qwen2.5:32b": "71885a95b0d717ca4f6814cfa4575bfa5f3cc20b7086c4de44f79835be3bcb1a",
     "qwen2.5:7b": "09631668500b307a79ca06e1a7de2dfdffc1632f4bd5bb4a460abab6caf09857",
     "qwen3.5:4b": "204b6f6beb8710155508938a2271cbf34013235fa612b40ecebf98ff5dcff061",
+    "qwen3.5:27b": "d83ddd506de32534c2b705b05ec2d44bef6ec19199094e86ec77ffbd2b38f59b",
     "qwen3.5:9b": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
     "qwen3.6:27b": "d0ebde3fdf25b9c56ab7bcad4adc3b54510a413285e51edcb46aec261e661157",
+    "qwen3.6:35b": "3b35d7070adca4f15fcc95bd522fd0ca0d5d77e5d4306be8f400da09c6899e25",
     "qwen3.8:latest": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",
     "qwen3:14b": "96e0d729224168eff3eddc16ed1bd588dd28cd133441c85790670ffd3e36dddd",
     "qwen3:4b": "57453d009646b45dcee4bd74c46fcad9fa03ce69790e302fc948f1a60809015a",

--- a/tests/unit/lib/agent/model-tuning.test.ts
+++ b/tests/unit/lib/agent/model-tuning.test.ts
@@ -93,7 +93,7 @@ afterEach(() => {
 describe("the document Studio ships with", () => {
   test("passes its own contract", () => {
     const tuning = parseTuning(bundled, "test");
-    expect(Object.keys(tuning.models)).toHaveLength(28);
+    expect(Object.keys(tuning.models)).toHaveLength(30);
   });
 
   test("argues for every value it changed", () => {
@@ -563,7 +563,7 @@ describe("a document an operator supplies", () => {
     process.env[ENV] = writeDocument("{ not json");
     resetTuning();
     expect(ceilingFor("gemma4:26b")).toBe(10);
-    expect(Object.keys(activeTuning().models)).toHaveLength(28);
+    expect(Object.keys(activeTuning().models)).toHaveLength(30);
   });
 
   test("reports that it ignored a document, naming the file and the reason", () => {
@@ -717,13 +717,13 @@ describe("a document an operator supplies", () => {
   test("is ignored when it breaks the contract, not partially applied", () => {
     process.env[ENV] = writeDocument(document({ schemaVersion: 99 }));
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(28);
+    expect(Object.keys(activeTuning().models)).toHaveLength(30);
   });
 
   test("is ignored when the file is not there at all", () => {
     process.env[ENV] = "/nonexistent/models.json";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(28);
+    expect(Object.keys(activeTuning().models)).toHaveLength(30);
   });
 
   test("an unset or blank variable is simply no operator document", () => {
@@ -731,7 +731,7 @@ describe("a document an operator supplies", () => {
     // reading it as a path would warn on every boot of an install that configured nothing.
     process.env[ENV] = "   ";
     resetTuning();
-    expect(Object.keys(activeTuning().models)).toHaveLength(28);
+    expect(Object.keys(activeTuning().models)).toHaveLength(30);
   });
 
   test("is read once, so a run cannot see the table change under it", () => {

--- a/tests/unit/lib/agent/tools.test.ts
+++ b/tests/unit/lib/agent/tools.test.ts
@@ -594,6 +594,45 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
       expect(answer.modelText).toContain("presentation");
     });
 
+    test("and names what ARRIVED, because a model told only what was expected sends it again", async () => {
+      /*
+        The other half of the sentence above, and by a wide margin the largest single refusal
+        this project has measured. Across twelve hours of sweeps on the build this branch
+        carries, `compose_report` was declined 1530 times and ONE issue is 1110 of them:
+
+            the fields that did not match — claims: expected array
+
+        True, and still not enough to act on. A model that serialized `claims` as a JSON
+        STRING reads "expected array" and agrees with it — what it sent is an array, as far as
+        it can tell — so it sends the same bytes again. The test above records exactly that
+        loop being fixed once by naming the field; this is the same loop surviving because the
+        message names one side of a comparison and not the other.
+
+        The rule the message is bounded by does not stand in the way, and this file already
+        states it: what crosses over is "the path and the expected type ... and never the
+        value the model sent". A TYPE is structural, like a field name. `string` is not the
+        model's text; it is the shape of it.
+
+        Zod 4 drops `received` from the issue, so the type is read off the arguments the tool
+        was actually handed, by walking the issue's own path.
+      */
+      const h = analysis();
+      const { artifact, events } = await readWithLedger(h.context);
+
+      const answer = presentAnswerTool(
+        h.context,
+        { runId: h.context.runId, events, autoExecute: false },
+        // `presentation` declared as an object and sent as a number: expected against arrived.
+        { artifact: artifact.correlationId, presentation: 7 },
+      );
+
+      expect(answer.kind).toBe("unavailable");
+      if (answer.kind !== "unavailable") return;
+      expect(answer.reasonCode).toBe("INVALID_TOOL_INPUT");
+      expect(answer.modelText).toContain("presentation");
+      expect(answer.modelText).toContain("received number");
+    });
+
     test("refuses a string that is not JSON at all, in the contract's own words", async () => {
       const h = analysis();
       const { artifact, events } = await readWithLedger(h.context);
@@ -902,7 +941,7 @@ describe("a tool that demands a citation says what a citation IS (#350)", () => 
         sending prose where an object goes.
 
         The paths were already named. What was gated was the SHAPE: `exampleReportCall` rebuilds a
-        whole call from the run's ledger and sits behind `refusalExamples`, which two of twenty-eight
+        whole call from the run's ledger and sits behind `refusalExamples`, which two of thirty
         shipped models carry. Everyone else reads "expected object" and has to guess the object.
 
         So this splits the two, on the rule the column advice was split on: a one-line skeleton is


### PR DESCRIPTION
Twenty-eight supported models becomes **thirty: 900 runs, 900 passes.**

| Model | Disk | Investigate | Optimize | Assess | Operate | Analyze | Plan | Median |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `qwen3.6:35b` | 22 GB | 8s | 19s | 18s | 7s | 13s | 2s | **13s** |
| `qwen3.5:27b` | 17 GB | 78s | 91s | 149s | 41s | 66s | 48s | **78s** |

Neither arrived by grinding, and the two arrived opposite ways.

## `qwen3.5:27b` — asked for nothing

Six surfaces on its **first attempt at the compiled defaults**, the whole model in 52 minutes, with
not one setting spent. It is the only size in its family whose entry carries no departure from the
defaults at all.

Its optimize cell is the figure worth naming: **three other models measured the same week could not
open that surface at any setting.** This one took it 5/5 unaided.

It was chosen by the family rule rather than by a probe — `qwen3.5` already has 4b and 9b on the
list at 30/30 — which is how every model that has ever reached 30/30 got here: on the defaults,
with nought to two settings.

## `qwen3.6:35b` — took its sibling's set, whole

Its optimize cell refused to close across three sweeps and four separate levers:

| Reading | 1 | 2 | 3 | 4 | 5 | 6 |
| --- | --- | --- | --- | --- | --- | --- |
| optimize | 4/5 | 3/5 | 4/5 | 3/5 | 4/5 | 2/5 |

Every loss a `model-timeout` at 200 to 350 seconds with two or three tools already called — the
model working, and the clock cutting the turn it was working in. Raising the ceiling alone did not
do it.

Its 27b sibling ships `suppressPlanReasoning`, `suppressAgentReasoning` and a 150-second limit.
Taken whole, the cell closed **on the first reading**, and the runs fell from 200-350 seconds to
**13-29**.

**The five cells that had locked without that set were then read again under it**, not inherited:
`suppressAgentReasoning` reaches all five agent surfaces, so none of them had been measured under
what ships. All five held. The table above is those runs.

Worth noting for the family page: the 35b is five gigabytes larger than the 27b and its median run
is **13s against 82s**. Size is a poor predictor of speed next to whether a model is being asked to
think in a place the run cannot use.

## Three refusals, all the same shape

Each was found by driving these models, and each is the server holding the missing half of a
sentence.

### 1. A tool call the endpoint could not parse ended the whole run

The re-ask above it is written for a broken connection and re-sends byte-identical bytes. This
failure is deterministic, so all three attempts died identically and the run ended
`model-unavailable` **seventeen seconds into a 630-second budget with four tools already called.**

The endpoint hands back exactly what it could not read:

```
error parsing tool call: raw='We need to answer: "Where is this database's data incomplete
or surprising?" ... First, profile salary.{"depth":"basic","table":"salary"}'
err=invalid character 'W' looking for beginning of value
```

A reasoning model writing its thinking into the argument field, with valid JSON after it. Studio
threw that away and said nothing.

Answered instead: **`gpt-oss:20b`'s assess cell went from 1/5 to 5/5 on its first reading**, with no
per-model setting at all. Four sweeps and two different levers had left it at 1/5, 1/5, 2/5, 2/5.

### 2. That answer was bounded once per run, and the bound was wrong

It shipped as a flag on the argument that a model which hears the sentence and repeats the mistake
is not rescued by hearing it twice. Measured on `gpt-oss:20b`, ten runs:

| | runs |
| --- | --- |
| met the fault | 4 |
| heard it once and went on to **answer** | **2** |
| met it again later and were ended **by the bound** | **2** |

Both of those two ended `failed / model-unavailable` after exactly one `tool-call-unreadable`. The
sentence works when it is allowed to be said; what the flag encoded was the assumption that the
mistake happens once, and a long run of a reasoning model makes it more than once, in different
turns and over different arguments. It is a count now, matching `AGENT_TRANSPORT_TURN_RETRIES`.

### 3. An invalid-argument refusal named what was expected and not what arrived

Across twelve hours of sweeps `compose_report` was declined **1530 times**, and one issue was
**1110 of them**:

> the fields that did not match — claims: expected array

Models from three vendors read that and sent the same bytes again. They were not ignoring it: a
model that serialized `claims` as a JSON **string** agrees with "expected array" — what it sent is
an array, as far as it can tell — and nothing in the sentence contradicts it.

Naming the arrived TYPE respects the rule the message already carries and this file already states:
the path and the type, **never the value**. A type is structural in the way a field name is.

After the change that error **stopped appearing entirely**; the failures moved one level deeper into
the schema, where the message was already specific enough to act on.

## Verification

Every assertion added here was mutated to confirm it bites:

| Mutation | Result |
| --- | --- |
| `isToolCallParseError` returns `false` always | **1 fail** |
| `AGENT_UNREADABLE_TOOL_CALL_ANSWERS` 2 → 1 | **1 fail** |
| `received ${arrivedAt(...)}` dropped from the message | **1 fail** |

A fourth failure was found by the coverage gate rather than by the suite: `route-auth.test.ts`
mocks `@/lib/llm/types` **whole**, so a new export it omits does not fall through — it stops
existing and every importer fails to load. Green under `bun run test`, red under `test:coverage`
where each file runs alone. The file's own comment records this happening once before with
`isRetryableError`; it now records that the next export does it too.

`chart:check` (strict) · `channels:showcase:check` · `readme:check` · `security:check` · `format` ·
`lint` · `typecheck` · `knip` · `test` (0 fail) · `build` · `build:lib` · `attw` — all green.
Coverage: **46442/46442 lines, 100.00%**.

Rebased onto `main` at `2f4ae612`.
