### PR TITLE
docs(readme): add the live Apache Cloudberry listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@
   Also listed in official
   <a href="https://redis.io/docs/latest/develop/tools/#libredb-studio">Redis</a>,
   <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>
-  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>
-  and
+  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>,
   <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>
+  and
+  <a href="https://cloudberry.apache.org/docs/ecosystem/sql-clients/libredb-studio/">Apache Cloudberry</a>
   docs
 </p>
 

--- a/README_es.md
+++ b/README_es.md
@@ -28,9 +28,10 @@
   Listado también en la documentación oficial de
   <a href="https://redis.io/docs/latest/develop/tools/#libredb-studio">Redis</a>,
   <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>
-  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>
-  y
+  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>,
   <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>
+  y
+  <a href="https://cloudberry.apache.org/docs/ecosystem/sql-clients/libredb-studio/">Apache Cloudberry</a>
 </p>
 
 <p align="center">

--- a/README_ja.md
+++ b/README_ja.md
@@ -28,7 +28,8 @@
   <a href="https://redis.io/docs/latest/develop/tools/#libredb-studio">Redis</a>、
   <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>、
   <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>、
-  <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>
+  <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>、
+  <a href="https://cloudberry.apache.org/docs/ecosystem/sql-clients/libredb-studio/">Apache Cloudberry</a>
   の公式ドキュメントにも掲載
 </p>
 

--- a/README_ur.md
+++ b/README_ur.md
@@ -27,9 +27,11 @@
 <p align="center" dir="rtl">
   اس کے علاوہ
   <a href="https://redis.io/docs/latest/develop/tools/#libredb-studio">Redis</a>،
-  <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>
+  <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>،
+  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>،
+  <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>
   اور
-  <a href="https://druid.apache.org/libraries">Apache Druid</a>
+  <a href="https://cloudberry.apache.org/docs/ecosystem/sql-clients/libredb-studio/">Apache Cloudberry</a>
   کی سرکاری دستاویزات میں بھی درج ہے
 </p>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -28,9 +28,10 @@
   同时列入
   <a href="https://redis.io/docs/latest/develop/tools/#libredb-studio">Redis</a>、
   <a href="https://clickhouse.com/docs/integrations/connectors/tools/gui#libredb-studio">ClickHouse</a>、
-  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>
-  和
+  <a href="https://mariadb.com/docs/server/clients-and-utilities/graphical-and-enhanced-clients/libredb-studio">MariaDB</a>、
   <a href="https://trino.io/ecosystem/client-application#libredb-studio">Trino</a>
+  和
+  <a href="https://cloudberry.apache.org/docs/ecosystem/sql-clients/libredb-studio/">Apache Cloudberry</a>
   官方文档
 </p>
 


### PR DESCRIPTION
## Description

apache/cloudberry-site#399 merged 2026-09-10 and is live on cloudberry.apache.org/docs/ecosystem/sql-clients/libredb-studio. This adds it next to the other official docs in all five READMEs.

While in there, fixed README_ur.md's badge block: it still pointed at the removed Apache Druid link and was missing MariaDB, the same drift #780 already fixed in the other three translations.

## Type of Change

- [x] Documentation update

## Changes Made

- Added the Apache Cloudberry link to the vendor-listing badge block in README.md, README_es.md, README_ja.md, README_zh.md and README_ur.md
- Fixed README_ur.md's stale Druid link and missing MariaDB entry to match the other four files

## Testing

- [x] bun run readme:check passes

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings