### PR TITLE
docs(readme): add the live Trino listing, drop Druid's not-yet-rendered one

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>
   <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>
   and
-  <a href="https://druid.apache.org/libraries">Apache Druid</a>
+  <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>
   docs
 </p>
 

--- a/README_es.md
+++ b/README_es.md
@@ -27,8 +27,9 @@
   Listado también en la documentación oficial de
   <a href="https://redis.io/docs/latest/develop/tools/#libredb-studio">Redis</a>,
   <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>
+  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>
   y
-  <a href="https://druid.apache.org/libraries">Apache Druid</a>
+  <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>
 </p>
 
 <p align="center">

--- a/README_ja.md
+++ b/README_ja.md
@@ -26,7 +26,8 @@
 <p align="center">
   <a href="https://redis.io/docs/latest/develop/tools/#libredb-studio">Redis</a>、
   <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>、
-  <a href="https://druid.apache.org/libraries">Apache Druid</a>
+  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>、
+  <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>
   の公式ドキュメントにも掲載
 </p>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -26,9 +26,10 @@
 <p align="center">
   同时列入
   <a href="https://redis.io/docs/latest/develop/tools/#libredb-studio">Redis</a>、
-  <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>
+  <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>、
+  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>
   和
-  <a href="https://druid.apache.org/libraries">Apache Druid</a>
+  <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>
   官方文档
 </p>
 


### PR DESCRIPTION
## Description

trinodb/trino.io#847 merged and went live today on trino.io/ecosystem/client-application, under Other client applications. This adds it next to the other official docs in all four READMEs.

Also removes the Apache Druid link: druid.apache.org/libraries still serves the 8 May (37.0.0) build and does not mention us yet, so the README was pointing at a listing that does not actually exist on the live site. It goes back in once the 38.0.0 site build ships and the page renders our entry.

While in there, brought README_es.md, README_ja.md and README_zh.md in line with README.md's badge block, which already listed MariaDB and now Trino but the three translations did not.

## Type of Change

- [x] Documentation update

## Changes Made

- Added the Trino link to the vendor-listing badge block in README.md, README_es.md, README_ja.md and README_zh.md
- Removed the Apache Druid link from the same block in all four files (not yet rendered on the live site)
- Added the missing MariaDB link to README_es.md, README_ja.md and README_zh.md so all four files match

## Testing

- [x] bun run readme:check passes

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings