### PR TITLE
feat: add pivot table CSV and JSON export

### DIFF
--- a/src/components/PivotTable.tsx
+++ b/src/components/PivotTable.tsx
@@ -121,11 +121,7 @@ export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProp
 
       const headers = [
         rowField,
-        ...pivotData.colKeys.map((ck) =>
-          ck === "__all__"
-            ? `${AGG_LABELS[aggFunction]}(${valueField || "*"})`
-            : ck,
-        ),
+        ...pivotData.colKeys.map((ck) => (ck === "__all__" ? `${AGG_LABELS[aggFunction]}(${valueField || "*"})` : ck)),
       ];
 
       const rows = pivotData.pivotRows.map((row) => [
@@ -141,7 +137,6 @@ export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProp
     },
     [pivotData, rowField, valueField, aggFunction],
   );
-
 
   // Generate SQL
   const generateSQL = useCallback(() => {
@@ -283,12 +278,8 @@ export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProp
             </DropdownMenuTrigger>
 
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => exportPivot("csv")}>
-                Export as CSV
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => exportPivot("json")}>
-                Export as JSON
-              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => exportPivot("csv")}>Export as CSV</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => exportPivot("json")}>Export as JSON</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/src/components/PivotTable.tsx
+++ b/src/components/PivotTable.tsx
@@ -1,11 +1,19 @@
 "use client";
 
 import React, { useState, useMemo, useCallback, useEffect } from "react";
-import { Columns3, GripVertical, ArrowRight } from "lucide-react";
+import { Columns3, GripVertical, ArrowRight, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DatabaseType, QueryResult } from "@/lib/types";
 import { quoteLiteral } from "@/lib/sql/values";
 import { quoteIdentifier } from "@/lib/sql/identifier";
+import { downloadText } from "@/lib/export/download";
+import { pivotTableText } from "@/lib/export/pivot-table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface PivotTableProps {
   result: QueryResult | null;
@@ -106,6 +114,34 @@ export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProp
 
     return { colKeys, pivotRows };
   }, [rows, rowField, colField, valueField, aggFunction]);
+
+  const exportPivot = useCallback(
+    (format: "csv" | "json") => {
+      if (!pivotData || !rowField) return;
+
+      const headers = [
+        rowField,
+        ...pivotData.colKeys.map((ck) =>
+          ck === "__all__"
+            ? `${AGG_LABELS[aggFunction]}(${valueField || "*"})`
+            : ck,
+        ),
+      ];
+
+      const rows = pivotData.pivotRows.map((row) => [
+        row.rowKey,
+        ...pivotData.colKeys.map((ck) => row.values.get(ck) || "0"),
+      ]);
+
+      downloadText(
+        pivotTableText(headers, rows, format),
+        format === "csv" ? "text/csv" : "application/json",
+        `pivot_table_${Date.now()}.${format}`,
+      );
+    },
+    [pivotData, rowField, valueField, aggFunction],
+  );
+
 
   // Generate SQL
   const generateSQL = useCallback(() => {
@@ -233,6 +269,28 @@ export function PivotTable({ result, onLoadQuery, databaseType }: PivotTableProp
           >
             <ArrowRight strokeWidth={1.5} className="w-3 h-3" /> Generate SQL
           </button>
+        )}
+        {pivotData && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium rounded-md hover:bg-surface-hover"
+              >
+                <Download className="w-3.5 h-3.5" />
+                Export
+              </button>
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => exportPivot("csv")}>
+                Export as CSV
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => exportPivot("json")}>
+                Export as JSON
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
       </div>
 

--- a/src/lib/export/pivot-table.ts
+++ b/src/lib/export/pivot-table.ts
@@ -1,0 +1,17 @@
+import { csvRow } from "./csv";
+import { jsonText } from "./json";
+
+export function pivotTableText(
+    headers: readonly string[],
+    rows: readonly (readonly unknown[])[],
+    format: "csv" | "json",
+): string {
+    if (format === "json") {
+        const records = rows.map((row) =>
+            Object.fromEntries(headers.map((header, index) => [header, row[index]])),
+        );
+        return jsonText(records, 2);
+    }
+
+    return [csvRow(headers), ...rows.map((row) => csvRow(row))].join("\n");
+}

--- a/src/lib/export/pivot-table.ts
+++ b/src/lib/export/pivot-table.ts
@@ -2,16 +2,14 @@ import { csvRow } from "./csv";
 import { jsonText } from "./json";
 
 export function pivotTableText(
-    headers: readonly string[],
-    rows: readonly (readonly unknown[])[],
-    format: "csv" | "json",
+  headers: readonly string[],
+  rows: readonly (readonly unknown[])[],
+  format: "csv" | "json",
 ): string {
-    if (format === "json") {
-        const records = rows.map((row) =>
-            Object.fromEntries(headers.map((header, index) => [header, row[index]])),
-        );
-        return jsonText(records, 2);
-    }
+  if (format === "json") {
+    const records = rows.map((row) => Object.fromEntries(headers.map((header, index) => [header, row[index]])));
+    return jsonText(records, 2);
+  }
 
-    return [csvRow(headers), ...rows.map((row) => csvRow(row))].join("\n");
+  return [csvRow(headers), ...rows.map((row) => csvRow(row))].join("\n");
 }

