### PR TITLE
feat(saved-queries): import and export JSON backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ And nothing is held back. Single sign-on, ER diagrams, the AI features and the N
 - **Smart Autocomplete**: Schema-aware suggestions for tables, columns, and SQL keywords.
 - **Command Palette**: Quick access to tables, connections, saved queries, and actions with `Cmd/Ctrl+K`.
 - **Multi-Tab Workspace**: Handle parallel tasks with independent execution states.
+- **Saved Query Backups**: Export the complete saved-query library as JSON. Import validates the file, preserves query metadata and merges new entries, reporting duplicate IDs while keeping existing queries intact.
 - **Visual EXPLAIN**: Graphical execution plans to identify performance bottlenecks.
 - **Interactive ER Diagrams**: Visual schema graph with real foreign key edges, cardinality labels, MiniMap navigation, table search/filter, compact mode, and PNG/SVG export. Automatic hierarchical layout powered by ELK.js.
 - **Schema Diff & Migration**: Compare schema snapshots or cross-connection schemas side-by-side. Color-coded diff view (added/removed/modified) with automatic migration SQL generation for PostgreSQL, MySQL, SQLite, Oracle, and SQL Server, plus ClickHouse column modifications.

--- a/src/components/SavedQueries.tsx
+++ b/src/components/SavedQueries.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { storage } from "@/lib/storage";
 import { SavedQuery } from "@/lib/types";
