### PR TITLE
fix(editor): quote PostgreSQL table completion identifiers

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -493,10 +493,10 @@ export const QueryEditor = forwardRef<QueryEditorRef, QueryEditorProps>(
     // SQL completion provider
     useEffect(() => {
       if (monaco && language === "sql") {
-        const disposable = registerSQLCompletionProvider(monaco, schemaCompletionCache);
+        const disposable = registerSQLCompletionProvider(monaco, schemaCompletionCache, databaseType);
         return () => disposable.dispose();
       }
-    }, [monaco, language, schemaCompletionCache]);
+    }, [monaco, language, schemaCompletionCache, databaseType]);
 
     // MongoDB JSON completion provider
     useEffect(() => {

--- a/src/lib/editor/postgres-identifiers.ts
+++ b/src/lib/editor/postgres-identifiers.ts
@@ -1,0 +1,28 @@
+import { quoteIdentifier } from "@/lib/sql/identifier";
+
+// PostgreSQL quote_ident quotes every keyword except UNRESERVED_KEYWORD.
+// Source: PostgreSQL 18, src/include/parser/kwlist.h and
+// src/backend/utils/adt/ruleutils.c (quote_identifier).
+// https://github.com/postgres/postgres/blob/REL_18_STABLE/src/include/parser/kwlist.h
+// Keep this separate from SQL_KEYWORDS: that list is only editor suggestions.
+const QUOTED_KEYWORDS = new Set(
+  `all analyse analyze and any array as asc asymmetric authorization between bigint binary bit boolean
+both case cast char character check coalesce collate collation column concurrently constraint create
+cross current_catalog current_date current_role current_schema current_time current_timestamp
+current_user dec decimal default deferrable desc distinct do else end except exists extract false
+fetch float for foreign freeze from full grant greatest group grouping having ilike in initially
+inner inout int integer intersect interval into is isnull join json json_array json_arrayagg
+json_exists json_object json_objectagg json_query json_scalar json_serialize json_table json_value
+lateral leading least left like limit localtime localtimestamp merge_action national natural nchar
+none normalize not notnull null nullif numeric offset on only or order out outer overlaps overlay
+placing position precision primary real references returning right row select session_user setof
+similar smallint some substring symmetric system_user table tablesample then time timestamp to
+trailing treat trim true union unique user using values varchar variadic verbose when where window
+with xmlattributes xmlconcat xmlelement xmlexists xmlforest xmlnamespaces xmlparse xmlpi xmlroot
+xmlserialize xmltable`.split(/\s+/),
+);
+
+/** Format one catalog identifier using PostgreSQL's conservative quote_ident rule. */
+export function formatPostgresIdentifier(name: string): string {
+  return /^[a-z_][a-z0-9_]*$/.test(name) && !QUOTED_KEYWORDS.has(name) ? name : quoteIdentifier(name, "postgres");
+}

--- a/src/lib/editor/sql-completions.ts
+++ b/src/lib/editor/sql-completions.ts
@@ -7,7 +7,7 @@
 
 import type * as Monaco from "monaco-editor";
 import { extractAliases, resolveAlias } from "@/lib/sql";
-import { quoteIdentifier } from "@/lib/sql/identifier";
+import { formatPostgresIdentifier } from "./postgres-identifiers";
 import type { DatabaseType } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -242,15 +242,10 @@ export function registerSQLCompletionProvider(
         .map((table) => ({
           label: table.label,
           kind: monaco.languages.CompletionItemKind.Class,
-          // PostgreSQL folds unquoted identifiers to lowercase. Schema labels
-          // preserve catalog spelling, so quote each component before insertion.
+          // Preserve ordinary identifiers; quote catalog names only when needed
+          // to preserve case, escape special characters, or avoid keywords.
           insertText:
-            databaseType === "postgres"
-              ? table.label
-                  .split(".")
-                  .map((part) => quoteIdentifier(part, databaseType))
-                  .join(".")
-              : table.label,
+            databaseType === "postgres" ? table.label.split(".").map(formatPostgresIdentifier).join(".") : table.label,
           range: tableRange,
           detail: `Table (${table.rowCount} rows)`,
           documentation: table.columnNames,

--- a/src/lib/editor/sql-completions.ts
+++ b/src/lib/editor/sql-completions.ts
@@ -7,6 +7,8 @@
 
 import type * as Monaco from "monaco-editor";
 import { extractAliases, resolveAlias } from "@/lib/sql";
+import { quoteIdentifier } from "@/lib/sql/identifier";
+import type { DatabaseType } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Static constants
@@ -207,6 +209,7 @@ export interface SchemaCompletionCache {
 export function registerSQLCompletionProvider(
   monaco: typeof Monaco,
   schemaCompletionCache: SchemaCompletionCache,
+  databaseType?: DatabaseType,
 ): Monaco.IDisposable {
   return monaco.languages.registerCompletionItemProvider("sql", {
     triggerCharacters: [".", " "],
@@ -239,7 +242,15 @@ export function registerSQLCompletionProvider(
         .map((table) => ({
           label: table.label,
           kind: monaco.languages.CompletionItemKind.Class,
-          insertText: table.label,
+          // PostgreSQL folds unquoted identifiers to lowercase. Schema labels
+          // preserve catalog spelling, so quote each component before insertion.
+          insertText:
+            databaseType === "postgres"
+              ? table.label
+                  .split(".")
+                  .map((part) => quoteIdentifier(part, databaseType))
+                  .join(".")
+              : table.label,
           range: tableRange,
           detail: `Table (${table.rowCount} rows)`,
           documentation: table.columnNames,
@@ -248,9 +259,9 @@ export function registerSQLCompletionProvider(
 
       // Dot-triggered: Show columns for specific table or alias
       if (lastChar === ".") {
-        const matches = line.substring(0, position.column - 1).match(/(\w+)\.$/);
+        const matches = line.substring(0, position.column - 1).match(/(?:"((?:[^"]|"")+)"|(\w+))\.$/);
         if (matches) {
-          const identifier = matches[1].toLowerCase();
+          const identifier = (matches[1]?.replace(/""/g, '"') ?? matches[2]).toLowerCase();
 
           // Helper to find columns by table name (handles schema.table format)
           const findColumns = (tableName: string) => {

--- a/src/lib/editor/sql-completions.ts
+++ b/src/lib/editor/sql-completions.ts
@@ -254,10 +254,13 @@ export function registerSQLCompletionProvider(
 
       // Dot-triggered: Show columns for specific table or alias
       if (lastChar === ".") {
-        const matches = line.substring(0, position.column - 1).match(/(?:"((?:[^"]|"")+)"|(\w+))\.$/);
-        if (matches) {
-          const identifier = (matches[1]?.replace(/""/g, '"') ?? matches[2]).toLowerCase();
-
+        const textToDot = line.substring(0, position.column - 1);
+        // Only PostgreSQL completions introduce quoted table names in this PR.
+        // Other dialects retain their existing bare-identifier lookup.
+        const quotedIdentifier =
+          databaseType === "postgres" ? textToDot.match(/"((?:[^"]|"")+)"\.$/)?.[1].replace(/""/g, '"') : undefined;
+        const identifier = (quotedIdentifier ?? textToDot.match(/(\w+)\.$/)?.[1])?.toLowerCase();
+        if (identifier) {
           // Helper to find columns by table name (handles schema.table format)
           const findColumns = (tableName: string) => {
             const tableNameLower = tableName.toLowerCase();

--- a/tests/components/QueryEditor.test.tsx
+++ b/tests/components/QueryEditor.test.tsx
@@ -1898,19 +1898,41 @@ describe("QueryEditor", () => {
 });
 
 describe("QueryEditor completion dialect", () => {
-  test("registers completions again when the connection dialect changes", () => {
-    mockUseMonacoReturn = { Range: class {} };
-    mockRegisterSQLCompletionProvider.mockClear();
-    const { rerender, unmount } = render(
-      React.createElement(QueryEditor, createDefaultProps({ databaseType: "postgres" })),
-    );
-    expect(mockRegisterSQLCompletionProvider).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.anything(),
-      "postgres",
-    );
-    rerender(React.createElement(QueryEditor, createDefaultProps({ databaseType: "mysql" })));
-    expect(mockRegisterSQLCompletionProvider).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), "mysql");
-    unmount();
-  });
+  test.each(["mysql", "sqlite", "duckdb", "mssql", "oracle"] as const)(
+    "disposes and replaces completions when switching PostgreSQL to %s and back",
+    (dialect) => {
+      mockUseMonacoReturn = { Range: class {} };
+      mockRegisterSQLCompletionProvider.mockClear();
+      const { rerender, unmount } = render(
+        React.createElement(QueryEditor, createDefaultProps({ databaseType: "postgres" })),
+      );
+      expect(mockRegisterSQLCompletionProvider).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.anything(),
+        "postgres",
+      );
+      const postgresRegistration = mockRegisterSQLCompletionProvider.mock.results[0].value as ReturnType<
+        typeof mockRegisterSQLCompletionProvider
+      >;
+      rerender(React.createElement(QueryEditor, createDefaultProps({ databaseType: dialect })));
+      expect(postgresRegistration.dispose).toHaveBeenCalledTimes(1);
+      expect(mockRegisterSQLCompletionProvider).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), dialect);
+      const otherRegistration = mockRegisterSQLCompletionProvider.mock.results[1].value as ReturnType<
+        typeof mockRegisterSQLCompletionProvider
+      >;
+      rerender(React.createElement(QueryEditor, createDefaultProps({ databaseType: "postgres" })));
+      expect(otherRegistration.dispose).toHaveBeenCalledTimes(1);
+      expect(mockRegisterSQLCompletionProvider).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.anything(),
+        "postgres",
+      );
+      expect(mockRegisterSQLCompletionProvider).toHaveBeenCalledTimes(3);
+      const finalRegistration = mockRegisterSQLCompletionProvider.mock.results[2].value as ReturnType<
+        typeof mockRegisterSQLCompletionProvider
+      >;
+      unmount();
+      expect(finalRegistration.dispose).toHaveBeenCalledTimes(1);
+    },
+  );
 });

--- a/tests/components/QueryEditor.test.tsx
+++ b/tests/components/QueryEditor.test.tsx
@@ -173,8 +173,9 @@ mock.module("sql-formatter", () => ({
 }));
 
 // ── Mock editor/sql-completions ─────────────────────────────────────────────
+const mockRegisterSQLCompletionProvider = mock((..._args: unknown[]) => ({ dispose: mock(() => {}) }));
 mock.module("@/lib/editor/sql-completions", () => ({
-  registerSQLCompletionProvider: mock(() => ({ dispose: mock(() => {}) })),
+  registerSQLCompletionProvider: mockRegisterSQLCompletionProvider,
 }));
 
 // ── Mock editor/mongodb-completions ─────────────────────────────────────────
@@ -1893,5 +1894,23 @@ describe("QueryEditor", () => {
     const schema = JSON.stringify([{ name: "empty", columns: [{ name: "id", type: "int", isPrimary: true }] }]);
     const { queryByTestId } = render(React.createElement(QueryEditor, createDefaultProps({ schemaContext: schema })));
     expect(queryByTestId("mock-monaco-editor")).not.toBeNull();
+  });
+});
+
+describe("QueryEditor completion dialect", () => {
+  test("registers completions again when the connection dialect changes", () => {
+    mockUseMonacoReturn = { Range: class {} };
+    mockRegisterSQLCompletionProvider.mockClear();
+    const { rerender, unmount } = render(
+      React.createElement(QueryEditor, createDefaultProps({ databaseType: "postgres" })),
+    );
+    expect(mockRegisterSQLCompletionProvider).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "postgres",
+    );
+    rerender(React.createElement(QueryEditor, createDefaultProps({ databaseType: "mysql" })));
+    expect(mockRegisterSQLCompletionProvider).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), "mysql");
+    unmount();
   });
 });

--- a/tests/unit/sql-completions.test.ts
+++ b/tests/unit/sql-completions.test.ts
@@ -535,3 +535,66 @@ describe("Empty schema cache", () => {
     expect(labels).toContain("SELECT");
   });
 });
+
+describe("PostgreSQL table completion quoting", () => {
+  test.each([
+    [
+      "SELECT * FROM ",
+      "My_Schema_With_Caps.My_Table_With_Caps",
+      'SELECT * FROM "My_Schema_With_Caps"."My_Table_With_Caps"',
+    ],
+    [
+      "SELECT * FROM My_Schema_With_Caps.My_T",
+      "My_Schema_With_Caps.My_Table_With_Caps",
+      'SELECT * FROM "My_Schema_With_Caps"."My_Table_With_Caps"',
+    ],
+    [
+      "SELECT * FROM My_Schema_With_Caps.",
+      "My_Schema_With_Caps.My_Table_With_Caps",
+      'SELECT * FROM "My_Schema_With_Caps"."My_Table_With_Caps"',
+    ],
+    ["SELECT * FROM public.My_T", "My_Table_With_Caps", 'SELECT * FROM public."My_Table_With_Caps"'],
+    ["SELECT * FROM ", 'Odd"Schema.Order Details', 'SELECT * FROM "Odd""Schema"."Order Details"'],
+    ["SELECT * FROM ", "select", 'SELECT * FROM "select"'],
+    ["SELECT * FROM sample.dem", "sample.demo", 'SELECT * FROM "sample"."demo"'],
+  ])("quotes the applied PostgreSQL edit for %s / %s", (line, label, expected) => {
+    const monaco = createMockMonaco();
+    registerSQLCompletionProvider(
+      monaco,
+      createSchemaCache({
+        tableItems: [{ label, labelLower: label.toLowerCase(), rowCount: 1, columnNames: "id" }],
+      }),
+      "postgres",
+    );
+    const result = monaco
+      ._getProvider()!
+      .provideCompletionItems(createMockModel(line), createPosition(1, line.length + 1));
+    const suggestion = result.suggestions.find((item) => item.label === label)!;
+    expect(suggestion).toBeDefined();
+    const range = suggestion.range as Monaco.IRange;
+    expect(line.slice(0, range.startColumn - 1) + suggestion.insertText + line.slice(range.endColumn - 1)).toBe(
+      expected,
+    );
+  });
+
+  test("leaves other dialects unchanged", () => {
+    const monaco = createMockMonaco();
+    registerSQLCompletionProvider(monaco, createSchemaCache(), "mysql");
+    const line = "SELECT * FROM us";
+    const result = monaco
+      ._getProvider()!
+      .provideCompletionItems(createMockModel(line), createPosition(1, line.length + 1));
+    expect(result.suggestions.find((item) => item.label === "users")!.insertText).toBe("users");
+  });
+});
+
+describe("Quoted PostgreSQL table column lookup", () => {
+  test.each(['SELECT "users".', 'SELECT "public"."users".'])("retains column suggestions after %s", (line) => {
+    const monaco = createMockMonaco();
+    registerSQLCompletionProvider(monaco, createSchemaCache(), "postgres");
+    const result = monaco
+      ._getProvider()!
+      .provideCompletionItems(createMockModel(line), createPosition(1, line.length + 1));
+    expect(result.suggestions.map((item) => item.label)).toEqual(["id", "name", "email"]);
+  });
+});

--- a/tests/unit/sql-completions.test.ts
+++ b/tests/unit/sql-completions.test.ts
@@ -556,7 +556,7 @@ describe("PostgreSQL table completion quoting", () => {
     ["SELECT * FROM public.My_T", "My_Table_With_Caps", 'SELECT * FROM public."My_Table_With_Caps"'],
     ["SELECT * FROM ", 'Odd"Schema.Order Details', 'SELECT * FROM "Odd""Schema"."Order Details"'],
     ["SELECT * FROM ", "select", 'SELECT * FROM "select"'],
-    ["SELECT * FROM sample.dem", "sample.demo", 'SELECT * FROM "sample"."demo"'],
+    ["SELECT * FROM sample.dem", "sample.demo", "SELECT * FROM sample.demo"],
   ])("quotes the applied PostgreSQL edit for %s / %s", (line, label, expected) => {
     const monaco = createMockMonaco();
     registerSQLCompletionProvider(
@@ -585,6 +585,74 @@ describe("PostgreSQL table completion quoting", () => {
       ._getProvider()!
       .provideCompletionItems(createMockModel(line), createPosition(1, line.length + 1));
     expect(result.suggestions.find((item) => item.label === "users")!.insertText).toBe("users");
+  });
+});
+
+describe("PostgreSQL selective identifier quoting", () => {
+  test.each([
+    ["user_authority", "user_authority"],
+    ["authschema.users", "authschema.users"],
+    ["public.orders", "public.orders"],
+    ["authschema.UserAuthority", 'authschema."UserAuthority"'],
+    ["AuthSchema.users", '"AuthSchema".users'],
+    ["USER_AUTHORITY", '"USER_AUTHORITY"'],
+    ["UserAuthority", '"UserAuthority"'],
+    ["abort", "abort"],
+    ["name$1", '"name$1"'],
+    ["_items_2", "_items_2"],
+    ["user", '"user"'],
+    ["authorization", '"authorization"'],
+    ["between", '"between"'],
+    ["select", '"select"'],
+    ["current_user", '"current_user"'],
+    ["1st_table", '"1st_table"'],
+    ["order details", '"order details"'],
+    ['odd"name', '"odd""name"'],
+    ["café", '"café"'],
+  ])("formats %s following PostgreSQL quote_ident", (label, expected) => {
+    const monaco = createMockMonaco();
+    registerSQLCompletionProvider(
+      monaco,
+      createSchemaCache({
+        tableItems: [{ label, labelLower: label.toLowerCase(), rowCount: 1, columnNames: "id" }],
+      }),
+      "postgres",
+    );
+    const line = "SELECT * FROM ";
+    const result = monaco
+      ._getProvider()!
+      .provideCompletionItems(createMockModel(line), createPosition(1, line.length + 1));
+    const suggestion = result.suggestions.find((item) => item.label === label)!;
+    expect(suggestion.label).toBe(label);
+    const range = suggestion.range as Monaco.IRange;
+    expect(line.slice(0, range.startColumn - 1) + suggestion.insertText).toBe("SELECT * FROM " + expected);
+  });
+
+  test("an uppercase typed prefix still matches an ordinary lowercase catalog name", () => {
+    const monaco = createMockMonaco();
+    registerSQLCompletionProvider(
+      monaco,
+      createSchemaCache({
+        tableItems: [
+          {
+            label: "authschema.user_authority",
+            labelLower: "authschema.user_authority",
+            rowCount: 1,
+            columnNames: "id",
+          },
+        ],
+      }),
+      "postgres",
+    );
+    const line = "SELECT * FROM AUTHSCHEMA.USER_A";
+    const result = monaco
+      ._getProvider()!
+      .provideCompletionItems(createMockModel(line), createPosition(1, line.length + 1));
+    const suggestion = result.suggestions.find((item) => item.label === "authschema.user_authority")!;
+    const range = suggestion.range as Monaco.IRange;
+    expect(line.slice(0, range.startColumn - 1) + suggestion.insertText).toBe(
+      "SELECT * FROM authschema.user_authority",
+    );
   });
 });
 

--- a/tests/unit/sql-completions.test.ts
+++ b/tests/unit/sql-completions.test.ts
@@ -1,6 +1,7 @@
 import "../setup";
 import { describe, test, expect } from "bun:test";
 import type * as Monaco from "monaco-editor";
+import { SHIPPED_DATABASE_TYPES } from "@/lib/db/compatibility";
 import {
   SQL_KEYWORDS,
   SQL_FUNCTIONS,
@@ -664,5 +665,64 @@ describe("Quoted PostgreSQL table column lookup", () => {
       ._getProvider()!
       .provideCompletionItems(createMockModel(line), createPosition(1, line.length + 1));
     expect(result.suggestions.map((item) => item.label)).toEqual(["id", "name", "email"]);
+  });
+});
+
+describe("Completion dialect compatibility", () => {
+  // Include the legacy caller without a dialect as well as every non-Postgres
+  // registration. This is provider behavior coverage, not live-engine coverage.
+  const otherDialects = [...SHIPPED_DATABASE_TYPES.filter((type) => type !== "postgres"), undefined];
+
+  test.each(otherDialects)("%s preserves table insertion and qualified replacement", (dialect) => {
+    const monaco = createMockMonaco();
+    const label = "Sales.OrderDetails";
+    registerSQLCompletionProvider(
+      monaco,
+      createSchemaCache({ tableItems: [{ label, labelLower: label.toLowerCase(), rowCount: 1, columnNames: "id" }] }),
+      dialect,
+    );
+    for (const line of ["SELECT * FROM ", "SELECT * FROM Sal", "SELECT * FROM Sales.", "SELECT * FROM Sales.Ord"]) {
+      const result = monaco
+        ._getProvider()!
+        .provideCompletionItems(createMockModel(line), createPosition(1, line.length + 1));
+      const suggestion = result.suggestions.find((item) => item.label === label)!;
+      expect(suggestion.insertText).toBe(label);
+      const range = suggestion.range as Monaco.IRange;
+      expect(line.slice(0, range.startColumn - 1) + suggestion.insertText).toBe("SELECT * FROM Sales.OrderDetails");
+    }
+  });
+
+  test.each(otherDialects)("%s retains bare column lookup and existing delimiter behavior", (dialect) => {
+    const monaco = createMockMonaco();
+    registerSQLCompletionProvider(monaco, createSchemaCache(), dialect);
+    for (const [line, fullText, expected] of [
+      ["SELECT users.", "SELECT users.", ["id", "name", "email"]],
+      ["SELECT u.", "SELECT u. FROM users u", ["id", "name", "email"]],
+      ["SELECT public.products.", "SELECT public.products.", ["id", "price"]],
+      ['SELECT "users".', 'SELECT "users".', []],
+      ['SELECT "public"."users".', 'SELECT "public"."users".', []],
+      ["SELECT `users`.", "SELECT `users`.", []],
+      ["SELECT [users].", "SELECT [users].", []],
+      ["SELECT missing.", "SELECT missing.", []],
+    ] as const) {
+      const result = monaco
+        ._getProvider()!
+        .provideCompletionItems(createMockModel(line, fullText), createPosition(1, line.length + 1));
+      expect(result.suggestions.map((item) => item.label)).toEqual([...expected]);
+    }
+  });
+
+  test("PostgreSQL keeps escaped quoted-name lookup", () => {
+    const monaco = createMockMonaco();
+    const cache = createSchemaCache();
+    cache.columnMap.set('odd"name', [
+      { label: "marker", labelLower: "marker", type: "text", isPrimary: false, tableName: 'Odd"Name' },
+    ]);
+    registerSQLCompletionProvider(monaco, cache, "postgres");
+    const line = 'SELECT "Odd""Name".';
+    const result = monaco
+      ._getProvider()!
+      .provideCompletionItems(createMockModel(line), createPosition(1, line.length + 1));
+    expect(result.suggestions.map((item) => item.label)).toEqual(["marker"]);
   });
 });


### PR DESCRIPTION
PostgreSQL table suggestions insert catalog names verbatim, so accepting `My_Schema_With_Caps.My_Table_With_Caps` produces unquoted SQL that resolves to lowercase names. This also reproduces with the completion provider from before #715 (base `4c5f6577`). Follow-up to the report in #705: https://github.com/libredb/libredb-studio/issues/705#issuecomment-5628323980.

Pass the editor's connection dialect into the completion provider and format PostgreSQL table-name components using PostgreSQL 18's conservative `quote_ident` rule. Ordinary lowercase names remain unquoted (`authschema.user_authority`); case-sensitive names retain their required quotes (`authschema."UserAuthority"`, `"USER_AUTHORITY"`); keywords and special characters are escaped. The keyword categories come from PostgreSQL's parser keyword list, separate from the editor's suggestion list. The shared unconditional identifier-quoter keeps its existing semantics.

Keep display labels and filtering separate from inserted SQL, preserve qualified replacement ranges and bare-label fallback, recognize quoted table names when offering columns after a dot only for PostgreSQL, and re-register when the connection dialect changes. Other dialects keep their existing insertion behavior.

The quoting decision uses the catalog name, not the case of the typed prefix. PostgreSQL stores `CREATE TABLE USER_AUTHORITY (...)` as `user_authority`; its completion is bare. A table explicitly created as `"USER_AUTHORITY"` is a distinct object and its completion retains quotes.

## Testing

- Regression-first: the selective-quoting expectations failed against the original blanket-quoting implementation. Revised focused provider selection: **80 pass, 0 fail**. New helper: **7/7 executable lines covered** in the focused coverage run.
- Native PostgreSQL **18.4** on macOS (verified on prior revision `1a63657a`): **45 autocomplete-generated queries** across `public`, `authschema`, and quoted `"AuthSchema"`, with distinct marker rows verifying the selected object. **9 unquoted spelling controls** also passed. Cache built from real `information_schema` names using the adapter's existing display-label convention; completion provider bundled from the revised source, Monaco word/range modeled for this matrix.
- Formatter output matched native `quote_ident` for **all 494 server keywords and 13 additional identifier cases**.
- Actual installed Monaco in an isolated browser fixture (prior revision `1a63657a`): accepted suggestions and executed the resulting SQL against the same PostgreSQL instance for **7 cases**: lowercase, uppercase typed prefix, mixed-case table, quoted uppercase table, quoted schema, keyword, and schema-dot trigger. All returned the intended marker. This is a real Monaco/provider interaction test, not full-application E2E.
- Format, lint, typecheck, knip, chart/check, channels/showcase/check, readme/check, and security/check passed. Lint retains existing warnings.
- Production build, library build, and package type-resolution check (`attw`) passed.
- `bun run test`: **15,122 pass, 0 fail**, including all 35 isolated component groups. Temporary local Helm 4.1.3, 7-Zip 26.03, and the locked chart dependency were installed before the successful complete run.

The implementation retains the provider's existing dot-delimited table-label representation. It does not redesign schema metadata, handle literal dots within individual identifier components, add completion of partially quoted input, or quote column suggestions. Full application E2E and the repository-wide coverage gate were not run locally; CI remains the merge gate.

AI-assisted implementation and validation.


## Cross-database follow-up

Both new quoted table insertion and new quoted-name column lookup are restricted to PostgreSQL. The latter was initially shared; this revision restores the pre-PR bare-name lookup for every other dialect and callers without a dialect.

- Regression-first: 17 compatibility cases failed before restricting the lookup; all pass afterward. The committed tests cover table insertion, qualified replacement, bare table/alias columns, previous delimiter behavior, and escaped PostgreSQL names.
- Differential probe: **544 complete-suggestion comparisons** match pre-PR `37fada54` across all 16 non-PostgreSQL registration settings plus the unspecified-dialect fallback (32 inputs each). This includes defensive registrations for non-SQL type IDs, not a claim that all 16 use the SQL editor. Insertion text, ranges, labels and other suggestion fields were compared. A separate **32-case PostgreSQL comparison** matches prior revision `1a63657a`. These use a modeled Monaco interface and a synthetic cache.
- Component tests check PostgreSQL to MySQL/SQLite/DuckDB/SQL Server/Oracle and back, verifying old-provider disposal, new dialect registration, and unmount cleanup.
- Live **SQLite 3.51.0** and **DuckDB v1.5.5**: fresh native in-process databases accessed through the real LibreDB providers and their `getSchema()`/`query()` methods. **28 completion-generated queries** returned expected marker rows (12 SQLite, 16 DuckDB), covering ordinary lowercase, mixed/uppercase names, direct/alias column completion, and DuckDB non-default-schema tables. Before/after suggestion objects matched. The cache mirrors QueryEditor and Monaco word/range is modeled; these are not browser UI checks.
- Known limitations explicitly retained: **10 generated queries for special/keyword names were rejected as expected**, with identical pre-PR/revised insertion text. Two manually quoted SQL controls succeeded, while both provider versions offer no quoted-dot column completion for these engines. SQLite's unchanged catalog reader also errors on a table containing an embedded double quote; that disposable fixture table was removed after recording the error so remaining checks could run. This PR does not repair those unrelated non-PostgreSQL limitations.
- No live MySQL, SQL Server, Oracle, or other server-engine compatibility checks were run locally. Those dialects have completion-provider regression checks, not full end-to-end engine coverage.
