### PR TITLE
feat(studio): add new-query shortcut and keyboard guide

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -9,8 +9,9 @@
 *   **Custom DB Theme:** Specialized `db-dark` theme for high-contrast SQL syntax highlighting.
 *   **Power Snippets:** Integrated templates for CTEs, Joins, and complex CRUD operations.
 *   **Modern Editor Specs:** Font ligatures, smooth scrolling, bracket pair colorization, and parameter hints enabled.
-*   **Keyboard Shortcuts:** `Cmd/Ctrl + Enter` to execute, `Alt + Shift + F` to format.
+*   **Keyboard Shortcuts:** `Cmd/Ctrl + Enter` to execute, `Alt + Shift + F` to format, and `Ctrl + Alt + Shift + N` / `Cmd + Option + Shift + N` to open a new query tab. The new-tab button also shows its shortcut; in embedded workspaces it applies to the workspace receiving keyboard input.
 *   **Command Palette:** Quick access to tables, connections, saved queries, and actions with `Cmd/Ctrl+K`.
+*   **Shortcut Guide:** Press `?` outside text fields, choose "Keyboard shortcuts" in the command palette, or use the Data Profiler's keyboard button. The guide lists app and query-editor bindings and their scope; it is also available in embedded workspaces.
 
 > See [`docs/editor/`](editor/) for the editor internals — completion provider, alias resolution, and performance design.
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -23,6 +23,7 @@ import {
   Bot,
   TextAlignStart,
   Save,
+  Keyboard,
 } from "lucide-react";
 import { DatabaseConnection, TableSchema, SavedQuery, QueryHistoryItem } from "@/lib/types";
 import { storage } from "@/lib/storage";