-import { Bookmark, Search, Trash2, PenLine, Tag, Calendar } from "lucide-react";
+import { Bookmark, Search, Trash2, PenLine, Tag, Calendar, Download, Upload } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { format } from "date-fns";
+import { downloadText } from "@/lib/export/download";
+import { jsonText } from "@/lib/export/json";
+import { parseSavedQueries } from "@/lib/saved-query-import";
+import { toast } from "sonner";
 
 interface SavedQueriesProps {
   onSelectQuery: (query: string) => void;
@@ -17,6 +21,8 @@ interface SavedQueriesProps {
 export function SavedQueries({ onSelectQuery, connectionType, refreshTrigger }: SavedQueriesProps) {
   const [queries, setQueries] = useState<SavedQuery[]>(() => storage.getSavedQueries());
   const [search, setSearch] = useState("");
+  const [isImporting, setIsImporting] = useState(false);
+  const fileInput = useRef<HTMLInputElement>(null);
 
   // `refreshTrigger` is bumped by whoever writes a saved query. Adjusting state during
   // render is React's prescribed replacement for a setState-in-effect, and unlike a `key`
@@ -42,12 +48,66 @@ export function SavedQueries({ onSelectQuery, connectionType, refreshTrigger }: 
     }
   };
 
+  const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    setIsImporting(true);
+    try {
+      const incoming = parseSavedQueries(await file.text());
+      const result = storage.importSavedQueries(incoming);
+      setQueries(storage.getSavedQueries());
+      if (result.collisions.length > 0) {
+        toast("Import finished with ID conflicts", {
+          description: `Added ${result.imported}; skipped duplicate IDs: ${result.collisions.join(", ")}.`,
+        });
+      } else {
+        toast.success("Saved queries import finished", { description: `Added ${result.imported}.` });
+      }
+    } catch {
+      toast.error("Could not import saved queries. Check the JSON file and available browser storage.");
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
   return (
     <div className="h-full flex flex-col bg-surface">
       <div className="p-4 border-b border-hairline flex flex-col gap-4">
         <h3 className="text-xs font-medium text-fg-tertiary flex items-center gap-2">
           <Bookmark strokeWidth={1.5} className="w-3.5 h-3.5" /> Saved Queries
         </h3>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs gap-2"
+            aria-label="Export all saved queries as JSON"
+            disabled={queries.length === 0}
+            onClick={() => downloadText(jsonText(queries, 2), "application/json", `saved_queries_${Date.now()}.json`)}
+          >
+            <Download className="w-3 h-3" /> Export all
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs gap-2"
+            disabled={isImporting}
+            onClick={() => fileInput.current?.click()}
+          >
+            <Upload className="w-3 h-3" /> Import JSON
+          </Button>
+          <input
+            ref={fileInput}
+            type="file"
+            accept="application/json,.json"
+            aria-label="Import saved queries JSON"
+            className="hidden"
+            disabled={isImporting}
+            onChange={handleImport}
+          />
+        </div>
 
         <div className="relative">
           <Search strokeWidth={1.5} className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-fg-muted" />

--- a/src/lib/saved-query-import.ts
+++ b/src/lib/saved-query-import.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { SHIPPED_DATABASE_TYPES } from "@/lib/db/compatibility";
+import type { SavedQuery } from "@/lib/types";
+
+const savedQuerySchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  query: z.string(),
+  description: z.string().optional(),
+  connectionType: z.enum(SHIPPED_DATABASE_TYPES),
+  createdAt: z.string().pipe(z.coerce.date()),
+  updatedAt: z.string().pipe(z.coerce.date()),
+  tags: z.array(z.string()).optional(),
+});
+
+/** Validate the complete backup before any query is persisted. */
+export function parseSavedQueries(text: string): SavedQuery[] {
+  return z.array(savedQuerySchema).parse(JSON.parse(text));
+}

--- a/src/lib/saved-query-import.ts
+++ b/src/lib/saved-query-import.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 import { SHIPPED_DATABASE_TYPES } from "@/lib/db/compatibility";
 import type { SavedQuery } from "@/lib/types";
 
+// This schema loads in the browser. Even Zod's caught eval-capability probe
+// violates the app's CSP, so disable JIT before constructing the object schema.
+z.config({ jitless: true });
+
 const savedQuerySchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),

--- a/src/lib/storage/storage-facade.ts
+++ b/src/lib/storage/storage-facade.ts
@@ -136,6 +136,27 @@ export const storage = {
     dispatchChange("saved_queries", filtered);
   },
 
+  importSavedQueries: (incoming: readonly SavedQuery[]) => {
+    const existing = storage.getSavedQueries();
+    const ids = new Set(existing.map((query) => query.id));
+    const added: SavedQuery[] = [];
+    const collisions: string[] = [];
+    for (const query of incoming) {
+      if (ids.has(query.id)) {
+        collisions.push(query.id);
+      } else {
+        ids.add(query.id);
+        added.push(query);
+      }
+    }
+    if (added.length > 0) {
+      const merged = [...existing, ...added];
+      if (!writeJSON("saved_queries", merged)) throw new Error("Could not save imported queries.");
+      dispatchChange("saved_queries", merged);
+    }
+    return { imported: added.length, collisions };
+  },
+
   // ═══════════════════════════════════════════════════════════════════════════
   // Schema Snapshots
   // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/components/SavedQueries.test.tsx
+++ b/tests/components/SavedQueries.test.tsx
@@ -4,9 +4,11 @@ import "../helpers/mock-navigation";
 
 import React from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import type { SavedQuery } from "@/lib/types";
+import { mockToastDefault, mockToastError, mockToastSuccess } from "../helpers/mock-sonner";
 
-const mockSavedQueries = [
+const mockSavedQueries: SavedQuery[] = [
   {
     id: "q1",
     name: "Active Users",
@@ -14,18 +16,22 @@ const mockSavedQueries = [
     query: "SELECT * FROM users WHERE active = true",
     connectionType: "postgres",
     tags: ["report"],
-    createdAt: "2026-01-15T10:00:00Z",
-    updatedAt: "2026-01-15T10:00:00Z",
+    createdAt: new Date("2026-01-15T10:00:00Z"),
+    updatedAt: new Date("2026-01-15T10:00:00Z"),
   },
 ];
 
 const mockGetSavedQueries = mock(() => [...mockSavedQueries]);
 const mockDeleteSavedQuery = mock(() => {});
+const mockImportSavedQueries = mock((_queries: SavedQuery[]) => ({ imported: 1, collisions: [] as string[] }));
+const mockDownloadText = mock((_text: string, _type: string, _name: string) => {});
+mock.module("@/lib/export/download", () => ({ downloadText: mockDownloadText }));
 
 mock.module("@/lib/storage", () => ({
   storage: {
     getSavedQueries: mockGetSavedQueries,
     deleteSavedQuery: mockDeleteSavedQuery,
+    importSavedQueries: mockImportSavedQueries,
   },
 }));
 
@@ -44,9 +50,124 @@ describe("SavedQueries", () => {
   });
 
   beforeEach(() => {
+    mockImportSavedQueries.mockClear();
+    mockImportSavedQueries.mockImplementation(() => ({ imported: 1, collisions: [] }));
+    mockDownloadText.mockClear();
+    mockToastDefault.mockClear();
+    mockToastError.mockClear();
+    mockToastSuccess.mockClear();
     mockGetSavedQueries.mockClear();
     mockDeleteSavedQuery.mockClear();
     mockGetSavedQueries.mockImplementation(() => [...mockSavedQueries]);
+  });
+
+  function importFile(input: HTMLElement, text: string) {
+    const file = new File([text], "saved_queries.json", { type: "application/json" });
+    Object.defineProperty(file, "text", { value: async () => text });
+    fireEvent.change(input, { target: { files: [file] } });
+  }
+
+  test("exports the complete library as JSON even while search and connection filters hide it", () => {
+    const library = [...mockSavedQueries, { ...mockSavedQueries[0], id: "mysql", connectionType: "mysql" as const }];
+    mockGetSavedQueries.mockReturnValue(library);
+    const onSelectQuery = mock(() => {});
+    const view = render(<SavedQueries onSelectQuery={onSelectQuery} connectionType="postgres" />);
+    fireEvent.change(view.getByPlaceholderText("Search saved queries..."), { target: { value: "missing" } });
+    fireEvent.click(view.getByRole("button", { name: "Export all saved queries as JSON" }));
+    expect(mockDownloadText).toHaveBeenCalledWith(
+      JSON.stringify(library, null, 2),
+      "application/json",
+      expect.stringMatching(/^saved_queries_\d+\.json$/),
+    );
+    expect(onSelectQuery).not.toHaveBeenCalled();
+  });
+
+  test("imports valid saved queries, reloads the library and retains search without executing", async () => {
+    const imported = { ...mockSavedQueries[0], id: "new", name: "Imported Query", query: "SELECT '你好';" };
+    const onSelectQuery = mock(() => {});
+    const view = render(<SavedQueries onSelectQuery={onSelectQuery} />);
+    const search = view.getByPlaceholderText("Search saved queries...") as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "Imported" } });
+    mockGetSavedQueries.mockReturnValue([...mockSavedQueries, imported]);
+    const input = view.getByLabelText("Import saved queries JSON") as HTMLInputElement;
+    importFile(input, JSON.stringify([imported]));
+    await waitFor(() => expect(mockImportSavedQueries).toHaveBeenCalledWith([imported]));
+    expect(view.getByRole("button", { name: "Imported Query" }) !== null).toBe(true);
+    expect(mockToastSuccess).toHaveBeenCalledWith("Saved queries import finished", { description: "Added 1." });
+    expect(search.value).toBe("Imported");
+    expect(input.value).toBe("");
+    expect(onSelectQuery).not.toHaveBeenCalled();
+  });
+
+  test("reports colliding IDs instead of announcing an unconditional success", async () => {
+    mockImportSavedQueries.mockReturnValue({ imported: 1, collisions: ["q1", "duplicate"] });
+    const view = render(<SavedQueries onSelectQuery={mock(() => {})} />);
+    importFile(view.getByLabelText("Import saved queries JSON"), JSON.stringify(mockSavedQueries));
+    await waitFor(() =>
+      expect(mockToastDefault).toHaveBeenCalledWith("Import finished with ID conflicts", {
+        description: "Added 1; skipped duplicate IDs: q1, duplicate.",
+      }),
+    );
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  test.each(["{", JSON.stringify({ queries: [] }), JSON.stringify([{ ...mockSavedQueries[0], updatedAt: "invalid" }])])(
+    "rejects an invalid import without writing any queries",
+    async (text) => {
+      const view = render(<SavedQueries onSelectQuery={mock(() => {})} />);
+      importFile(view.getByLabelText("Import saved queries JSON"), text);
+      await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+      expect(mockImportSavedQueries).not.toHaveBeenCalled();
+      expect((view.getByRole("button", { name: "Import JSON" }) as HTMLButtonElement).disabled).toBe(false);
+    },
+  );
+
+  test("opens the file picker, handles cancellation and disables export for an empty library", () => {
+    mockGetSavedQueries.mockReturnValue([]);
+    const view = render(<SavedQueries onSelectQuery={mock(() => {})} />);
+    const input = view.getByLabelText("Import saved queries JSON") as HTMLInputElement;
+    input.click = mock(() => {});
+    fireEvent.click(view.getByRole("button", { name: "Import JSON" }));
+    expect(input.click).toHaveBeenCalledTimes(1);
+    fireEvent.change(input, { target: { files: [] } });
+    expect(mockImportSavedQueries).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect((view.getByRole("button", { name: "Export all saved queries as JSON" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  test("keeps the import control disabled until the file read settles and reports read failures", async () => {
+    const view = render(<SavedQueries onSelectQuery={mock(() => {})} />);
+    let rejectRead!: (error: Error) => void;
+    const file = new File([], "queries.json");
+    Object.defineProperty(file, "text", {
+      value: () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectRead = reject;
+        }),
+    });
+    fireEvent.change(view.getByLabelText("Import saved queries JSON"), { target: { files: [file] } });
+    const button = view.getByRole("button", { name: "Import JSON" }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    rejectRead(new Error("Unreadable file"));
+    await waitFor(() => expect(button.disabled).toBe(false));
+    expect(mockImportSavedQueries).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Could not import saved queries. Check the JSON file and available browser storage.",
+    );
+  });
+
+  test("reports a storage failure without success or executing a query", async () => {
+    mockImportSavedQueries.mockImplementation(() => {
+      throw new Error("Storage full");
+    });
+    const onSelectQuery = mock(() => {});
+    const view = render(<SavedQueries onSelectQuery={onSelectQuery} />);
+    importFile(view.getByLabelText("Import saved queries JSON"), JSON.stringify(mockSavedQueries));
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSelectQuery).not.toHaveBeenCalled();
   });
 
   test("renders saved query items", () => {
@@ -141,8 +262,8 @@ describe("SavedQueries", () => {
         query: "SELECT * FROM users WHERE active = false",
         connectionType: "postgres",
         tags: ["report"],
-        createdAt: "2026-01-16T10:00:00Z",
-        updatedAt: "2026-01-16T10:00:00Z",
+        createdAt: new Date("2026-01-16T10:00:00Z"),
+        updatedAt: new Date("2026-01-16T10:00:00Z"),
       },
     ]);
 

--- a/tests/components/SavedQueries.test.tsx
+++ b/tests/components/SavedQueries.test.tsx
@@ -90,12 +90,14 @@ describe("SavedQueries", () => {
     fireEvent.change(search, { target: { value: "Imported" } });
     mockGetSavedQueries.mockReturnValue([...mockSavedQueries, imported]);
     const input = view.getByLabelText("Import saved queries JSON") as HTMLInputElement;
+    const setInputValue = mock((_value: string) => {});
+    Object.defineProperty(input, "value", { configurable: true, set: setInputValue });
     importFile(input, JSON.stringify([imported]));
     await waitFor(() => expect(mockImportSavedQueries).toHaveBeenCalledWith([imported]));
     expect(view.getByRole("button", { name: "Imported Query" }) !== null).toBe(true);
     expect(mockToastSuccess).toHaveBeenCalledWith("Saved queries import finished", { description: "Added 1." });
     expect(search.value).toBe("Imported");
-    expect(input.value).toBe("");
+    expect(setInputValue).toHaveBeenCalledWith("");
     expect(onSelectQuery).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/lib/saved-query-import.test.ts
+++ b/tests/unit/lib/saved-query-import.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { parseSavedQueries } from "@/lib/saved-query-import";
+import type { SavedQuery } from "@/lib/types";
+
+const query: SavedQuery = {
+  id: "saved-1",
+  name: "Team report",
+  query: "SELECT '你好';\n-- report",
+  description: "A saved report",
+  connectionType: "postgres",
+  tags: ["monthly", "shared"],
+  createdAt: new Date("2025-04-03T01:02:03Z"),
+  updatedAt: new Date("2026-04-03T01:02:03Z"),
+};
+
+describe("parseSavedQueries", () => {
+  test("round-trips every saved field and revives both timestamps", () => {
+    expect(parseSavedQueries(JSON.stringify([query], null, 2))).toEqual([query]);
+    expect(parseSavedQueries("[]")).toEqual([]);
+  });
+
+  test.each([
+    "{",
+    JSON.stringify({ queries: [] }),
+    JSON.stringify([null]),
+    JSON.stringify([{ ...query, id: "" }]),
+    JSON.stringify([{ ...query, name: "" }]),
+    JSON.stringify([{ ...query, query: 1 }]),
+    JSON.stringify([{ ...query, tags: [1] }]),
+    JSON.stringify([{ ...query, description: null }]),
+    JSON.stringify([{ ...query, connectionType: "unknown" }]),
+    JSON.stringify([{ ...query, createdAt: null }]),
+    JSON.stringify([query, { ...query, id: "bad", updatedAt: "not a date" }]),
+  ])("rejects the entire invalid backup %s", (text) => {
+    expect(() => parseSavedQueries(text)).toThrow();
+  });
+
+  test("accepts missing optional fields and strips unrecognized fields", () => {
+    const { description: _description, tags: _tags, ...minimal } = query;
+    expect(parseSavedQueries(JSON.stringify([{ ...minimal, connectionType: "mysql", extra: "ignored" }]))).toEqual([
+      { ...minimal, connectionType: "mysql" },
+    ]);
+  });
+});

--- a/tests/unit/lib/saved-query-import.test.ts
+++ b/tests/unit/lib/saved-query-import.test.ts
@@ -14,6 +14,28 @@ const query: SavedQuery = {
 };
 
 describe("parseSavedQueries", () => {
+  test("loading and using the browser importer never probes dynamic code evaluation", () => {
+    // A CSP violation is reported even when a library catches the EvalError.
+    // A fresh process also observes the schema's import-time capability probe.
+    const script = `
+      let evaluations = 0;
+      globalThis.Function = new Proxy(Function, {
+        construct() { evaluations++; throw new EvalError("CSP blocks eval"); },
+      });
+      const { parseSavedQueries } = await import(${JSON.stringify(import.meta.dir + "/../../../src/lib/saved-query-import.ts")});
+      const rows = parseSavedQueries(${JSON.stringify(JSON.stringify([query]))});
+      process.stdout.write(JSON.stringify({ evaluations, name: rows[0].name, date: rows[0].createdAt instanceof Date }));
+    `;
+    const processResult = Bun.spawnSync([process.execPath, "-e", script], { stdout: "pipe", stderr: "pipe" });
+    expect(new TextDecoder().decode(processResult.stderr)).toBe("");
+    expect(processResult.exitCode).toBe(0);
+    expect(JSON.parse(new TextDecoder().decode(processResult.stdout))).toEqual({
+      evaluations: 0,
+      name: query.name,
+      date: true,
+    });
+  });
+
   test("round-trips every saved field and revives both timestamps", () => {
     expect(parseSavedQueries(JSON.stringify([query], null, 2))).toEqual([query]);
     expect(parseSavedQueries("[]")).toEqual([]);

--- a/tests/unit/lib/storage.test.ts
+++ b/tests/unit/lib/storage.test.ts
@@ -174,6 +174,60 @@ describe("storage: saved queries", () => {
     expect(result.length).toBe(1);
     expect(result[0].id).toBe("b");
   });
+
+  test("importSavedQueries preserves metadata and reports existing and within-file ID collisions", () => {
+    storage.saveQuery(makeSavedQuery({ id: "existing" }));
+    const original = storage.getSavedQueries()[0];
+    const imported = makeSavedQuery({
+      id: "new",
+      createdAt: new Date("2020-01-01"),
+      updatedAt: new Date("2021-01-01"),
+      tags: ["backup"],
+    });
+    const input = [
+      makeSavedQuery({ id: "existing", query: "replacement" }),
+      imported,
+      { ...imported, query: "duplicate" },
+    ];
+    expect(storage.importSavedQueries(input)).toEqual({ imported: 1, collisions: ["existing", "new"] });
+    expect(storage.getSavedQueries()).toEqual([original, imported]);
+    expect(input[1]).toEqual(imported);
+  });
+
+  test("importSavedQueries writes and emits one complete merged collection", () => {
+    const events: CustomEvent[] = [];
+    const listener = (event: Event) => events.push(event as CustomEvent);
+    window.addEventListener("libredb-storage-change", listener);
+    const incoming = [makeSavedQuery({ id: "a" }), makeSavedQuery({ id: "b" })];
+    try {
+      expect(storage.importSavedQueries(incoming)).toEqual({ imported: 2, collisions: [] });
+      expect(events).toHaveLength(1);
+      expect(events[0].detail).toEqual({ collection: "saved_queries", data: incoming });
+      expect(storage.getSavedQueries()).toEqual(incoming);
+      expect(storage.importSavedQueries([])).toEqual({ imported: 0, collisions: [] });
+      expect(storage.importSavedQueries(incoming)).toEqual({ imported: 0, collisions: ["a", "b"] });
+      expect(events).toHaveLength(1);
+    } finally {
+      window.removeEventListener("libredb-storage-change", listener);
+    }
+  });
+
+  test("importSavedQueries leaves the old library intact when storage rejects the write", () => {
+    storage.saveQuery(makeSavedQuery({ id: "existing" }));
+    const original = localStorage.getItem("libredb_saved_queries");
+    const setItem = localStorage.setItem;
+    localStorage.setItem = () => {
+      throw new Error("Storage full");
+    };
+    try {
+      expect(() => storage.importSavedQueries([makeSavedQuery({ id: "new" })])).toThrow(
+        "Could not save imported queries.",
+      );
+      expect(localStorage.getItem("libredb_saved_queries")).toBe(original);
+    } finally {
+      localStorage.setItem = setItem;
+    }
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Description

Saved Queries now offers JSON export and import. Export writes the complete library even while a search or connection-type filter is active. Import validates the entire file before writing, merges new IDs, and reports collisions while preserving existing queries.

Closes #690.

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation and test updates

## Changes Made

- Reuse `downloadText` and `jsonText` for the JSON array backup. Preserve query text, engine, descriptions, tags and both timestamps.
- Validate imported fields against the existing shipped-engine registry with Zod, restore Date objects and strip unknown fields. Invalid files make no writes.
- Configure Zod's JIT-free mode before the browser-loaded schema is constructed, so even its caught eval-capability probe does not violate the app's CSP. The security policy is unchanged.
- Merge against the latest saved library through the storage facade, retaining the first occurrence of each ID. A successful merge makes one write and emits the existing storage-sync event; empty or all-conflicting imports make no write.
- Show added counts and skipped IDs, handle file-read and storage failures, and allow selecting the same file again. Import never selects or executes a query.
- Document saved-query backups in README.

## Testing

- TDD: six new component cases failed against the original source.
- `bun run test:components --pass-with-no-tests -t 'SavedQueries'`: 18 matching tests passed, 0 failed, including the reviewed file-input reset assertion.
- The import test observes the input's `value` setter receiving an empty string. Removing the reset assignment makes that case fail; the production source was restored byte-for-byte afterward.
- `bun run test:unit --isolate --pass-with-no-tests -t 'parseSavedQueries|storage: saved queries'`: 21 passed, 0 failed.
- The initial Linux E2E run caught an eval CSP violation introduced by schema construction. A fresh-process regression blocks and counts Function construction during both import and parsing; it sees one attempted evaluation before the fix and zero afterward while preserving the imported fields and Date values.
- Covers complete-library export despite filters, metadata/date round trips, invalid payloads, duplicate IDs both within a file and in storage, empty imports, quota/read errors, one storage event and unchanged existing queries.
- Passed locally: `format`, `lint`, `typecheck`, `knip`, `readme:check`, `chart:check`, `channels:showcase:check`, `security:check`, production `build`, `build:lib` and `attw`.
- Full local `bun run test` / coverage and E2E were not completed: this Windows host lacks Helm/chart dependencies, Docker is unavailable, and existing SQLite cleanup tests encounter Windows file-lock errors. Official Linux CI must verify the full suite and 100% line-coverage gate.

Environment: Windows, Node.js 24.18.1, Bun 1.4.2. Builds used a clean checkout with real local dependencies; the latest follow-up changes only the component test.

## Checklist

- [x] Reviewed the diff and reused the existing export/storage paths.
- [x] Added regression tests and updated README.
- [x] Required CI test job passes the 100% line-coverage gate (pending CI for the test follow-up).

## Additional Notes

AI-assisted implementation and test execution using Codex. No new dependencies or provider/schema changes. Import is additive: an ID collision is reported and skipped, never overwritten.
