### PR TITLE
feat(elasticsearch): support API Key authentication

### DIFF
--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -1220,7 +1220,7 @@ Auth required. Merges a client's localStorage payload into server storage on fir
 
 #### GET /api/connections/managed
 
-Auth required. Returns seed/managed connections for the current user's role, with secrets (`password`, `connectionString`) stripped. `cacheHint` is the client cache TTL in ms (`SEED_CACHE_TTL_MS`, default 60000). See [`docs/SEED_CONNECTIONS.md`](SEED_CONNECTIONS.md).
+Auth required. Returns seed/managed connections for the current user's role, with secrets (`password`, `apiKey`, `connectionString`) stripped from managed connections. Editable seeds include their credentials so they can be copied and edited. `cacheHint` is the client cache TTL in ms (`SEED_CACHE_TTL_MS`, default 60000). See [`docs/SEED_CONNECTIONS.md`](SEED_CONNECTIONS.md).
 
 ```json
 { "connections": [], "cacheHint": 60000 }
@@ -1268,7 +1268,7 @@ Body `{ "connections": [...] }`; returns per-connection health `{ "results": [{ 
 
 The object is one shape on the wire. Fields the server reads from a request body — and that
 change how a connection is opened — are the coordinates and credentials (`id`, `name`, `type`,
-`host`, `port`, `user`, `password`, `database`, `schema`, `connectionString`), plus `ssl`,
+`host`, `port`, `user`, `password`, `apiKey`, `database`, `schema`, `connectionString`), plus `ssl`,
 `sshTunnel`, `serviceName` (Oracle), `instanceName` (MSSQL), `localDataCenter` (Cassandra),
 `authSource` (MongoDB), `agentUser`, and `agentPassword`. `color`, `environment`, `group`,
 `managed`, `seedId`, and `createdAt` are client-side bookkeeping that travel in the same object.
@@ -1282,6 +1282,7 @@ interface DatabaseConnection {
   port?: number;           // Port number
   user?: string;           // Username
   password?: string;       // Password
+  apiKey?: string;         // Elasticsearch: encoded API key or id:secret; secret-classified
   database?: string;       // Database name (Couchbase: the bucket; Druid: unused, it has one catalog; Trino: the CATALOG; Cassandra: the KEYSPACE)
   schema?: string;         // Trino: session schema for unqualified table names
   connectionString?: string; // Full connection string (alternative; Druid has no URI form, host + port only; Cassandra has none either, no URI carries localDataCenter)

--- a/docs/providers/elasticsearch.md
+++ b/docs/providers/elasticsearch.md
@@ -439,16 +439,33 @@ shared generator emits a `?` this provider would then decline to fill.
 
 ### 4.1 Configuration fields
 
-The form offers exactly four fields
-([`db-ui-config.ts:138`](../../src/lib/db-ui-config.ts)): `host`, `port`, `user`, `password`.
+The form offers five fields
+([`db-ui-config.ts`](../../src/lib/db-ui-config.ts)): `host`, `port`, `user`, `password`, `apiKey`.
 
 | Field | Required | Notes |
 |---|---|---|
 | `host` | **Yes** | `validate()` ([index.ts:529](../../src/lib/db/providers/sql/search/index.ts)) throws `DatabaseConfigError` — "Elasticsearch requires a host". There is no connection string to substitute for it |
 | `port` | No | Defaults to `9200` ([index.ts:151](../../src/lib/db/providers/sql/search/index.ts), and the transport applies the same floor at [http-transport.ts:99](../../src/lib/db/providers/sql/search/http-transport.ts)). One number for both schemes — see [§4.3](#43-tls) |
-| `user` / `password` | No | Sent as HTTP Basic **only when `user` is set**, for the security plugin. Measured on a node with security disabled: a bogus `Basic` header is *ignored* (HTTP 200), so credentials are genuinely optional |
+| `user` / `password` | No | Sent as HTTP Basic **when `user` is set and `apiKey` is empty**, for the security plugin. Measured on a node with security disabled: a bogus `Basic` header is *ignored* (HTTP 200), so credentials are genuinely optional |
+| `apiKey` | No | Accepts the encoded value returned by Elasticsearch or Kibana's `id:secret` form. Takes precedence over Basic credentials on SQL, cursor, schema and monitoring requests |
 | `ssl` | No | Any mode but `disable` switches the transport to `https` ([§4.3](#43-tls)) |
 | `database` | — | **Not offered, and ignored if set** — see below |
+
+API Key authentication follows the [Elasticsearch API contract](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key):
+the `Authorization` header is `ApiKey <encoded>`, where `encoded` is Base64 of the UTF-8
+`id:api_key` pair. Paste the encoded value unchanged, or enter the pair and let the transport
+encode it. Clear the field to return to Basic authentication. Malformed header values are refused
+before a request; authentication errors do not include the key. Use TLS for remote credentials.
+
+The field follows the existing secret classification for encrypted server storage. Seed configs
+accept `apiKey: "${ELASTICSEARCH_API_KEY}"`; managed connection descriptors omit the key, while
+editable seeds retain it like their passwords. Changing a seed copy's key prevents resolving it
+back to the original seed. A configured least-privilege agent username/password clears the primary
+API Key when constructing that separate provider, so it cannot override the agent identity.
+
+These authentication assertions are protocol-contract tests against the real transport with fake
+HTTP responses. They do not claim a live security-enabled cluster probe; the captured cluster
+fixtures below still have security disabled.
 
 **There is no `database` field, and that is not an omission.** An index has no namespace above it, and
 this product's own SQL says so: `SHOW TABLES` reports a `catalog` of `docker-cluster` — the cluster

--- a/docs/providers/opensearch.md
+++ b/docs/providers/opensearch.md
@@ -429,6 +429,13 @@ The form offers exactly four fields
 | `ssl` | No | Any mode but `disable` switches the transport to `https` ([§4.3](#43-tls)) |
 | `database` | — | **Not offered, and ignored if set** — see below |
 
+Elasticsearch's `apiKey` field is not offered for OpenSearch. If supplied programmatically, the
+provider refuses it before sending a request instead of falling back to a different identity.
+OpenSearch has its [own API key contract](https://docs.opensearch.org/latest/api-reference/security/api-keys/create/),
+which this provider does not implement. Basic authentication and connections without credentials
+retain their existing behavior; integration tests pin this boundary alongside Elasticsearch's
+encoded-key support in the shared transport.
+
 **There is no `database` field, and that is not an omission.** An index has no namespace above it, and
 this product's own SQL says so: `SHOW TABLES LIKE %` answers `TABLE_CAT` `docker-cluster` with
 `TABLE_SCHEM` **null** (measured). So a database selector would be a control with no effect, and worse,

--- a/src/app/api/connections/managed/route.ts
+++ b/src/app/api/connections/managed/route.ts
@@ -33,7 +33,7 @@ export async function GET() {
 
     const sanitized = connections.map((conn) => {
       if (conn.managed) {
-        const { password, connectionString, ...rest } = conn;
+        const { password, apiKey, connectionString, ...rest } = conn;
         return rest;
       }
       return conn;

--- a/src/components/ConnectionModal.tsx
+++ b/src/components/ConnectionModal.tsx
@@ -87,6 +87,8 @@ export function ConnectionModal({
     setUser,
     password,
     setPassword,
+    apiKey,
+    setApiKey,
     database,
     setDatabase,
     schema,
@@ -520,6 +522,26 @@ export function ConnectionModal({
                     </div>
                   </div>
 
+                  {takesConnectionField(type, "apiKey") && (
+                    <div className="space-y-2">
+                      <Label htmlFor="apiKey" className="text-xs font-medium text-fg-muted">
+                        API Key
+                      </Label>
+                      <Input
+                        id="apiKey"
+                        type="password"
+                        value={apiKey}
+                        onChange={(e) => setApiKey(e.target.value)}
+                        autoComplete="new-password"
+                        aria-describedby="apiKeyHelp"
+                        className="h-10 bg-panel border-hairline focus:border-brand-tint/50 transition-all text-xs"
+                      />
+                      <p id="apiKeyHelp" className="text-xs text-fg-muted">
+                        Paste the encoded value or id:secret from Kibana. Takes precedence over username and password;
+                        leave empty to use Basic authentication.
+                      </p>
+                    </div>
+                  )}
                   {/*
                     Only when the engine takes it. Druid and the two search engines address
                     a datasource or an index by name in the statement, and libSQL addresses

--- a/src/hooks/use-connection-form.ts
+++ b/src/hooks/use-connection-form.ts
@@ -46,6 +46,7 @@ const FIELD_OWNERSHIP: Record<keyof DatabaseConnection, FieldOwnership> = {
   port: "edited",
   user: "edited",
   password: "edited",
+  apiKey: "edited",
   database: "edited",
   schema: "edited",
   connectionString: "edited",
@@ -134,6 +135,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
   const [port, setPort] = useState("5432");
   const [user, setUser] = useState("");
   const [password, setPassword] = useState("");
+  const [apiKey, setApiKey] = useState("");
   const [database, setDatabase] = useState("");
   const [schema, setSchema] = useState("");
   const [isTesting, setIsTesting] = useState(false);
@@ -200,6 +202,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       setPort(editConnection.port?.toString() || getDBConfig(editConnection.type).defaultPort);
       setUser(editConnection.user || "");
       setPassword(editConnection.password || "");
+      setApiKey(editConnection.apiKey || "");
       setDatabase(editConnection.database || "");
       setSchema(editConnection.schema || "");
       setConnectionString(editConnection.connectionString || "");
@@ -276,6 +279,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
         setName("");
         setUser("");
         setPassword("");
+        setApiKey("");
         setDatabase("");
         setSchema("");
         setConnectionString("");
@@ -345,6 +349,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
       ...(addressedFields.has("port") ? { port: parseInt(port) } : {}),
       ...(addressedFields.has("user") ? { user } : {}),
       ...(addressedFields.has("password") ? { password } : {}),
+      ...(addressedFields.has("apiKey") && apiKey ? { apiKey } : {}),
       ...(addressedFields.has("database") ? { database } : {}),
       ...(addressedFields.has("schema") && schema ? { schema } : {}),
       createdAt: editConnection?.createdAt || new Date(),
@@ -386,6 +391,7 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     port,
     user,
     password,
+    apiKey,
     database,
     schema,
     environment,
@@ -629,6 +635,8 @@ export function useConnectionForm({ isOpen, onConnect, editConnection, onTestCon
     setUser,
     password,
     setPassword,
+    apiKey,
+    setApiKey,
     database,
     schema,
     setDatabase,

--- a/src/hooks/use-connection-payload.ts
+++ b/src/hooks/use-connection-payload.ts
@@ -93,6 +93,7 @@ const CONNECTION_RELEVANCE: Record<keyof DatabaseConnection, FieldRelevance> = {
   port: "resolution",
   user: "resolution",
   password: "resolution",
+  apiKey: "resolution",
   database: "resolution",
   schema: "resolution",
   connectionString: "resolution",

--- a/src/lib/db-ui-config.ts
+++ b/src/lib/db-ui-config.ts
@@ -34,6 +34,7 @@ export interface DatabaseUIConfig {
     | "port"
     | "user"
     | "password"
+    | "apiKey"
     | "database"
     | "schema"
     | "connectionString"
@@ -220,7 +221,7 @@ export const DB_UI_CONFIG: Record<DatabaseType, DatabaseUIConfig> = {
     // database selector would be a control with no effect. Credentials stay offered
     // because a cluster running the security plugin needs them; a stock node ignores
     // the Authorization header entirely (measured).
-    connectionFields: ["host", "port", "user", "password"],
+    connectionFields: ["host", "port", "user", "password", "apiKey"],
   },
   opensearch: {
     icon: OpenSearchIcon,

--- a/src/lib/db/factory.ts
+++ b/src/lib/db/factory.ts
@@ -652,7 +652,7 @@ export async function acquireExecutionProfileProvider(
   }
 
   let effectiveConnection: DatabaseConnection = credential
-    ? { ...connection, user: credential.user, password: credential.password }
+    ? { ...connection, user: credential.user, password: credential.password, apiKey: undefined }
     : connection;
 
   // The SSH tunnel is keyed by connection id and shared with the writable

--- a/src/lib/db/providers/sql/search/http-transport.ts
+++ b/src/lib/db/providers/sql/search/http-transport.ts
@@ -282,6 +282,8 @@ interface SearchDialectSpec {
   readonly sqlQuery: string;
   /** Whether SQL should tolerate multi-valued fields. Elasticsearch supports this request option. */
   readonly fieldMultiValueLeniency: boolean;
+  /** Whether this provider implements Elasticsearch's encoded ApiKey credentials. */
+  readonly supportsApiKey: boolean;
   /** The success envelope's declared-columns key. */
   readonly columnsKey: string;
   /**
@@ -324,6 +326,7 @@ const DIALECTS: Readonly<Record<SearchDialectId, SearchDialectSpec>> = Object.fr
     sqlPath: "/_sql",
     sqlQuery: "format=json",
     fieldMultiValueLeniency: true,
+    supportsApiKey: true,
     columnsKey: "columns",
     // Elasticsearch folds the alias into `name`, so there is no separate member.
     aliasKey: null,
@@ -362,6 +365,7 @@ const DIALECTS: Readonly<Record<SearchDialectId, SearchDialectSpec>> = Object.fr
     sqlPath: "/_plugins/_sql",
     sqlQuery: "",
     fieldMultiValueLeniency: false,
+    supportsApiKey: false,
     columnsKey: "schema",
     aliasKey: "alias",
     rowsKey: "datarows",
@@ -838,9 +842,25 @@ export class SearchHttpTransport implements SearchTransport {
     // `Basic` header is IGNORED (HTTP 200), so credentials are optional and sending
     // none is the normal local case. When they are configured they are for the
     // product's security plugin, whose refusal this transport reads off the status.
-    this.authorization = config.user
-      ? `Basic ${Buffer.from(`${config.user}:${config.password ?? ""}`).toString("base64")}`
-      : undefined;
+    if (config.apiKey) {
+      if (!this.spec.supportsApiKey) {
+        throw new SearchTransportError(
+          "auth",
+          `${this.spec.label} API Key authentication is not supported by this provider.`,
+        );
+      }
+      const key = typeof config.apiKey === "string" ? config.apiKey.trim() : "";
+      const separator = key.indexOf(":");
+      const encoded = separator > 0 && separator < key.length - 1 ? Buffer.from(key).toString("base64") : key;
+      if (!/^[A-Za-z0-9+/]+={0,2}$/.test(encoded)) {
+        throw new SearchTransportError("auth", "API Key must be encoded or in id:secret format.");
+      }
+      this.authorization = `ApiKey ${encoded}`;
+    } else {
+      this.authorization = config.user
+        ? `Basic ${Buffer.from(`${config.user}:${config.password ?? ""}`).toString("base64")}`
+        : undefined;
+    }
   }
 
   /**

--- a/src/lib/db/providers/sql/search/index.ts
+++ b/src/lib/db/providers/sql/search/index.ts
@@ -603,18 +603,16 @@ abstract class SearchProvider extends SQLBaseProvider {
   }
 
   public async connect(): Promise<void> {
-    const transport = new SearchHttpTransport(this.product.dialect, this.config);
-
     try {
+      const transport = new SearchHttpTransport(this.product.dialect, this.config);
       await transport.query(CONNECT_PROBE_SQL, this.deadline());
+      this.transport = transport;
+      this.setConnected(true);
     } catch (error) {
       const failure = this.describeConnectFailure(error);
       this.setError(failure);
       throw failure;
     }
-
-    this.transport = transport;
-    this.setConnected(true);
   }
 
   /**

--- a/src/lib/seed/connection-filter.ts
+++ b/src/lib/seed/connection-filter.ts
@@ -28,6 +28,7 @@ export function filterByRoles(connections: SeedConnection[], userRoles: string[]
       database: conn.database,
       user: conn.user,
       password: conn.password,
+      apiKey: conn.apiKey,
       connectionString: conn.connectionString,
       environment: conn.environment,
       group: conn.group,

--- a/src/lib/seed/credential-resolver.ts
+++ b/src/lib/seed/credential-resolver.ts
@@ -2,7 +2,7 @@ import { logger } from "@/lib/logger";
 import type { SeedConnection } from "./types";
 
 const ENV_VAR_PATTERN = /^\$\{([A-Z_][A-Z0-9_]*)\}$/;
-const RESOLVABLE_FIELDS = ["password", "connectionString", "user", "host", "database"] as const;
+const RESOLVABLE_FIELDS = ["password", "apiKey", "connectionString", "user", "host", "database"] as const;
 
 const warnedPlaintext = new Set<string>();
 

--- a/src/lib/seed/types.ts
+++ b/src/lib/seed/types.ts
@@ -63,6 +63,7 @@ export const SeedConnectionSchema = z.object({
   database: z.string().optional(),
   user: z.string().optional(),
   password: z.string().optional(),
+  apiKey: z.string().optional(),
   connectionString: z.string().optional(),
   environment: ConnectionEnvironmentSchema.optional(),
   group: z.string().max(64).optional(),

--- a/src/lib/storage/connection-secrets.ts
+++ b/src/lib/storage/connection-secrets.ts
@@ -24,6 +24,7 @@ export const CONNECTION_FIELDS: Record<keyof DatabaseConnection, FieldClass> = {
   port: "public",
   user: "public",
   password: "secret",
+  apiKey: "secret",
   database: "public",
   // Carries scheme://user:pass@host. The same shape src/lib/audit.ts redacts out of log lines.
   connectionString: "secret",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -149,6 +149,8 @@ export interface DatabaseConnection {
   port?: number;
   user?: string;
   password?: string;
+  /** Elasticsearch API Key: encoded credentials or id:secret. Takes precedence over Basic auth. */
+  apiKey?: string;
   database?: string;
   /** Trino: the session schema used to resolve unqualified table names. */
   schema?: string;

--- a/tests/api/seed/managed-route.test.ts
+++ b/tests/api/seed/managed-route.test.ts
@@ -53,6 +53,29 @@ describe("GET /api/connections/managed", () => {
     }
   });
 
+  it("resolves seeded API Keys and exposes them only for editable connections", async () => {
+    const originalPath = process.env.SEED_CONFIG_PATH;
+    const originalKey = process.env.TEST_ES_API_KEY;
+    process.env.SEED_CONFIG_PATH = path.join(FIXTURES, "elasticsearch-api-key.json");
+    process.env.TEST_ES_API_KEY = "fixture-id:fixture-secret";
+    resetCache();
+    try {
+      const response = await GET();
+      expect(response.status).toBe(200);
+      const { connections } = await response.json();
+      const managed = connections.find((connection: { seedId: string }) => connection.seedId === "es-managed");
+      const editable = connections.find((connection: { seedId: string }) => connection.seedId === "es-editable");
+      expect(managed).toBeDefined();
+      expect(managed.apiKey).toBeUndefined();
+      expect(editable.apiKey).toBe("fixture-id:fixture-secret");
+    } finally {
+      process.env.SEED_CONFIG_PATH = originalPath;
+      if (originalKey === undefined) delete process.env.TEST_ES_API_KEY;
+      else process.env.TEST_ES_API_KEY = originalKey;
+      resetCache();
+    }
+  });
+
   it("returns 401 when no session", async () => {
     (getSession as ReturnType<typeof mock>).mockImplementation(() => null);
     const res = await GET();

--- a/tests/components/ConnectionModal.test.tsx
+++ b/tests/components/ConnectionModal.test.tsx
@@ -98,6 +98,7 @@ const mockSetHost = mock(() => {});
 const mockSetPort = mock(() => {});
 const mockSetUser = mock(() => {});
 const mockSetPassword = mock(() => {});
+const mockSetApiKey = mock((_value: string) => {});
 const mockSetDatabase = mock(() => {});
 const mockSetConnectionString = mock(() => {});
 const mockSetMongoConnectionMode = mock(() => {});
@@ -145,6 +146,8 @@ function getDefaultForm() {
     setUser: mockSetUser,
     password: "",
     setPassword: mockSetPassword,
+    apiKey: "",
+    setApiKey: mockSetApiKey,
     database: "",
     setDatabase: mockSetDatabase,
     connectionString: "",
@@ -242,7 +245,7 @@ const MOCK_CONNECTION_FIELDS: Record<string, string[]> = {
   duckdb: ["database"],
   libsql: ["host", "port", "password", "connectionString"],
   druid: ["host", "port", "user", "password"],
-  elasticsearch: ["host", "port", "user", "password"],
+  elasticsearch: ["host", "port", "user", "password", "apiKey"],
   opensearch: ["host", "port", "user", "password"],
 };
 const mockFields = (type: string): string[] =>
@@ -310,6 +313,7 @@ describe("ConnectionModal", () => {
 
   beforeEach(() => {
     mockFormOverrides = {};
+    mockSetApiKey.mockClear();
     mockSetType.mockClear();
     mockSetName.mockClear();
     mockSetHost.mockClear();
@@ -319,6 +323,27 @@ describe("ConnectionModal", () => {
     mockHandleTestConnection.mockClear();
     mockHandleConnect.mockClear();
   });
+
+  test("offers a secret API Key input with both accepted forms for Elasticsearch", () => {
+    mockFormOverrides = { type: "elasticsearch", apiKey: "fixture-id:fixture-secret" };
+    const view = render(<ConnectionModal {...createDefaultProps()} />);
+    const input = view.getByLabelText("API Key") as HTMLInputElement;
+    expect(input.type).toBe("password");
+    expect(input.autocomplete).toBe("new-password");
+    expect(input.value).toBe("fixture-id:fixture-secret");
+    expect(view.getByText(/encoded.*id:secret/).textContent).toContain("Takes precedence over username and password");
+    fireEvent.change(input, { target: { value: "updated:secret" } });
+    expect(mockSetApiKey).toHaveBeenCalledWith("updated:secret");
+  });
+
+  test.each(["postgres", "opensearch"])(
+    "does not offer Elasticsearch API Key authentication to other engines",
+    (type) => {
+      mockFormOverrides = { type };
+      const view = render(<ConnectionModal {...createDefaultProps()} />);
+      expect(view.queryByLabelText("API Key") === null).toBe(true);
+    },
+  );
 
   // ── 1. Does not render when isOpen=false ────────────────────────────────────
 

--- a/tests/fixtures/seed-connections/elasticsearch-api-key.json
+++ b/tests/fixtures/seed-connections/elasticsearch-api-key.json
@@ -1,0 +1,23 @@
+{
+  "version": "1",
+  "connections": [
+    {
+      "id": "es-managed",
+      "name": "Managed Elasticsearch",
+      "type": "elasticsearch",
+      "host": "localhost",
+      "apiKey": "${TEST_ES_API_KEY}",
+      "roles": ["admin"],
+      "managed": true
+    },
+    {
+      "id": "es-editable",
+      "name": "Editable Elasticsearch",
+      "type": "elasticsearch",
+      "host": "localhost",
+      "apiKey": "${TEST_ES_API_KEY}",
+      "roles": ["admin"],
+      "managed": false
+    }
+  ]
+}

--- a/tests/hooks/use-connection-form.test.ts
+++ b/tests/hooks/use-connection-form.test.ts
@@ -34,7 +34,7 @@ const MOCK_CONNECTION_FIELDS: Record<string, string[]> = {
   // convenience.
   redis: ["host", "port", "user", "password", "database"],
   druid: ["host", "port", "user", "password"],
-  elasticsearch: ["host", "port", "user", "password"],
+  elasticsearch: ["host", "port", "user", "password", "apiKey"],
   opensearch: ["host", "port", "user", "password"],
 };
 const mockFields = (type: string): string[] =>
@@ -81,6 +81,60 @@ describe("useConnectionForm", () => {
 
   afterEach(() => {
     restoreGlobalFetch();
+  });
+
+  test("edits, probes, saves and clears an Elasticsearch API Key", async () => {
+    const onConnect = mock((_connection: DatabaseConnection) => {});
+    const onTestConnection = mock(async (_connection: DatabaseConnection) => ({ success: true }));
+    const editConnection: DatabaseConnection = {
+      id: "es-edit",
+      name: "Elasticsearch",
+      type: "elasticsearch",
+      host: "localhost",
+      port: 9200,
+      apiKey: "fixture-id:old-secret",
+      createdAt: new Date(0),
+    };
+    const { result } = renderHook(() =>
+      useConnectionForm({ ...defaultProps, editConnection, onConnect, onTestConnection }),
+    );
+    expect(result.current.apiKey).toBe(editConnection.apiKey!);
+    act(() => result.current.setApiKey("fixture-id:new-secret"));
+    await act(async () => {
+      await result.current.handleTestConnection();
+      await result.current.handleConnect();
+    });
+    expect(onTestConnection).toHaveBeenCalledTimes(2);
+    expect(onTestConnection.mock.calls.every(([connection]) => connection.apiKey === "fixture-id:new-secret")).toBe(
+      true,
+    );
+    expect(onConnect.mock.calls[0][0].apiKey).toBe("fixture-id:new-secret");
+    act(() => result.current.setApiKey(""));
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+    expect(onConnect.mock.calls[1][0].apiKey).toBeUndefined();
+  });
+
+  test("does not carry an API Key into another engine or a reopened blank form", async () => {
+    const onConnect = mock((_connection: DatabaseConnection) => {});
+    const onTestConnection = mock(async (_connection: DatabaseConnection) => ({ success: true }));
+    const { result, rerender } = renderHook(
+      ({ isOpen }) => useConnectionForm({ ...defaultProps, isOpen, onConnect, onTestConnection }),
+      { initialProps: { isOpen: true } },
+    );
+    act(() => {
+      result.current.setType("elasticsearch");
+      result.current.setApiKey("fixture-id:fixture-secret");
+    });
+    act(() => result.current.setType("opensearch"));
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+    expect(onConnect.mock.calls[0][0].apiKey).toBeUndefined();
+    rerender({ isOpen: false });
+    rerender({ isOpen: true });
+    expect(result.current.apiKey).toBe("");
   });
 
   // ── Default State ──────────────────────────────────────────────────────────

--- a/tests/integration/db/elasticsearch-provider.test.ts
+++ b/tests/integration/db/elasticsearch-provider.test.ts
@@ -899,6 +899,46 @@ describe("ElasticsearchProvider validation", () => {
     await provider.disconnect();
   });
 
+  // Protocol-contract cases, not captures from the security-disabled fixture cluster.
+  test.each(["fixture-id:fixture-secret", Buffer.from("fixture-id:fixture-secret").toString("base64")])(
+    "sends an Elasticsearch API Key on every endpoint instead of Basic credentials",
+    async (apiKey) => {
+      const provider = await connectProvider({ apiKey, user: "reader", password: "unused-basic-password" });
+      await provider.query("SELECT id FROM probe_orders");
+      await provider.getSchema();
+      await provider.getOverview();
+      expect(sent.length).toBeGreaterThan(3);
+      expect(
+        sent.every(
+          (request) => request.auth === `ApiKey ${Buffer.from("fixture-id:fixture-secret").toString("base64")}`,
+        ),
+      ).toBe(true);
+      await provider.disconnect();
+    },
+  );
+
+  test.each([" ", "ApiKey invalid", ":secret", "id:", "bad\r\nheader"])(
+    "refuses an invalid Elasticsearch API Key without sending or exposing it",
+    async (apiKey) => {
+      const provider = new ElasticsearchProvider(makeConnection({ apiKey, user: "reader", password: "unused" }));
+      const error = await provider.connect().catch((failure: unknown) => failure);
+      expect(error).toBeInstanceOf(AuthenticationError);
+      expect((error as Error).message).toContain("API Key must be encoded or in id:secret format");
+      expect(sent).toHaveLength(0);
+      expect(provider.isConnected()).toBe(false);
+    },
+  );
+
+  test.each([401, 403])("does not include a rejected API Key in an authentication error", async (status) => {
+    const apiKey = "fixture-id:fixture-secret";
+    replyFor = () => fail(status, apiKey);
+    const provider = new ElasticsearchProvider(makeConnection({ apiKey }));
+    const error = await provider.connect().catch((failure: unknown) => failure);
+    expect(error).toBeInstanceOf(AuthenticationError);
+    expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(Buffer.from(apiKey).toString("base64"));
+  });
+
   test("sends a user with no password rather than refusing the connection", async () => {
     const provider = await connectProvider({ user: "reader" });
 

--- a/tests/integration/db/opensearch-provider.test.ts
+++ b/tests/integration/db/opensearch-provider.test.ts
@@ -54,7 +54,7 @@ import type { DatabaseConnection, DatabaseType } from "@/lib/types";
 import { ElasticsearchProvider, OpenSearchProvider } from "@/lib/db/providers/sql/search";
 import { SearchHttpTransport } from "@/lib/db/providers/sql/search/http-transport";
 import { type SearchErrorCategory, SearchTransportError } from "@/lib/db/providers/sql/search/transport";
-import { ConnectionError, QueryError } from "@/lib/db/errors";
+import { AuthenticationError, ConnectionError, QueryError } from "@/lib/db/errors";
 
 // ============================================================================
 // Connection
@@ -420,6 +420,7 @@ const originalFetch = globalThis.fetch;
 
 let sentPaths: string[] = [];
 let sentBodies: (Record<string, unknown> | null)[] = [];
+let sentAuth: (string | null)[] = [];
 let replyFor: (path: string, body: Record<string, unknown> | null) => Reply;
 
 function ok(body: string): Reply {
@@ -469,6 +470,7 @@ function installFetch(): void {
     const body = init?.body === undefined ? null : (JSON.parse(String(init.body)) as Record<string, unknown>);
     sentPaths.push(`${url.pathname}${url.search}`);
     sentBodies.push(body);
+    sentAuth.push(new Headers(init?.headers).get("authorization"));
 
     const reply = replyFor(`${url.pathname}${url.search}`, body);
     return new Response(reply.body, {
@@ -511,6 +513,7 @@ async function faultOf(call: () => Promise<unknown>): Promise<SearchTransportErr
 beforeEach(() => {
   sentPaths = [];
   sentBodies = [];
+  sentAuth = [];
   replyFor = defaultReply;
   installFetch();
 });
@@ -524,6 +527,26 @@ afterEach(() => {
 // ============================================================================
 
 describe("OpenSearch envelope", () => {
+  test("does not apply Elasticsearch API Key authentication to OpenSearch", async () => {
+    const provider = new OpenSearchProvider(
+      makeConnection({ apiKey: "fixture-id:fixture-secret", user: "reader", password: "unused" }),
+    );
+    await expect(provider.connect()).rejects.toBeInstanceOf(AuthenticationError);
+    expect(sentPaths).toHaveLength(0);
+  });
+
+  test.each([
+    { credentials: {}, expected: null },
+    {
+      credentials: { user: "reader", password: "fixture-secret" },
+      expected: `Basic ${Buffer.from("reader:fixture-secret").toString("base64")}`,
+    },
+  ])("retains OpenSearch's existing authentication without an API Key", async ({ credentials, expected }) => {
+    const provider = new OpenSearchProvider(makeConnection(credentials));
+    await provider.connect();
+    expect(sentAuth).toEqual([expected]);
+    await provider.disconnect();
+  });
   test("reads rows out of schema/datarows, which is not where Elasticsearch puts them", async () => {
     const result = await transport().query("SELECT id, customer, total FROM probe_orders");
 

--- a/tests/unit/agent-connection-eligibility.test.ts
+++ b/tests/unit/agent-connection-eligibility.test.ts
@@ -119,6 +119,12 @@ describe("which connection a run may be started on", () => {
     expect(startableId(browserCopy(server, { password: "different" }), loaded(server))).toBeNull();
   });
 
+  test("changing an Elasticsearch API Key prevents resolving the copy to its original seed", () => {
+    const server = descriptor({ type: "elasticsearch", apiKey: "fixture-id:fixture-secret" });
+    expect(startableId(browserCopy(server), loaded(server))).toBe("seed:sales");
+    expect(startableId(browserCopy(server, { apiKey: "different:credential" }), loaded(server))).toBeNull();
+  });
+
   // The field a hand-written comparison forgets: it changes which role the agent
   // executes as, which is the whole point of the least-privilege profile (#328).
   test("a copy carrying its own agent credentials is not startable", () => {

--- a/tests/unit/db/factory.test.ts
+++ b/tests/unit/db/factory.test.ts
@@ -1019,14 +1019,21 @@ describe("acquireExecutionProfileProvider", () => {
   });
 
   test("uses the least-privilege agent credential for the profile provider only", async () => {
-    const conn = pgConn({ id: "pg-cred", agentUser: "agent_ro", agentPassword: "agent-secret" });
+    const conn = pgConn({
+      id: "pg-cred",
+      apiKey: "fixture-id:privileged-secret",
+      agentUser: "agent_ro",
+      agentPassword: "agent-secret",
+    });
 
     const agent = await acquireExecutionProfileProvider(conn, "agent-read-only");
     const shared = await getOrCreateProvider(conn);
 
     expect(agent.config.user).toBe("agent_ro");
     expect(agent.config.password).toBe("agent-secret");
+    expect(agent.config.apiKey).toBeUndefined();
     expect(shared.config.user).toBe("test");
+    expect(shared.config.apiKey).toBe("fixture-id:privileged-secret");
   });
 
   test("denies when the agent credential is configured but unresolvable (fail closed)", async () => {

--- a/tests/unit/lib/agent/state-guard.test.ts
+++ b/tests/unit/lib/agent/state-guard.test.ts
@@ -342,7 +342,7 @@ describe("assertPersistableState — CREDENTIAL_KEY", () => {
     // matters - no credential stem matches it, so the derivation is its only
     // cover.
     expect(new Set(STORED_SECRET_FIELDS)).toEqual(
-      new Set(["password", "connectionString", "agentPassword", "clientKey", "privateKey", "passphrase"]),
+      new Set(["password", "apiKey", "connectionString", "agentPassword", "clientKey", "privateKey", "passphrase"]),
     );
   });
 

--- a/tests/unit/lib/db-ui-config.test.ts
+++ b/tests/unit/lib/db-ui-config.test.ts
@@ -317,11 +317,17 @@ describe("db-ui-config", () => {
       test("agrees with the list it reads, for every type and every field", () => {
         // Derived rather than enumerated: the predicate must not develop an opinion of its
         // own about any engine.
-        const FIELDS = ["host", "port", "user", "password", "database", "connectionString"] as const;
+        const FIELDS = ["host", "port", "user", "password", "apiKey", "database", "connectionString"] as const;
         for (const type of ALL_TYPES) {
           for (const field of FIELDS) {
             expect(takesConnectionField(type, field)).toBe(getDBConfig(type).connectionFields.includes(field));
           }
+        }
+      });
+
+      test("offers Elasticsearch API Key authentication only for Elasticsearch", () => {
+        for (const type of ALL_TYPES) {
+          expect(takesConnectionField(type, "apiKey")).toBe(type === "elasticsearch");
         }
       });
     });

--- a/tests/unit/lib/storage/connection-secrets.test.ts
+++ b/tests/unit/lib/storage/connection-secrets.test.ts
@@ -37,6 +37,7 @@ function fullConnection(): DatabaseConnection {
     port: 5432,
     user: "app",
     password: "CANARY-DB-PASSWORD",
+    apiKey: "CANARY-API-KEY",
     database: "prod",
     connectionString: "postgres://app:CANARY-IN-URL@db.internal:5432/prod",
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -64,6 +65,7 @@ function fullConnection(): DatabaseConnection {
 
 const CANARIES = [
   "CANARY-DB-PASSWORD",
+  "CANARY-API-KEY",
   "CANARY-IN-URL",
   "CANARY-TLS-CLIENT-KEY",
   "CANARY-SSH-PASSWORD",
@@ -84,6 +86,7 @@ describe("the classification is exhaustive by construction", () => {
       [
         "agentPassword",
         "agentUser",
+        "apiKey",
         // MongoDB's auth database. A database NAME, so `public`; the password
         // checked against it is the secret and is classified below.
         "authSource",
@@ -114,7 +117,7 @@ describe("the classification is exhaustive by construction", () => {
     );
   });
 
-  test("exactly the seven credential-bearing fields are classified secret", () => {
+  test("exactly the eight credential-bearing fields are classified secret", () => {
     const secrets = [
       ...Object.keys(CONNECTION_FIELDS).filter((k) => CONNECTION_FIELDS[k as never] === "secret"),
       ...Object.keys(SSL_FIELDS)
@@ -128,6 +131,7 @@ describe("the classification is exhaustive by construction", () => {
     expect(secrets).toEqual(
       [
         "agentPassword",
+        "apiKey",
         "connectionString",
         "password",
         "ssl.clientKey",
@@ -158,6 +162,7 @@ describe("encryptConnections", () => {
     const prefix = `${ENVELOPE_VERSION}:`;
 
     expect(encrypted.password?.startsWith(prefix)).toBe(true);
+    expect(encrypted.apiKey?.startsWith(prefix)).toBe(true);
     expect(encrypted.connectionString?.startsWith(prefix)).toBe(true);
     expect(encrypted.agentPassword?.startsWith(prefix)).toBe(true);
     expect(encrypted.ssl?.clientKey?.startsWith(prefix)).toBe(true);
@@ -266,8 +271,8 @@ describe("decryptConnections", () => {
     resetStorageEncryptionKey();
     const result = decryptConnections(encrypted);
 
-    // Seven unreadable fields on one record.
-    expect(result.undecryptable).toBe(7);
+    // Eight unreadable fields on one record.
+    expect(result.undecryptable).toBe(8);
     // The record SURVIVES. Dropping it would be persisted as a deletion by the write-through
     // cache on the next sync, destroying ciphertext a restored key could still have opened.
     expect(result.connections).toHaveLength(1);
@@ -275,6 +280,7 @@ describe("decryptConnections", () => {
     expect(result.connections[0].host).toBe("db.internal");
     // And the field is ABSENT, never the raw envelope: "v1:..." must never reach a driver.
     expect("password" in result.connections[0]).toBe(false);
+    expect("apiKey" in result.connections[0]).toBe(false);
     expect(result.connections[0].sshTunnel?.privateKey).toBeUndefined();
     expect(JSON.stringify(result.connections)).not.toContain(ENVELOPE_VERSION + ":");
   });
@@ -285,7 +291,7 @@ describe("decryptConnections", () => {
     process.env.JWT_SECRET = "a-different-secret-that-cannot-open-it";
     resetStorageEncryptionKey();
 
-    expect(decryptConnections(encrypted).undecryptable).toBe(14);
+    expect(decryptConnections(encrypted).undecryptable).toBe(16);
   });
 
   test("an empty list is not an error", () => {


### PR DESCRIPTION
## Description

Elasticsearch connections can now authenticate with an API Key. Paste either Kibana's encoded value or `id:secret`; the shared transport sends the documented `Authorization: ApiKey <Base64(id:secret)>` header. A populated key takes precedence over Basic credentials, as explained beside the password input. Clearing it restores the existing Basic/unauthenticated behavior.

## Changes Made

- Add the optional secret field to the connection form and the existing typed ownership, secret-storage and seed-resolution maps. Probe, save, edit and reset carry the same value; changing engine drops the field.
- Resolve API Key environment references in seed configs, omit the key from managed connection descriptors and retain it for editable seeds. Server storage seals it using the existing encryption path.
- Clear the main API Key when constructing a provider with separate least-privilege agent credentials, so the key cannot override that identity.
- Declare authentication support in the existing transport product table. OpenSearch refuses this Elasticsearch-specific field before sending a request; its existing Basic and unauthenticated paths remain covered.
- Update both provider documents and integration tests together. No new dependencies.

## Testing

- TDD: 19 failures against the original implementation across provider, form, UI, secret-storage and seed tests.
- `bun run test:integration --isolate --pass-with-no-tests -t 'Elasticsearch|OpenSearch'`: 172 passed.
- Targeted `bun run test:unit --isolate` covering secret encryption/decryption, seed identity, the agent credential override, UI configuration and the shared-provider seam: 283 passed.
- `bun run test:hooks --isolate --pass-with-no-tests -t 'useConnectionForm'`: 81 passed.
- `bun run test:api --isolate --pass-with-no-tests -t 'GET /api/connections/managed'`: 12 passed.
- `bun run test:components --pass-with-no-tests -t 'ConnectionModal'`: 73 passed, including the mobile wrapper.
- API reference/type drift checks and the agent state credential guard: 79 passed after registering `apiKey` in their documented and pinned field lists.
- Passed locally: `format`, `lint`, `typecheck`, `knip`, `readme:check`, `chart:check`, `channels:showcase:check` and `security:check`.
- `bun run build`, `bun run build:lib` and `bun run attw` passed from a clean checkout of commit `1ed23f8bd8ac1cc4d797e72f9534e11c9511504f` with real local dependencies.
- A broader factory test selection passed its SQLite assertions but failed its existing Windows `afterAll` cleanup with `EBUSY`. The final focused selection includes the changed credential-override case and passes. Full local `bun run test` / coverage and E2E were not run: this host lacks Helm/chart dependencies and working Docker; Linux CI must verify the complete suite and 100% line-coverage gate.

The authentication tests drive the real provider and HTTP transport with synthetic responses. No live security-enabled Elasticsearch/OpenSearch cluster was used; the provider docs distinguish this protocol validation from the existing captured cluster fixtures. Tests verify both API Key input forms, authentication errors without key disclosure, Basic compatibility, seed descriptor redaction, encryption round trips and separate agent credentials.

Environment: Windows, Node.js 24.18.1, Bun 1.4.2.

## Checklist

- [x] Linked the claimed issue, reviewed the diff and updated the provider code/docs/tests together.
- [x] Required CI test job passes the 100% line-coverage gate.

## Additional Notes

AI-assisted implementation and test execution using Codex. The new optional field requires no database migration. API Keys are created and revoked in Elasticsearch/Kibana; this change only consumes an existing key.