@@ -53,6 +54,7 @@ interface CommandPaletteProps {
    */
   onAskAgent?: () => void;
   onLogout: () => void;
+  onShowShortcuts?: () => void;
 }
 
 export function CommandPalette({
@@ -72,6 +74,7 @@ export function CommandPalette({
   onSaveQuery,
   onAskAgent,
   onLogout,
+  onShowShortcuts,
 }: CommandPaletteProps) {
   const [open, setOpen] = useState(false);
 
@@ -112,6 +115,13 @@ export function CommandPalette({
 
         {/* Quick Actions */}
         <CommandGroup heading="Actions">
+          {onShowShortcuts && (
+            <CommandItem onSelect={() => runAction(onShowShortcuts)}>
+              <Keyboard strokeWidth={1.5} className="w-3.5 h-3.5 text-fg-tertiary" />
+              <span>Keyboard shortcuts</span>
+              <CommandShortcut>?</CommandShortcut>
+            </CommandItem>
+          )}
           <CommandItem onSelect={() => runAction(onExecuteQuery)}>
             <Play strokeWidth={1.5} className="w-3.5 h-3.5 text-hue-blue" />
             <span>Run Query</span>

--- a/src/components/DataProfiler.tsx
+++ b/src/components/DataProfiler.tsx
@@ -2,7 +2,8 @@
 
 import { appFetch } from "@/lib/config/base-path";
 import { useState, useEffect, useMemo } from "react";
-import { LoaderCircle, ChartColumn, X, Hash, CircleAlert, Sparkles, Lock } from "lucide-react";
+import { LoaderCircle, ChartColumn, X, Hash, CircleAlert, Sparkles, Lock, Keyboard } from "lucide-react";
+import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { cn } from "@/lib/utils";
 import { TableSchema, DatabaseConnection } from "@/lib/types";
 import { detectSensitiveColumns, maskValue } from "@/lib/data-masking";
@@ -57,6 +58,7 @@ export function DataProfiler({
   const [aiSummary, setAiSummary] = useState("");
   const [isAiLoading, setIsAiLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
   // Detect sensitive columns for masking sample values in profiler
   const sensitiveColumnNames = useMemo(() => {
@@ -165,6 +167,7 @@ export function DataProfiler({
       setProfile(null);
       setAiSummary("");
       setError(null);
+      setShortcutsOpen(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, tableName]);
@@ -216,6 +219,15 @@ export function DataProfiler({
             <span className="text-xs font-medium text-fg shrink-0">Data Profiler</span>
             <span className="text-xs text-fg-muted font-mono truncate">{tableName}</span>
           </div>
+          <button
+            type="button"
+            onClick={() => setShortcutsOpen(true)}
+            aria-label="Keyboard shortcuts"
+            title="Keyboard shortcuts (?)"
+            className="ml-auto shrink-0 p-1 rounded hover:bg-fill text-fg-muted"
+          >
+            <Keyboard strokeWidth={1.5} className="w-3.5 h-3.5" />
+          </button>
           <button
             onClick={onClose}
             aria-label="Close data profiler"
@@ -389,6 +401,7 @@ export function DataProfiler({
           )}
         </div>
       </div>
+      <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
     </div>
   );
 }

--- a/src/components/KeyboardShortcutsDialog.tsx
+++ b/src/components/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+const SHORTCUTS = [
+  ["Command palette", "Ctrl / ⌘ + K", "Standalone app"],
+  ["New query tab", "Ctrl / ⌘ + Alt / Option + Shift + N", "Workspace"],
+  ["Show shortcuts", "?", "Outside text fields"],
+  ["Run query", "Ctrl / ⌘ + Enter", "Query editor"],
+  ["Format query", "Alt / Option + Shift + F", "Query editor"],
+  ["Editor command palette", "F1", "Query editor"],
+  ["Switch editor tab", "← / →", "Tab strip"],
+  ["First / last editor tab", "Home / End", "Tab strip"],
+  ["Finish / cancel tab rename", "Enter / Escape", "Tab name"],
+  ["Close dialog or profiler", "Escape", "Open dialog"],
+];
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  enabled?: boolean;
+}
+
+export function KeyboardShortcutsDialog({ open, onOpenChange, enabled = true }: KeyboardShortcutsDialogProps) {
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key !== "?" ||
+        event.defaultPrevented ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        event.repeat ||
+        event.isComposing
+      )
+        return;
+      if (
+        event.target instanceof Element &&
+        event.target.closest(
+          'input, textarea, select, [contenteditable]:not([contenteditable="false"]), .monaco-editor, dialog, [role="dialog"], [role="alertdialog"]',
+        )
+      )
+        return;
+      event.preventDefault();
+      onOpenChange(true);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [enabled, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-studio-workspace=""
+        className="bg-overlay text-fg border-hairline max-h-[85vh] overflow-y-auto sm:max-w-xl"
+        onOpenAutoFocus={() => {
+          previousFocus.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          previousFocus.current?.focus();
+        }}
+        onEscapeKeyDown={(event) => event.stopImmediatePropagation()}
+      >
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            Press ? outside text fields to open this guide. Use F1 in the query editor for more editing commands.
+          </DialogDescription>
+        </DialogHeader>
+        <dl className="divide-y divide-hairline">
+          {SHORTCUTS.map(([action, keys, scope]) => (
+            <div key={action} className="flex items-center justify-between gap-3 py-2.5 text-xs">
+              <dt>
+                <span className="block font-medium">{action}</span>
+                <span className="text-fg-muted">{scope}</span>
+              </dt>
+              <dd className="text-right">
+                <kbd className="rounded border border-hairline bg-fill px-1.5 py-1 font-mono leading-6">{keys}</kbd>
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/Studio.tsx
+++ b/src/components/Studio.tsx
@@ -7,6 +7,7 @@ import { MobileNav } from "@/components/MobileNav";
 import { SchemaExplorer } from "@/components/schema-explorer";
 import { ConnectionModal } from "@/components/ConnectionModal";
 import { CommandPalette } from "@/components/CommandPalette";
+import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { QueryEditor, QueryEditorRef } from "@/components/QueryEditor";
 import { DataImportModal } from "@/components/DataImportModal";
 import { QuerySafetyDialog } from "@/components/QuerySafetyDialog";
@@ -205,6 +206,7 @@ export default function Studio() {
   const isMobile = useIsMobile();
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [profilerTable, setProfilerTable] = useState<string | null>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [codeGenTable, setCodeGenTable] = useState<string | null>(null);
   const [testDataTable, setTestDataTable] = useState<string | null>(null);
 
@@ -938,8 +940,11 @@ export default function Studio() {
         onFormatQuery={() => queryEditorRef.current?.format()}
         onSaveQuery={() => setIsSaveQueryModalOpen(true)}
         onAskAgent={agentEnabled ? askAgentAboutStatement : undefined}
+        onShowShortcuts={() => setShortcutsOpen(true)}
         onLogout={handleLogout}
       />
+
+      <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} enabled={!profilerTable} />
 
       <MobileNav
         activeTab={activeMobileTab}

--- a/src/components/studio/StudioTabBar.tsx
+++ b/src/components/studio/StudioTabBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { type Dispatch, type SetStateAction } from "react";
+import React, { useEffect, useRef, type Dispatch, type SetStateAction } from "react";
 import type { QueryTab } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { FileBraces, Hash, Plus, X } from "lucide-react";
@@ -30,6 +30,37 @@ export function StudioTabBar({
   onCloseTab,
   onAddTab,
 }: StudioTabBarProps) {
+  const tabBarRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleNewTab = (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.repeat ||
+        event.isComposing ||
+        !(event.ctrlKey || event.metaKey) ||
+        !event.altKey ||
+        !event.shiftKey ||
+        event.code !== "KeyN"
+      )
+        return;
+
+      // Ctrl+Alt can also produce AltGr characters; keep those available for typing.
+      // Command+Option may report a dead key on macOS, so use the physical key there.
+      if (!event.metaKey && event.key.toLowerCase() !== "n") return;
+
+      const workspace = tabBarRef.current?.closest("[data-studio-workspace]");
+      if (workspace && !(event.target instanceof Node && workspace.contains(event.target))) return;
+      if (event.target instanceof Element && event.target.closest('dialog, [role="dialog"], [role="alertdialog"]'))
+        return;
+
+      event.preventDefault();
+      onAddTab();
+    };
+    document.addEventListener("keydown", handleNewTab);
+    return () => document.removeEventListener("keydown", handleNewTab);
+  }, [onAddTab]);
+
   // Roving tabindex (WAI-ARIA tabs pattern): arrows/Home/End move activation,
   // and focus follows the newly activated tab.
   const activateTabAt = (index: number, e: React.KeyboardEvent) => {
@@ -52,6 +83,7 @@ export function StudioTabBar({
 
   return (
     <div
+      ref={tabBarRef}
       role="tablist"
       aria-label="Editor tabs"
       className="hidden md:flex h-10 bg-raised border-b border-hairline items-center px-2 gap-1 overflow-x-auto no-scrollbar"
@@ -151,6 +183,8 @@ export function StudioTabBar({
       <button
         type="button"
         aria-label="New tab"
+        title="New tab (Ctrl+Alt+Shift+N / ⌘+Option+Shift+N)"
+        aria-keyshortcuts="Control+Alt+Shift+N Meta+Alt+Shift+N"
         className="text-fg-muted cursor-pointer hover:text-fg-bright mx-2"
         onClick={onAddTab}
       >

--- a/src/workspace/StudioWorkspace.tsx
+++ b/src/workspace/StudioWorkspace.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import { Sidebar } from "@/components/sidebar";
 // MobileNav and mobile tab panels excluded in embedded mode — platform provides its own navigation
 import { QueryEditor, QueryEditorRef } from "@/components/QueryEditor";
+import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { DataImportModal } from "@/components/DataImportModal";
 import { QuerySafetyDialog } from "@/components/QuerySafetyDialog";
 import { DataProfiler } from "@/components/DataProfiler";
@@ -224,6 +225,7 @@ export function StudioWorkspace({
   const [savedKey, setSavedKey] = useState(0);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [profilerTable, setProfilerTable] = useState<string | null>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [codeGenTable, setCodeGenTable] = useState<string | null>(null);
   const [testDataTable, setTestDataTable] = useState<string | null>(null);
 
@@ -574,6 +576,7 @@ export function StudioWorkspace({
       </AlertDialog>
 
       {/* Mobile Navigation — hidden in embedded mode, platform provides its own */}
+      <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} enabled={!profilerTable} />
     </div>
   );
 }

--- a/tests/components/CommandPalette.test.tsx
+++ b/tests/components/CommandPalette.test.tsx
@@ -145,6 +145,18 @@ describe("CommandPalette", () => {
     expect(queryByText("Run Query")).not.toBeNull();
   });
 
+  test("offers the keyboard shortcuts guide only when its action is supplied", async () => {
+    const onShowShortcuts = mock(() => {});
+    const props = createDefaultProps();
+    const { queryByText, getByText, rerender } = render(<CommandPalette {...props} />);
+    fireEvent.keyDown(document, { key: "k", ctrlKey: true });
+    expect(queryByText("Keyboard shortcuts")).toBeNull();
+    rerender(<CommandPalette {...props} onShowShortcuts={onShowShortcuts} />);
+    fireEvent.click(getByText("Keyboard shortcuts"));
+    await waitFor(() => expect(onShowShortcuts).toHaveBeenCalledTimes(1));
+    expect(queryByText("Run Query")).toBeNull();
+  });
+
   test("shows connections when dialog is open", () => {
     const props = createDefaultProps();
     const { queryByText } = render(<CommandPalette {...props} />);

--- a/tests/components/DataProfiler.test.tsx
+++ b/tests/components/DataProfiler.test.tsx
@@ -109,6 +109,29 @@ describe("DataProfiler", () => {
     expect(view.queryByText("Data Profiler")).not.toBeNull();
   });
 
+  test("opens keyboard shortcuts with ? and closes the guide before the profiler", async () => {
+    const props = createDefaultProps();
+    const { getByRole, queryByRole } = render(<DataProfiler {...props} />);
+    fireEvent.keyDown(document, { key: "?", shiftKey: true });
+    expect(getByRole("dialog", { name: "Keyboard shortcuts" })).not.toBeNull();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeNull());
+    expect(props.onClose).not.toHaveBeenCalled();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("offers a shortcuts button and resets the guide when the profiler closes", () => {
+    const props = createDefaultProps();
+    const { getByRole, queryByRole, rerender } = render(<DataProfiler {...props} />);
+    fireEvent.click(getByRole("button", { name: "Keyboard shortcuts" }));
+    expect(getByRole("dialog", { name: "Keyboard shortcuts" })).not.toBeNull();
+    rerender(<DataProfiler {...props} isOpen={false} />);
+    expect(queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeNull();
+    rerender(<DataProfiler {...props} />);
+    expect(queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeNull();
+  });
+
   // ── Shows table name in title ─────────────────────────────────────────────
 
   test("shows table name in title area", () => {
@@ -160,7 +183,7 @@ describe("DataProfiler", () => {
     const { container } = render(<DataProfiler {...props} />);
 
     // The close button is in the header with text-fg-muted token
-    const closeButton = container.querySelector("button.text-fg-muted");
+    const closeButton = container.querySelector('button[aria-label="Close data profiler"]');
     expect(closeButton).not.toBeNull();
 
     fireEvent.click(closeButton!);

--- a/tests/components/KeyboardShortcutsDialog.test.tsx
+++ b/tests/components/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,135 @@
+import "../setup-dom";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import React, { useState } from "react";
+import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
+
+afterEach(cleanup);
+
+function Guide({ enabled = true }: { enabled?: boolean }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Show guide
+      </button>
+      <KeyboardShortcutsDialog open={open} onOpenChange={setOpen} enabled={enabled} />
+    </>
+  );
+}
+
+describe("KeyboardShortcutsDialog", () => {
+  test("opens with ? and lists app shortcuts and the editor's registered bindings", () => {
+    const { getByRole, queryByRole } = render(<Guide />);
+    expect(queryByRole("dialog")).toBeNull();
+    const event = new KeyboardEvent("keydown", { key: "?", shiftKey: true, cancelable: true });
+    fireEvent(document, event);
+    expect(event.defaultPrevented).toBe(true);
+    const guide = within(getByRole("dialog", { name: "Keyboard shortcuts" }));
+    for (const label of [
+      "Command palette",
+      "New query tab",
+      "Show shortcuts",
+      "Run query",
+      "Format query",
+      "Editor command palette",
+      "Switch editor tab",
+      "First / last editor tab",
+      "Close dialog or profiler",
+    ])
+      expect(guide.getByText(label)).not.toBeNull();
+    for (const binding of [
+      "Ctrl / ⌘ + K",
+      "Ctrl / ⌘ + Alt / Option + Shift + N",
+      "?",
+      "Ctrl / ⌘ + Enter",
+      "Alt / Option + Shift + F",
+      "F1",
+      "← / →",
+      "Home / End",
+      "Escape",
+    ])
+      expect(guide.getByText(binding)).not.toBeNull();
+  });
+
+  test("preserves typing in inputs, editable content and Monaco", () => {
+    const { getByLabelText, queryByRole } = render(
+      <>
+        <Guide />
+        <input aria-label="Input" />
+        <textarea aria-label="Query" />
+        <select aria-label="Choice">
+          <option>One</option>
+        </select>
+        <div contentEditable aria-label="Editable" />
+        <div className="monaco-editor">
+          <button type="button" aria-label="Editor control" />
+        </div>
+      </>,
+    );
+    for (const label of ["Input", "Query", "Choice", "Editable", "Editor control"]) {
+      const event = new KeyboardEvent("keydown", { key: "?", bubbles: true, cancelable: true });
+      fireEvent(getByLabelText(label), event);
+      expect(event.defaultPrevented).toBe(false);
+    }
+    expect(queryByRole("dialog")).toBeNull();
+  });
+
+  test("ignores modified, composing, repeated and already handled keys", () => {
+    const onOpenChange = mock(() => {});
+    render(<KeyboardShortcutsDialog open={false} onOpenChange={onOpenChange} />);
+    for (const key of [
+      { key: "x" },
+      { key: "?", ctrlKey: true },
+      { key: "?", metaKey: true },
+      { key: "?", altKey: true },
+      { key: "?", repeat: true },
+      { key: "?", isComposing: true },
+    ])
+      fireEvent.keyDown(document, key);
+    const handled = new KeyboardEvent("keydown", { key: "?", cancelable: true });
+    handled.preventDefault();
+    fireEvent(document, handled);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  test("does not handle ? inside another dialog", () => {
+    const { getByLabelText, queryByRole } = render(
+      <>
+        <Guide />
+        <dialog open>
+          <button type="button" aria-label="Other dialog control" />
+        </dialog>
+      </>,
+    );
+    fireEvent.keyDown(getByLabelText("Other dialog control"), { key: "?" });
+    expect(queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeNull();
+  });
+
+  test("can disable the global binding and removes the listener on unmount", () => {
+    const onOpenChange = mock(() => {});
+    const { rerender, unmount } = render(
+      <KeyboardShortcutsDialog open={false} onOpenChange={onOpenChange} enabled={false} />,
+    );
+    fireEvent.keyDown(document, { key: "?" });
+    expect(onOpenChange).not.toHaveBeenCalled();
+    rerender(<KeyboardShortcutsDialog open={false} onOpenChange={onOpenChange} />);
+    fireEvent.keyDown(document, { key: "?" });
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    unmount();
+    fireEvent.keyDown(document, { key: "?" });
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("restores keyboard focus when closed", async () => {
+    const { getByRole, queryByRole } = render(<Guide />);
+    const trigger = getByRole("button", { name: "Show guide" });
+    trigger.focus();
+    fireEvent.click(trigger);
+    fireEvent.click(getByRole("button", { name: "Close" }));
+    await waitFor(() => {
+      expect(queryByRole("dialog")).toBeNull();
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+});

--- a/tests/components/Studio.test.tsx
+++ b/tests/components/Studio.test.tsx
@@ -631,6 +631,12 @@ describe("Studio", () => {
     expect(palette.textContent).toBe("CommandPalette");
   });
 
+  test("opens keyboard shortcuts from the command palette", () => {
+    const { getByRole } = render(<Studio />);
+    act(() => (capturedCommandPaletteProps.onShowShortcuts as () => void)());
+    expect(getByRole("dialog", { name: "Keyboard shortcuts" })).not.toBeNull();
+  });
+
   test("connection modal hidden by default", () => {
     const { queryByTestId } = render(<Studio />);
     const modal = queryByTestId("connection-modal");

--- a/tests/components/StudioWorkspace.test.tsx
+++ b/tests/components/StudioWorkspace.test.tsx
@@ -282,7 +282,7 @@ mock.module("@/components/ui/resizable", () => {
 // that no real heavy child module evaluates in this process.
 
 import { describe, test, expect, afterEach, beforeEach } from "bun:test";
-import { render, cleanup, act } from "@testing-library/react";
+import { render, cleanup, act, fireEvent } from "@testing-library/react";
 import React from "react";
 import type { SavedQueryInput, StudioWorkspaceProps } from "@/workspace/types";
 import type { ProviderMetadata } from "@/hooks/use-provider-metadata";
@@ -437,6 +437,12 @@ describe("StudioWorkspace", () => {
     const root = container.querySelector("[data-studio-workspace]");
     expect(root).not.toBeNull();
     expect(root?.className).toContain("my-custom-class");
+  });
+
+  test("opens keyboard shortcuts in the embedded workspace", () => {
+    const { getByRole } = renderWorkspace();
+    fireEvent.keyDown(document, { key: "?", shiftKey: true });
+    expect(getByRole("dialog", { name: "Keyboard shortcuts" })).not.toBeNull();
   });
 
   test("multiple rerenders do not crash", () => {

--- a/tests/components/studio/StudioTabBar.test.tsx
+++ b/tests/components/studio/StudioTabBar.test.tsx
@@ -115,6 +115,121 @@ describe("StudioTabBar", () => {
     expect(onAddTab).toHaveBeenCalledTimes(1);
   });
 
+  describe("new tab shortcut", () => {
+    const shortcut = { key: "N", code: "KeyN", ctrlKey: true, altKey: true, shiftKey: true };
+    const keyDown = (target: Node, init: KeyboardEventInit) => {
+      const event = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+      fireEvent(target, event);
+      return event;
+    };
+
+    test("uses Ctrl/Command+Alt+Shift+N and exposes the binding on the button", () => {
+      const props = createDefaultProps();
+      const { getByRole } = render(<StudioTabBar {...props} />);
+      const button = getByRole("button", { name: "New tab" });
+      expect(button.title).toBe("New tab (Ctrl+Alt+Shift+N / ⌘+Option+Shift+N)");
+      expect(button.getAttribute("aria-keyshortcuts")).toBe("Control+Alt+Shift+N Meta+Alt+Shift+N");
+
+      for (const modifier of [
+        { ctrlKey: true, key: "n" },
+        { metaKey: true, key: "Dead" },
+      ]) {
+        const event = keyDown(document, {
+          ...modifier,
+          code: "KeyN",
+          altKey: true,
+          shiftKey: true,
+        });
+        expect(event.defaultPrevented).toBe(true);
+      }
+      expect(props.onAddTab).toHaveBeenCalledTimes(2);
+    });
+
+    test("leaves browser shortcuts, typing, repeats and composition untouched", () => {
+      const props = createDefaultProps();
+      render(<StudioTabBar {...props} />);
+      for (const binding of [
+        { code: "KeyN" },
+        { code: "KeyN", ctrlKey: true },
+        { code: "KeyT", metaKey: true },
+        { code: "KeyN", ctrlKey: true, shiftKey: true },
+        { code: "KeyN", altKey: true },
+        { code: "KeyN", metaKey: true, altKey: true },
+        { ...shortcut, code: "KeyT" },
+        { ...shortcut, repeat: true },
+        { ...shortcut, isComposing: true },
+        { ...shortcut, key: "Ń", modifierAltGraph: true },
+      ]) {
+        const event = keyDown(document, binding);
+        expect(event.defaultPrevented).toBe(false);
+      }
+      const handled = new KeyboardEvent("keydown", {
+        ...shortcut,
+        cancelable: true,
+      });
+      handled.preventDefault();
+      fireEvent(document, handled);
+      expect(props.onAddTab).not.toHaveBeenCalled();
+    });
+
+    test("uses the current callback and removes its listener on unmount", () => {
+      const props = createDefaultProps();
+      const { rerender, unmount } = render(<StudioTabBar {...props} />);
+      const onAddTab = mock(() => {});
+      rerender(<StudioTabBar {...props} onAddTab={onAddTab} />);
+      keyDown(document, shortcut);
+      expect(onAddTab).toHaveBeenCalledTimes(1);
+      expect(props.onAddTab).not.toHaveBeenCalled();
+      unmount();
+      keyDown(document, shortcut);
+      expect(onAddTab).toHaveBeenCalledTimes(1);
+    });
+
+    test("scopes embedded workspaces to the one receiving the keyboard event", () => {
+      const first = createDefaultProps();
+      const second = createDefaultProps();
+      const { getByLabelText } = render(
+        <>
+          <section data-studio-workspace>
+            <StudioTabBar {...first} />
+            <textarea aria-label="First query" />
+          </section>
+          <section data-studio-workspace>
+            <StudioTabBar {...second} />
+            <textarea aria-label="Second query" />
+          </section>
+        </>,
+      );
+      keyDown(document, shortcut);
+      expect(first.onAddTab).not.toHaveBeenCalled();
+      expect(second.onAddTab).not.toHaveBeenCalled();
+      keyDown(getByLabelText("First query"), shortcut);
+      expect(first.onAddTab).toHaveBeenCalledTimes(1);
+      expect(second.onAddTab).not.toHaveBeenCalled();
+      keyDown(getByLabelText("Second query"), { ...shortcut, ctrlKey: false, metaKey: true });
+      expect(first.onAddTab).toHaveBeenCalledTimes(1);
+      expect(second.onAddTab).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not create a tab behind a dialog", () => {
+      const props = createDefaultProps();
+      const { getByLabelText } = render(
+        <>
+          <StudioTabBar {...props} />
+          <dialog open>
+            <input aria-label="Connection name" />
+          </dialog>
+          <div role="alertdialog">
+            <button type="button">Confirm</button>
+          </div>
+        </>,
+      );
+      keyDown(getByLabelText("Connection name"), shortcut);
+      keyDown(document.querySelector('[role="alertdialog"] button')!, shortcut);
+      expect(props.onAddTab).not.toHaveBeenCalled();
+    });
+  });
+
   // ── Close button ──────────────────────────────────────────────────────
 
   test("close button fires onCloseTab when multiple tabs", () => {

--- a/tests/run-components.sh
+++ b/tests/run-components.sh
@@ -30,7 +30,7 @@ FAIL=0
 # green summary line reported a group count no run had.
 # Drifted again before this line was touched: it read 30 while 32 `run_group` calls
 # existed, so every green run reported a group count no run had. 33 is the grep below.
-TOTAL_GROUPS=34
+TOTAL_GROUPS=35
 EXTRA_BUN_ARGS=("$@")
 GROUP_INDEX=0
 COVERAGE_MODE=0
@@ -269,7 +269,6 @@ run_group "Group 15/16: Remaining components" \
   tests/components/CommandPalette.test.tsx \
   tests/components/ResultsGrid.test.tsx \
   tests/components/SchemaDiagram.test.tsx \
-  tests/components/DataProfiler.test.tsx \
   tests/components/schema-explorer/SchemaExplorer.test.tsx \
   tests/components/schema-explorer/ColumnList.test.tsx \
   tests/components/sidebar/ConnectionItem.test.tsx \
@@ -285,6 +284,11 @@ run_group "Group 15/16: Remaining components" \
   tests/components/monitoring/QueriesTab.test.tsx \
   tests/components/monitoring/PerformanceTab.test.tsx \
   tests/components/monitoring/OverviewTab.test.tsx
+
+# Shortcut dialogs need real Radix focus/Escape behavior, not ConnectionModal's UI mock.
+run_group "Keyboard shortcuts and DataProfiler" \
+  tests/components/KeyboardShortcutsDialog.test.tsx \
+  tests/components/DataProfiler.test.tsx
 
 # Group 18: ui/resizable (isolated — installs a global DOMRect that
 #           react-resizable-panels 4 needs, and is the one suite that renders


### PR DESCRIPTION
## Description

Open a query tab with Ctrl+Alt+Shift+N / Command+Option+Shift+N using the existing new-tab action. The new-tab button exposes the binding in its tooltip and accessibility metadata. A shared keyboard guide opens with `?` outside text fields, from the command palette, or from the Data Profiler's keyboard button.

## Type of Change

- [x] New feature
- [x] Documentation and regression tests

## Changes Made

- Preserve reserved browser bindings, composition, repeated keys and AltGr character input. Embedded new-tab handling is scoped to the workspace receiving the event.
- List application and registered query-editor bindings with their scope, including the editor's F1 command palette. Reuse the existing dialog, restore focus on close, and close the guide before an underlying profiler on Escape.
- Wire the guide into both Studio and StudioWorkspace. Isolate its real Radix dialog tests with DataProfiler in the existing component runner to avoid unrelated module mocks.

## Testing

- TDD: new shortcut regressions failed before implementation; the guide's component/wiring regressions failed before implementation.
- Project-isolated component run targeting `StudioTabBar|KeyboardShortcutsDialog|CommandPalette|DataProfiler|^Studio >|StudioWorkspace`: 147 passed. After the final AltGr compatibility adjustment, reran StudioTabBar: 33 passed.
- Component-runner coverage guard: 3 passed.
- Passed locally: `format`, `lint`, `typecheck`, `knip`, `readme:check`, `chart:check`, `channels:showcase:check`, `security:check`, `build`, `build:lib`, `attw`. Builds used clean commit `d5187606aa2c5f63f225163015ba5536c5f931f9`.
- Browser smoke check used the actual components and production CSS in an isolated local fixture: new-tab shortcut, `?` guide, guide focus restoration, command-palette entry, and embedded input scoping passed. A host input did not create an embedded tab; the embedded query input did. This was not a full application E2E test or a native macOS keyboard test.
- Full local `bun run test`, coverage and app E2E were not run: this Windows host lacks Helm/chart dependencies and working Docker; existing SQLite cleanup also encounters Windows file locks. CI must verify the full suite and 100% line coverage.

Environment: Windows, Node.js 24.18.1, Bun 1.4.2.

## Checklist

- [x] Claimed both issues before implementation, reviewed the final diff and updated documentation.
- [x] Added regression tests and passed relevant local checks.
- [x] Required CI test job passes the 100% line-coverage gate.

## Additional Notes

AI-assisted implementation and validation using Codex. No dependencies, storage migrations or provider changes. Browser extensions, OS shortcuts and keyboard layouts can override application key combinations.
