### PR TITLE
fix(editor): run the complete buffer from the toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Standalone application only: the embedded `@libredb/studio` package carries no a
 
 ### Pro Data Management
 - **Universal Data Grid**: Virtualized rendering (TanStack) for millions of rows.
+- **Script Execution**: **RUN** executes the full editor buffer; **Run Sel** and `Cmd/Ctrl+Enter` execute the selection (or the current statement when no text is selected). Standalone SQL scripts use the existing sequential multi-query path and stop on the first error; no transaction is started automatically.
 - **Inline Editing**: Double-click to update values directly in the grid, on engines whose SQL has a single-table row update (the control is hidden elsewhere).
 - **Column Filtering**: Per-column text filters on query results for instant data exploration.
 - **Interactive Pivot Table**: Client-side pivoting with 5 aggregation functions (COUNT, SUM, AVG, MIN, MAX) and SQL generation.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -9,7 +9,8 @@
 *   **Custom DB Theme:** Specialized `db-dark` theme for high-contrast SQL syntax highlighting.
 *   **Power Snippets:** Integrated templates for CTEs, Joins, and complex CRUD operations.
 *   **Modern Editor Specs:** Font ligatures, smooth scrolling, bracket pair colorization, and parameter hints enabled.
-*   **Keyboard Shortcuts:** `Cmd/Ctrl + Enter` to execute, `Alt + Shift + F` to format.
+*   **Execution Scope:** **RUN** executes the full editor buffer regardless of selection or cursor position. **Run Sel** executes the selected text. `Cmd/Ctrl + Enter` executes the selection, or the statement at the cursor when nothing is selected; EXPLAIN keeps this same scope. Standalone SQL scripts use the existing sequential multi-query path and stop on the first error, without starting a transaction automatically. The embedded workspace delegates the chosen text to its host callback. Dangerous-query confirmation still checks the complete submitted text.
+*   **Keyboard Shortcuts:** `Cmd/Ctrl + Enter` to execute the selection/current statement, `Alt + Shift + F` to format.
 *   **Command Palette:** Quick access to tables, connections, saved queries, and actions with `Cmd/Ctrl+K`.
 
 > See [`docs/editor/`](editor/) for the editor internals — completion provider, alias resolution, and performance design.

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -48,6 +48,8 @@ interface QueryEditorProps {
   onChange?: (val: string) => void;
   /** Called when content changes in real-time. Use sparingly as it triggers on every keystroke. */
   onContentChange?: (val: string) => void;
+  /** Execute the selection/current statement through the embedding host. */
+  onExecute?: (query: string) => void;
   onExplain?: () => void;
   language?: "sql" | "json" | "libredb" | "redis";
   /**
@@ -109,12 +111,27 @@ const getEditorOptions = (showLineNumbers: boolean) => ({
 
 export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
   (
-    { value, onChange, onContentChange, onExplain, language = "sql", databaseType, schemaContext, capabilities },
+    {
+      value,
+      onChange,
+      onContentChange,
+      onExecute,
+      onExplain,
+      language = "sql",
+      databaseType,
+      schemaContext,
+      capabilities,
+    },
     ref,
   ) => {
     const monaco = useMonacoInstance();
     const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
     const [hasSelection, setHasSelection] = useState(false);
+    // Monaco registers keyboard actions once; read the host's current callback.
+    const executeHandlerRef = useRef(onExecute);
+    useEffect(() => {
+      executeHandlerRef.current = onExecute;
+    }, [onExecute]);
 
     // Both themes are defined in `beforeMount`; this only picks which is applied.
     // Monaco re-reads the `theme` prop on change, so the switch needs no remount.
@@ -532,6 +549,10 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
 
       const { query, range } = getEffectiveQuery();
       flashHighlight(range);
+      if (executeHandlerRef.current) {
+        executeHandlerRef.current(query);
+        return;
+      }
       const event = new CustomEvent("execute-query", { detail: { query } });
       window.dispatchEvent(event);
     };

--- a/src/hooks/use-query-execution.ts
+++ b/src/hooks/use-query-execution.ts
@@ -215,10 +215,11 @@ export function useQueryExecution({
       const targetTabId = tabId || activeTabId;
       const tabToExec = tabsRef.current.find((t) => t.id === targetTabId) || currentTabRef.current;
 
-      // Modern Execution Logic: Prioritize selection from ref, then override, then tab state
+      // RUN reads the full live buffer. Run Sel / Ctrl+Enter supply an explicit
+      // statement; EXPLAIN still targets the selection or statement at the cursor.
       let queryToExecute = overrideQuery;
       if (!queryToExecute && targetTabId === activeTabId && queryEditorRef.current) {
-        queryToExecute = queryEditorRef.current.getEffectiveQuery();
+        queryToExecute = isExplain ? queryEditorRef.current.getEffectiveQuery() : queryEditorRef.current.getValue();
       }
       if (!queryToExecute) {
         queryToExecute = tabToExec.query;

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -412,6 +412,7 @@ export function StudioWorkspace({
                             ref={queryEditorRef}
                             value={tabMgr.currentTab.query}
                             onContentChange={(val) => tabMgr.updateTabById(tabMgr.currentTab.id, { query: val })}
+                            onExecute={(query) => queryExec.executeQuery(query)}
                             language={editorLanguageForTabType(tabMgr.currentTab.type)}
                             databaseType={conn.activeConnection?.type}
                             schemaContext={conn.schemaContext}

--- a/tests/components/QueryEditor.test.tsx
+++ b/tests/components/QueryEditor.test.tsx
@@ -876,6 +876,34 @@ describe("QueryEditor", () => {
     window.removeEventListener("execute-query", handler);
   });
 
+  test("Run Sel and the mounted shortcut use the latest host execution callback", () => {
+    mockUseMonacoReturn = { Range: class {} };
+    mockSelectionReturn = { isEmpty: () => false };
+    mockSelectedText = "SELECT selected";
+    const first = mock(() => {});
+    const next = mock(() => {});
+    const globalRun = mock(() => {});
+    window.addEventListener("execute-query", globalRun);
+    try {
+      const { getByText, rerender } = render(<QueryEditor {...createDefaultProps({ onExecute: first })} />);
+      const mountedShortcut = capturedCommands[0].handler;
+      act(() => {
+        capturedSelectionCb?.();
+      });
+      fireEvent.click(getByText("Run Sel"));
+      expect(first).toHaveBeenCalledWith("SELECT selected");
+      rerender(<QueryEditor {...createDefaultProps({ onExecute: next })} />);
+      act(() => {
+        mountedShortcut();
+      });
+      expect(next).toHaveBeenCalledWith("SELECT selected");
+      expect(first).toHaveBeenCalledTimes(1);
+      expect(globalRun).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("execute-query", globalRun);
+    }
+  });
+
   // -----------------------------------------------------------------------
   // flashHighlight — decoration creation and cleanup
   // -----------------------------------------------------------------------

--- a/tests/components/StudioWorkspace.test.tsx
+++ b/tests/components/StudioWorkspace.test.tsx
@@ -830,6 +830,13 @@ describe("StudioWorkspace", () => {
     expect(capturedQueryToolbarProps.onToggleEditing).toBeUndefined();
   });
 
+  test("editor selection executes through the workspace adapter with an explicit query", () => {
+    renderWorkspace();
+    expect(typeof capturedQueryEditorProps.onExecute).toBe("function");
+    act(() => (capturedQueryEditorProps.onExecute as (query: string) => void)("SELECT selected"));
+    expect(mockExecuteQuery).toHaveBeenCalledWith("SELECT selected");
+  });
+
   test("toolbar onImport opens the import modal which delegates and closes", () => {
     const { queryByTestId } = renderWorkspace();
     expect(queryByTestId("dataimportmodal")).toBeNull();

--- a/tests/hooks/use-query-execution.test.ts
+++ b/tests/hooks/use-query-execution.test.ts
@@ -941,15 +941,14 @@ describe("useQueryExecution", () => {
     expect(result.current.pendingUnlimitedQuery).toBeNull();
   });
 
-  // ── executeQuery uses queryEditorRef.getEffectiveQuery when available ──
-
-  test("executeQuery uses queryEditorRef.getEffectiveQuery when no override", async () => {
+  test("executeQuery reads the full current editor buffer when no override", async () => {
     const fetchMock = mockGlobalFetch({
       "/api/db/query": { ok: true, json: mockQueryResult },
     });
     const mockEditorRef = {
       current: {
-        getEffectiveQuery: () => "SELECT id FROM users WHERE active = true",
+        getValue: () => "SELECT id FROM users WHERE active = true",
+        getEffectiveQuery: () => "SELECT selected",
         focus: () => {},
       },
     };
@@ -967,6 +966,87 @@ describe("useQueryExecution", () => {
     expect(queryCall).toBeDefined();
     const body = JSON.parse(queryCall![1]!.body as string);
     expect(body.sql).toBe("SELECT id FROM users WHERE active = true");
+  });
+
+  test.each(["SELECT * FROM sample.demo", "SELECT 1"])(
+    "Run All ignores the selection or cursor statement %s and submits the complete script",
+    async (effectiveQuery) => {
+      const sql =
+        "CREATE SCHEMA IF NOT EXISTS sample; CREATE TABLE IF NOT EXISTS sample.demo (id INT PRIMARY KEY); INSERT INTO sample.demo VALUES (1); SELECT * FROM sample.demo;";
+      const fetchMock = mockGlobalFetch({
+        "/api/db/multi-query": {
+          ok: true,
+          json: { ...mockQueryResult, multiStatement: true, statements: [], hasError: false },
+        },
+        "/api/db/query": { ok: true, json: mockQueryResult },
+      });
+      const getEffectiveQuery = mock(() => effectiveQuery);
+      const params = createDefaultParams({ queryEditorRef: { current: { getValue: () => sql, getEffectiveQuery } } });
+      const { result } = renderHook(() => useQueryExecution(params));
+      await act(async () => {
+        await result.current.executeQuery();
+      });
+      const calls = fetchMock.mock.calls.filter((call) => String(call[0]).includes("/api/db/multi-query"));
+      expect(calls).toHaveLength(1);
+      expect(JSON.parse(calls[0][1]!.body as string).sql).toBe(sql);
+      expect(getEffectiveQuery).not.toHaveBeenCalled();
+    },
+  );
+
+  test("Run All checks the entire script before sending any statement", async () => {
+    const sql = "DROP TABLE users; SELECT 1;";
+    const fetchMock = mockGlobalFetch({});
+    const params = createDefaultParams({
+      queryEditorRef: {
+        current: {
+          getValue: () => sql,
+          getEffectiveQuery: () => "SELECT 1",
+        },
+      },
+    });
+    const { result } = renderHook(() => useQueryExecution(params));
+    await act(async () => {
+      await result.current.executeQuery();
+    });
+    expect(result.current.safetyCheckQuery).toBe(sql);
+    expect(isDangerousQueryMock).toHaveBeenLastCalledWith(sql, "postgres");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("an explicit selected query takes precedence over the full editor buffer", async () => {
+    const fetchMock = mockGlobalFetch({ "/api/db/query": { ok: true, json: mockQueryResult } });
+    const getValue = mock(() => "DROP TABLE users; SELECT 1;");
+    const params = createDefaultParams({ queryEditorRef: { current: { getValue } } });
+    const { result } = renderHook(() => useQueryExecution(params));
+    await act(async () => {
+      await result.current.executeQuery("SELECT 1");
+    });
+    const queryCall = fetchMock.mock.calls.find((call) => String(call[0]).includes("/api/db/query"));
+    expect(JSON.parse(queryCall![1]!.body as string).sql).toBe("SELECT 1");
+    expect(result.current.safetyCheckQuery).toBeNull();
+    expect(getValue).not.toHaveBeenCalled();
+  });
+
+  test("EXPLAIN still reads the selection or current statement", async () => {
+    const fetchMock = mockGlobalFetch({ "/api/db/query": { ok: true, json: mockQueryResult } });
+    const getValue = mock(() => "CREATE TABLE demo (id INT); SELECT id FROM demo;");
+    const params = createDefaultParams({
+      queryEditorRef: {
+        current: {
+          getValue,
+          getEffectiveQuery: () => "SELECT id FROM demo",
+        },
+      },
+    });
+    const { result } = renderHook(() => useQueryExecution(params));
+    await act(async () => {
+      await result.current.executeQuery(undefined, undefined, true);
+    });
+    const queryCall = fetchMock.mock.calls.find((call) => String(call[0]).includes("/api/db/query"));
+    const body = JSON.parse(queryCall![1]!.body as string);
+    expect(body.sql).toBe("SELECT id FROM demo");
+    expect(body.explain).toEqual({ mode: "analyze" });
+    expect(getValue).not.toHaveBeenCalled();
   });
 
   // ── executeQuery falls back to tab query when no override and no ref ────


### PR DESCRIPTION
## Description

**RUN** now submits the entire live editor buffer, regardless of the selected text or cursor position. **Run Sel** and `Cmd/Ctrl+Enter` continue to submit the selection/current statement, and EXPLAIN retains that scope.

## Type of Change

- [x] Bug fix
- [x] Documentation and test updates

## Changes Made

- Read `QueryEditorRef.getValue()` for ordinary toolbar execution and keep `getEffectiveQuery()` for EXPLAIN. Explicit queries still take precedence.
- Reuse the existing SQL multi-query route, which executes sequentially and stops on the first error. The full submitted script still passes through the dangerous-query confirmation before any request. No automatic transaction is introduced; existing transaction/sandbox routes are unchanged.
- Wire the embedded editor's selection/shortcut action to its workspace adapter through an optional callback. Monaco's mounted shortcut reads the latest host callback, so changing tabs/connections does not retain the original handler. The standalone custom event remains the fallback.
- Document the execution scopes and transaction behavior.

## Testing

- TDD: four hook regressions and two component regressions failed before the fix.
- `bun run test:hooks --isolate --pass-with-no-tests -t 'useQueryExecution|useQueryAdapter'`: 148 passed, 0 failed.
- `bun run test:components --pass-with-no-tests -t 'QueryEditor|StudioWorkspace'`: 157 matching tests passed, 0 failed.
- `bun run test:api --isolate --pass-with-no-tests -t 'multi-query'`: 22 passed, 0 failed.
- Regressions cover the reported DDL/INSERT/SELECT script, selection/cursor independence, full-script safety checks, explicit selection overrides, EXPLAIN, embedded selection execution and a callback replacement after Monaco mounts.
- Passed locally: `format`, `lint`, `typecheck`, `knip`, `readme:check`, `chart:check`, `channels:showcase:check`, `security:check`, production `build`, `build:lib` and `attw`.
- Full local `bun run test` / coverage and E2E were not completed: this Windows host lacks Helm/chart dependencies, Docker is unavailable, and existing SQLite cleanup tests encounter Windows file-lock errors. Official Linux CI must verify the full suite and 100% line-coverage gate.

Environment: Windows, Node.js 24.18.1, Bun 1.4.2. Both builds ran from a clean checkout of the submitted commit with real local dependencies.

## Checklist

- [x] Reviewed the diff, added regression tests and updated documentation.
- [x] Required CI test job passes the 100% line-coverage gate; latest-head CI completed with 20 successful checks and 2 normal skips.

## Additional Notes

AI-assisted implementation and test execution using Codex. No dependencies or provider behavior changed. RUN intentionally now includes every statement in the buffer, including writes; the existing safety gate remains in place.