--- a/tests/components/PivotTable.test.tsx
+++ b/tests/components/PivotTable.test.tsx
@@ -5,6 +5,41 @@ import "../helpers/mock-navigation";
 import React from "react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render, fireEvent } from "@testing-library/react";
+
+const mockDownloadText = mock(
+  (_content: string, _mimeType: string, _fileName: string) => { },
+);
+mock.module("@/lib/export/download", () => ({
+  downloadText: mockDownloadText,
+}));
+
+mock.module("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div>{children}</div>,
+  DropdownMenuContent: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
 import { PivotTable, aggregate } from "@/components/PivotTable";
 import type { QueryResult } from "@/lib/types";
 
@@ -23,6 +58,45 @@ const result: QueryResult = {
 describe("PivotTable", () => {
   afterEach(() => {
     cleanup();
+    mockDownloadText.mockClear();
+  });
+
+  test("exports the configured pivot table as CSV", () => {
+    const { getByText } = render(<PivotTable result={result} />);
+
+    fireEvent.click(getByText("Export as CSV"));
+
+    expect(mockDownloadText).toHaveBeenCalledTimes(1);
+
+    const [content, mimeType, fileName] = mockDownloadText.mock.calls[0];
+
+    expect(mimeType).toBe("text/csv");
+    expect(fileName).toMatch(/^pivot_table_\d+\.csv$/);
+    expect(content).toContain("dept");
+    expect(content).toContain("COUNT(salary)");
+    expect(content).toContain("Engineering");
+    expect(content).toContain("Sales");
+    expect(content).toContain("2");
+  });
+
+  test("exports the configured pivot table as JSON", () => {
+    const { getByText } = render(<PivotTable result={result} />);
+
+    fireEvent.click(getByText("Export as JSON"));
+
+    expect(mockDownloadText).toHaveBeenCalledTimes(1);
+
+    const [content, mimeType, fileName] = mockDownloadText.mock.calls[0];
+
+    expect(mimeType).toBe("application/json");
+    expect(fileName).toMatch(/^pivot_table_\d+\.json$/);
+
+    const exported = JSON.parse(content);
+
+    expect(exported).toEqual([
+      { dept: "Engineering", "COUNT(salary)": "2" },
+      { dept: "Sales", "COUNT(salary)": "2" },
+    ]);
   });
 
   test("shows empty state when result is null", () => {
@@ -124,7 +198,7 @@ describe("PivotTable", () => {
   });
 
   test("Generate SQL button appears when onLoadQuery provided and row selected", () => {
-    const onLoadQuery = mock(() => {});
+    const onLoadQuery = mock(() => { });
     const { queryByText } = render(<PivotTable result={result} onLoadQuery={onLoadQuery} />);
     expect(queryByText("Generate SQL")).not.toBeNull();
   });

--- a/tests/components/PivotTable.test.tsx
+++ b/tests/components/PivotTable.test.tsx
@@ -6,34 +6,16 @@ import React from "react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render, fireEvent } from "@testing-library/react";
 
-const mockDownloadText = mock(
-  (_content: string, _mimeType: string, _fileName: string) => { },
-);
+const mockDownloadText = mock((_content: string, _mimeType: string, _fileName: string) => {});
 mock.module("@/lib/export/download", () => ({
   downloadText: mockDownloadText,
 }));
 
 mock.module("@/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  DropdownMenuTrigger: ({
-    children,
-  }: {
-    children: React.ReactNode;
-  }) => <div>{children}</div>,
-  DropdownMenuContent: ({
-    children,
-  }: {
-    children: React.ReactNode;
-  }) => <div>{children}</div>,
-  DropdownMenuItem: ({
-    children,
-    onClick,
-  }: {
-    children: React.ReactNode;
-    onClick?: () => void;
-  }) => (
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
     <button type="button" onClick={onClick}>
       {children}
     </button>
@@ -198,7 +180,7 @@ describe("PivotTable", () => {
   });
 
   test("Generate SQL button appears when onLoadQuery provided and row selected", () => {
-    const onLoadQuery = mock(() => { });
+    const onLoadQuery = mock(() => {});
     const { queryByText } = render(<PivotTable result={result} onLoadQuery={onLoadQuery} />);
     expect(queryByText("Generate SQL")).not.toBeNull();
   });


### PR DESCRIPTION
## Summary

* Add CSV and JSON export options to the Pivot Table view.
* Export the pivot table using its currently configured rows, columns, and aggregation.
* Reuse the existing CSV/JSON export utilities.
* Add component tests covering CSV and JSON exports.

## Testing

* `bun test tests/components/PivotTable.test.tsx` — 38 passed, 0 failed
* `bun run typecheck` — passed
* `git diff --check` — passed
* `bun run test` — 10,779 passed, 506 failed, 6 errors (existing unrelated repository test failures)


Closes: #749 
