### PR TITLE
fix(monitoring): preserve schema-qualified maintenance targets

### DIFF
--- a/docs/providers/postgres.md
+++ b/docs/providers/postgres.md
@@ -386,7 +386,9 @@ Monitoring never hard-fails on a missing optional feature:
 
 `qualifyMaintenanceTarget()` ([`postgres.ts`](../../src/lib/db/providers/sql/postgres.ts)) quotes
 maintenance targets through `escapeIdentifier()`: a bare name defaults to the `public` schema; a
-`schema.table` target is quoted per-part. This prevents identifier injection in `VACUUM`/`ANALYZE`/
+`schema.table` target is quoted per-part. A fully quoted `"schema"."table"` is also accepted,
+only when the entire target consists of those two quoted identifiers. This preserves literal
+dots and doubled quotes in catalog names. This prevents identifier injection in `VACUUM`/`ANALYZE`/
 `REINDEX` statements (which cannot use bind parameters for object names).
 
 ---
@@ -720,7 +722,11 @@ base) fans these out in parallel.
 | `getPgStatActivity()` | `pg_stat_activity` | raw passthrough for advanced views |
 
 `getTableStats()` / `getIndexStats()` accept an optional `{ schema }` filter; with none they cover
-all user schemas.
+all user schemas. Table statistics retain the separate `schemaName` and `tableName` and also
+publish `maintenanceTarget`, with both identifiers quoted. Monitoring and admin table actions
+pass that target unchanged, including for `public`, so a same-named table in another schema
+cannot redirect the action. Providers that omit this optional field keep their existing bare
+table target. Admin searches and Explorer deep links also match `schema.table`.
 
 **Database size is absent, never zeroed, when it is not measured.** `getOverview()` sizes the
 database with `pg_database_size($1)` and reads the byte figure only, the shape `mssql.ts` uses:

--- a/src/components/admin/tabs/OperationsTab.tsx
+++ b/src/components/admin/tabs/OperationsTab.tsx
@@ -260,7 +260,9 @@ export function OperationsTab() {
   const sessionsUnavailable = data?.activeSessions === undefined ? data?.errors?.activeSessions : undefined;
   const tablesUnavailable = data?.tables === undefined ? data?.errors?.tables : undefined;
   const [tableSearch, setTableSearch] = useState(deepLinkedTable ?? "");
-  const filteredTables = tables.filter((t) => t.tableName.toLowerCase().includes(tableSearch.toLowerCase()));
+  const filteredTables = tables.filter((t) =>
+    `${t.schemaName}.${t.tableName}`.toLowerCase().includes(tableSearch.toLowerCase()),
+  );
 
   // U22. Both halves have to be true for the dead end: the engine declares a control
   // that takes ONE table, and this page has no row to offer it on. Which absence it is
@@ -516,16 +518,20 @@ export function OperationsTab() {
                   {filteredTables.map((table) => (
                     <div
                       key={`${table.schemaName}.${table.tableName}`}
-                      data-selected={table.tableName === deepLinkedTable ? "true" : undefined}
-                      className={`group flex items-center justify-between px-4 py-2 hover:bg-fill transition-colors ${
-                        table.tableName === deepLinkedTable ? "bg-fill" : ""
-                      }`}
+                      data-selected={
+                        table.tableName === deepLinkedTable ||
+                        `${table.schemaName}.${table.tableName}` === deepLinkedTable
+                          ? "true"
+                          : undefined
+                      }
+                      className="group flex items-center justify-between px-4 py-2 hover:bg-fill data-[selected=true]:bg-fill transition-colors"
                     >
                       <div className="min-w-0">
                         <div className="text-sm font-medium text-fg-secondary truncate max-w-[160px]">
                           {table.tableName}
                         </div>
                         <div className="flex items-center gap-2 text-xs text-fg-muted">
+                          <span>{table.schemaName}</span>
                           <span className="font-mono">{table.rowCount.toLocaleString()} rows</span>
                           <span>-</span>
                           <span className="font-mono">{table.tableSize}</span>
@@ -547,10 +553,10 @@ export function OperationsTab() {
                             variant="ghost"
                             className={`w-7 h-7 text-fg-muted ${hover}`}
                             title={label}
-                            onClick={() => handleRunMaintenance(type, table.tableName)}
+                            onClick={() => handleRunMaintenance(type, table.maintenanceTarget ?? table.tableName)}
                             disabled={!!actionLoading}
                           >
-                            {actionLoading === `${type}-${table.tableName}` ? (
+                            {actionLoading === `${type}-${table.maintenanceTarget ?? table.tableName}` ? (
                               <LoaderCircle className="w-3 h-3 animate-spin" />
                             ) : (
                               <Icon className="w-3 h-3" />

--- a/src/components/monitoring/tabs/TablesTab.tsx
+++ b/src/components/monitoring/tabs/TablesTab.tsx
@@ -388,11 +388,11 @@ export function TablesTab({ data, loading, onRunMaintenance, isAdmin = true, cap
                                 variant="ghost"
                                 size="icon"
                                 className={className}
-                                onClick={() => handleMaintenance(type, table.tableName)}
+                                onClick={() => handleMaintenance(type, table.maintenanceTarget ?? table.tableName)}
                                 disabled={!!actionLoading}
                                 title={label}
                               >
-                                {actionLoading === `${type}-${table.tableName}` ? (
+                                {actionLoading === `${type}-${table.maintenanceTarget ?? table.tableName}` ? (
                                   <LoaderCircle strokeWidth={1.5} className="h-3 w-3 animate-spin" />
                                 ) : (
                                   <Icon strokeWidth={1.5} className="h-3 w-3" />

--- a/src/lib/db/providers/sql/postgres.ts
+++ b/src/lib/db/providers/sql/postgres.ts
@@ -1684,6 +1684,9 @@ export class PostgresProvider extends SQLBaseProvider {
    */
   private qualifyMaintenanceTarget(target?: string): string {
     if (!target) return "";
+    // getTableStats quotes the two catalog names separately, including literal dots.
+    // Accept only that complete identifier shape before retaining the legacy raw form.
+    if (/^"(?:[^"]|"")+"\."(?:[^"]|"")+"$/.test(target)) return target;
     if (target.includes(".")) {
       return target
         .split(".")
@@ -2038,6 +2041,7 @@ export class PostgresProvider extends SQLBaseProvider {
       return res.rows.map((r) => ({
         schemaName: r.schema_name,
         tableName: r.table_name,
+        maintenanceTarget: `${this.escapeIdentifier(r.schema_name)}.${this.escapeIdentifier(r.table_name)}`,
         rowCount: parseInt(r.row_count || "0"),
         liveRowCount: parseInt(r.live_row_count || "0"),
         deadRowCount: parseInt(r.dead_row_count || "0"),

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -845,6 +845,8 @@ export interface ActiveSessionDetails {
 export interface TableStats {
   schemaName: string;
   tableName: string;
+  /** Provider-owned maintenance identifier; callers fall back to tableName when absent. */
+  maintenanceTarget?: string;
   rowCount: number;
   liveRowCount?: number;
   deadRowCount?: number;

--- a/tests/components/admin/OperationsTab.test.tsx
+++ b/tests/components/admin/OperationsTab.test.tsx
@@ -835,6 +835,39 @@ describe("OperationsTab", () => {
     expect(mockRunMaintenance).toHaveBeenCalledWith("vacuum", "users");
   });
 
+  test("schema-qualified deep links select the right table and preserve its maintenance target", async () => {
+    setMockSearchParams(new URLSearchParams({ table: "reporting.Users" }));
+    monitoringOverride = {
+      data: {
+        tables: ["public", "reporting"].map((schemaName) => ({
+          ...defaultTables[0],
+          schemaName,
+          tableName: "Users",
+          maintenanceTarget: `"${schemaName}"."Users"`,
+        })),
+      },
+    };
+    let rendered!: ReturnType<typeof render>;
+    await act(async () => {
+      rendered = render(<OperationsTab />);
+    });
+    const { container, getByPlaceholderText, getByText } = rendered;
+    const selected = container.querySelector('[data-selected="true"]');
+    expect(selected).not.toBeNull();
+    expect(getByText("reporting")).not.toBeNull();
+    const tableList = selected!.parentElement!;
+    expect(tableList.children.length).toBe(1);
+    for (const operation of ["Analyze", "Vacuum", "Reindex"]) {
+      await act(async () => {
+        fireEvent.click(selected!.querySelector(`button[title="${operation}"]`)!);
+      });
+      expect(mockRunMaintenance).toHaveBeenLastCalledWith(operation.toLowerCase(), '"reporting"."Users"');
+    }
+    fireEvent.change(getByPlaceholderText("Filter..."), { target: { value: "Users" } });
+    expect(tableList.children.length).toBe(2);
+    expect(container.querySelectorAll('[data-selected="true"]').length).toBe(1);
+  });
+
   // =========================================================================
   // Kill session flow
   // =========================================================================

--- a/tests/components/monitoring/TablesTab.test.tsx
+++ b/tests/components/monitoring/TablesTab.test.tsx
@@ -268,6 +268,37 @@ describe("TablesTab", () => {
     expect(container.querySelector('button[title="Reindex"]')).toBeNull();
     expect(queryAllByText("-").length).toBeGreaterThan(0);
   });
+
+  test("maintenance preserves provider targets and distinguishes same-named tables across schemas", async () => {
+    const data = makeData();
+    data.tables = ["public", "reporting"].map((schemaName) => ({
+      ...data.tables![0],
+      schemaName,
+      tableName: "Users",
+      maintenanceTarget: `"${schemaName}"."Users"`,
+    }));
+    let finish!: (success: boolean) => void;
+    const onRunMaintenance = mock(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const { container } = render(
+      <TablesTab data={data} loading={false} onRunMaintenance={onRunMaintenance} capabilities={makeCapabilities()} />,
+    );
+    const rows = container.querySelectorAll("tbody tr");
+    for (const operation of ["Analyze", "Vacuum", "Reindex"]) {
+      fireEvent.click(rows[1].querySelector(`button[title="${operation}"]`)!);
+      expect(onRunMaintenance).toHaveBeenLastCalledWith(operation.toLowerCase(), '"reporting"."Users"');
+      expect(rows[1].querySelectorAll(".animate-spin").length).toBe(1);
+      expect(rows[0].querySelectorAll(".animate-spin").length).toBe(0);
+      finish(true);
+      await waitFor(() =>
+        expect(rows[1].querySelector(`button[title="${operation}"]`)!.hasAttribute("disabled")).toBe(false),
+      );
+    }
+  });
   // #448 settled the rule this panel broke one component over: absence and zero are
   // different inputs. Measured 2026-08-21 in Chrome against Apache Cassandra 5.0.9 —
   // Monitoring -> Tables read "Tables 0 / 0 rows", "Size 0 B" and a green "Vacuum 0 / OK"

--- a/tests/integration/db/postgres-provider.test.ts
+++ b/tests/integration/db/postgres-provider.test.ts
@@ -2668,6 +2668,36 @@ describe("PostgresProvider", () => {
   // --------------------------------------------------------------------------
 
   describe("getTableStats()", () => {
+    test.each([
+      ["public", "Users"],
+      ["reporting", "Users"],
+      ["Sales.Operations", 'Monthly."Summary;--'],
+    ])("round-trips the maintenance target for %s.%s", async (schemaName, tableName) => {
+      provider = new PostgresProvider(makePgConfig());
+      await provider.connect();
+      const statements: string[] = [];
+      mockQueryFn = async (sql: string) => {
+        statements.push(sql);
+        if (sql.includes("schemaname as schema_name") && sql.includes("pg_stat_user_tables")) {
+          return { rows: [{ schema_name: schemaName, table_name: tableName }], fields: [], rowCount: 1 };
+        }
+        return defaultMockQuery(sql);
+      };
+      const [table] = await provider.getTableStats();
+      const expected = `"${schemaName.replace(/"/g, '""')}"."${tableName.replace(/"/g, '""')}"`;
+      expect(table.tableName).toBe(tableName);
+      expect(table.schemaName).toBe(schemaName);
+      expect(table.maintenanceTarget).toBe(expected);
+      for (const [operation, command] of [
+        ["analyze", "ANALYZE"],
+        ["vacuum", "VACUUM ANALYZE"],
+        ["reindex", "REINDEX TABLE"],
+      ] as const) {
+        await provider.runMaintenance(operation, table.maintenanceTarget);
+        expect(statements.at(-1)).toBe(`${command} ${expected}`);
+      }
+    });
+
     test("returns table stats for all schemas", async () => {
       provider = new PostgresProvider(makePgConfig());
       await provider.connect();


### PR DESCRIPTION
## Description

Table actions in Monitoring and Admin Operations discarded `schemaName`, so PostgreSQL resolved `reporting.Users` as `public.Users`. If both existed, the operation could target the wrong table instead of returning an error.

PostgreSQL table statistics now provide an optional, fully quoted `maintenanceTarget`. Both surfaces pass it unchanged and use it for the loading indicator. Providers that do not publish it retain the existing bare-table behavior. Admin filtering and Explorer deep links accept `schema.table`, and rows display their schema.

## Type of Change

- [x] Bug fix (backward compatible)
- [x] Documentation update
- [x] Test addition or update

## Related Issue

## Changes Made

- Preserve both catalog identifiers, including mixed case, literal dots and doubled quotes; retain existing bare and unquoted qualified target support.
- Accept a prequoted target only when the complete string is exactly two quoted identifiers, so trailing SQL is not treated as a command.
- Cover all three PostgreSQL maintenance actions, same-named tables across schemas, loading state, and a schema-qualified admin deep link. Keep PostgreSQL code, provider documentation and integration tests together.

## Testing

- [x] Regression tests were written first and failed before the fix.
- [x] `bun run test:integration --isolate --pass-with-no-tests -t '^PostgresProvider'`: 194 passed.
- [x] `bun run test:components --pass-with-no-tests -t '^TablesTab|^OperationsTab'`: 92 passed through the project's isolated component runner.
- [x] `format`, `lint`, `typecheck`, `knip`, `readme:check`, `chart:check`, `channels:showcase:check`, `security:check`.
- [x] `bun run build`, `bun run build:lib`, `bun run attw`.
- [x] Actual production `PostgresProvider`, with only its `pg.Pool` transport adapted to isolated PostgreSQL 18.3 via PGlite 0.5.8: all nine ANALYZE/VACUUM/REINDEX operations succeeded across public, reporting and quoted-name fixtures. An appended SQL target was rejected and the other table remained intact.
- [x] Upstream CI: all 20 executed checks passed, including the full test suite, 100% line-coverage gate, browser E2E, PostgreSQL functional smoke and channel E2E (2 conditional checks skipped).

### Test Environment

Windows; Node.js 24; Bun 1.4.2. PGlite exercises PostgreSQL SQL and catalogs, not the TCP driver or other wire-compatible engines. The full local suite was not run because this host lacks the required Helm/chart and Docker test environment; those lanes passed in upstream Actions.

## Checklist

- [x] Followed contribution guidelines and claimed the issue before coding.
- [x] Reviewed the final diff and preserved existing provider behavior when the optional target is absent.
- [x] Added regression tests and updated provider documentation in the same PR.
- [x] Local targeted tests, static checks and both distribution builds pass.
- [x] Required CI test job passes the 100% line-coverage gate.

## Additional Notes

AI-assisted with Codex. The implementation, regression failures, resulting diff and validation results were reviewed before submission. No dependency, authentication, maintenance-permission or global-operation changes.
