### PR TITLE
fix(docker): mount postgres:18 data volumes at the path the image expects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -632,3 +632,16 @@ LLM_MODEL=gemini-2.5-flash
 # bucket, so a single attacker tripping the login limiter locks everyone out
 # until the window closes.
 # TRUST_PROXY_HEADERS=true
+
+# ─── Development Compose Fixtures (#792) ─────────────────────────────────────
+# Read by docker/postgres.yml, database-compose.yml and the root
+# docker-compose.yml's libredb-postgres service — never by the app itself.
+# Both default to today's values (`libredb` in container/volume names, port
+# 5432), so unset keeps every documented command working. Set them together to
+# run the three files side by side, or beside a PostgreSQL you already run:
+# the prefix scopes the container name AND the named data volume, so two
+# prefixed fleets cannot silently share one data directory.
+# The port value interpolates into the full host spec, so an `ip:port` shape
+# (e.g. "127.0.0.1:5433") also pins the bind address — trusted-input only.
+# LIBREDB_CONTAINER_PREFIX=dev
+# LIBREDB_POSTGRES_HOST_PORT=55432

--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ docker compose -f database-compose.yml --profile druid down -v
 
 ### PostgreSQL Sample Data
 
-The `docker/postgres.yml` setup includes a pre-loaded e-commerce schema:
+The `docker/postgres.yml` setup includes a pre-loaded e-commerce schema (since #792, so does the `postgres` service in `database-compose.yml`, which mounts the same `docker/postgres-init/` scripts):
 
 | Feature | Description |
 |---------|-------------|

--- a/database-compose.yml
+++ b/database-compose.yml
@@ -37,14 +37,23 @@ x-druid-env: &druid-env
 services:
   postgres:
     image: postgres:18
-    container_name: libredb-postgres
+    # Container name and host port are parameters (#792): both default to what this
+    # file used before, and the same LIBREDB_CONTAINER_PREFIX /
+    # LIBREDB_POSTGRES_HOST_PORT overrides apply to docker/postgres.yml, which used to
+    # hardcode this exact name and port and so could never run alongside this fleet.
+    container_name: ${LIBREDB_CONTAINER_PREFIX:-libredb}-postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
     ports:
-      - "5432:5432"
+      - "${LIBREDB_POSTGRES_HOST_PORT:-5432}:5432"
+    # The repo's only engine seed script lives in docker/postgres-init/; without this
+    # mount a plain `docker compose up` of this file never applied it, so the two
+    # compose files disagreed about what a development PostgreSQL is. (#792)
+    volumes:
+      - ./docker/postgres-init:/docker-entrypoint-initdb.d:ro
   mongodb:
     image: mongo:latest
     container_name: libredb-mongodb

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -131,7 +131,7 @@ services:
   #     POSTGRES_PASSWORD: postgres
   #     POSTGRES_DB: libredb_storage
   #   volumes:
-  #     - pgdata:/var/lib/postgresql/data
+  #     - pgdata:/var/lib/postgresql
   #   healthcheck:
   #     test: ["CMD-SHELL", "pg_isready -U postgres"]
   #     interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,15 +40,22 @@ services:
 
   libredb-postgres:
     image: postgres:18
-    container_name: libredb-postgres
+    # Same parameterisation as the dev fixtures (#792), same defaults: one
+    # LIBREDB_CONTAINER_PREFIX / LIBREDB_POSTGRES_HOST_PORT override moves all
+    # three files together, so the collision `docs/providers/README.md` records
+    # between this file and the fixture no longer needs a manual rename.
+    container_name: ${LIBREDB_CONTAINER_PREFIX:-libredb}-postgres
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: libredb_storage
     ports:
-      - "5432:5432"
+      - "${LIBREDB_POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      # postgres:18 moved the expected data mount to /var/lib/postgresql (the data
+      # dir is a PGDATA subdirectory of it); the old path restart-loops the 18 image.
+      # Same defect and fix as #792's docker/postgres.yml.
+      - pgdata:/var/lib/postgresql
 
 volumes:
   storage-data:

--- a/docker/postgres.yml
+++ b/docker/postgres.yml
@@ -5,17 +5,37 @@
 #   docker compose -f docker/postgres.yml down
 #   docker compose -f docker/postgres.yml down -v  # Remove volumes too
 #
+# Upgrading from #792's restart-looping state: a failed run may have left a
+# partially-initialized data directory in libredb_postgres_data, which the 18
+# image refuses to start on. Run `down -v` once to clear it; after that the
+# documented command is all you need.
+#
 # Connection:
 #   Host: localhost
-#   Port: 5432
+#   Port: 5432 (override the host side with LIBREDB_POSTGRES_HOST_PORT)
 #   Database: postgres (or libredb_dev)
 #   User: postgres
 #   Password: postgres
+#
+# Running alongside another PostgreSQL (your own, or this repo's
+# database-compose.yml, which publishes the same 5432)? Parameterise instead of
+# stopping it:
+#   LIBREDB_CONTAINER_PREFIX=dev LIBREDB_POSTGRES_HOST_PORT=55432 \
+#     docker compose -f docker/postgres.yml up -d
 
 services:
   postgres:
     image: postgres:18
-    container_name: libredb-postgres
+    # The prefix and the host port are parameters (#792). Both default to what the file
+    # used before, so `docker compose -f docker/postgres.yml up -d` alone is unchanged;
+    # a contributor already running PostgreSQL on 5432, or bringing this file up next to
+    # `database-compose.yml` (which used the same container name and port and so could
+    # never start alongside it), overrides them via the environment:
+    #   LIBREDB_CONTAINER_PREFIX=me LIBREDB_POSTGRES_HOST_PORT=55432 \
+    #     docker compose -f docker/postgres.yml up -d
+    # The prefix also scopes the named volume, so two prefixed fleets on one host cannot
+    # silently share one data directory.
+    container_name: ${LIBREDB_CONTAINER_PREFIX:-libredb}-postgres
     restart: unless-stopped
 
     # Enable pg_stat_statements and other monitoring extensions
@@ -40,11 +60,16 @@ services:
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C"
 
     ports:
-      - "5432:5432"
+      - "${LIBREDB_POSTGRES_HOST_PORT:-5432}:5432"
 
     volumes:
-      # Persistent data volume
-      - libredb_postgres_data:/var/lib/postgresql/data
+      # Persistent data volume. PostgreSQL 18's image wants the mount at
+      # /var/lib/postgresql (the data dir is a PGDATA subdirectory of it); mounting
+      # over the old /var/lib/postgresql/data path makes the 18 image refuse to start
+      # and restart-loop, because it sees a non-empty pgdata directory left over from
+      # a different major. The parent mount is what the image documents for 18+ and is
+      # forward-compatible. (#792)
+      - postgres_data:/var/lib/postgresql
       # Init scripts (executed in alphabetical order on first run)
       - ./postgres-init:/docker-entrypoint-initdb.d:ro
 
@@ -63,6 +88,11 @@ services:
         reservations:
           memory: 256M
 
+# The `name:` is what scopes the volume: the key is a static internal reference
+# (Compose forbids interpolation in mapping keys), while the real volume name carries
+# the prefix, so two prefixed fleets on one host cannot silently share one data
+# directory. The old file pinned `libredb_postgres_data` with no prefix — exactly how
+# #792's `docker/postgres.yml` collided with `database-compose.yml`.
 volumes:
-  libredb_postgres_data:
-    name: libredb_postgres_data
+  postgres_data:
+    name: ${LIBREDB_CONTAINER_PREFIX:-libredb}_postgres_data

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -252,7 +252,7 @@ services:
       - POSTGRES_USER=libredb
       - POSTGRES_PASSWORD=secret
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U libredb"]
       interval: 5s

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -452,4 +452,7 @@ each other by service name, so nothing depends on a published host port existing
 
 One collision to know about if you run both files: that root compose file and the fixture both name a
 container `libredb-postgres`, so the second one to start fails with *"container name is already in
-use"*. Rename one, or run only the fixture and point Studio's `STORAGE_*` variables at it.
+use"* unless you override. Set `LIBREDB_CONTAINER_PREFIX` (and `LIBREDB_POSTGRES_HOST_PORT` if the
+published 5432 is also taken) to move all three files' names, ports and data volume apart with one
+pair of values; without an override they still share `libredb-postgres` and `5432` by design, so run
+only one at a time. Alternatively, run only the fixture and point Studio's `STORAGE_*` variables at it.

--- a/tests/unit/docker-postgres-compose.test.ts
+++ b/tests/unit/docker-postgres-compose.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Drift guard for the development PostgreSQL compose files (#792).
+ *
+ * `docker/postgres.yml` ran `postgres:18` with the data volume mounted at
+ * `/var/lib/postgresql/data`, the pre-18 path. The 18 image moved the expected
+ * mount to `/var/lib/postgresql` (the data dir is a PGDATA subdirectory of it),
+ * so the documented `docker compose -f docker/postgres.yml up -d` restart-looped
+ * on a fresh volume and nobody could bring up the repo's only engine seed.
+ * Reproduced against a live daemon on 2026-09-11: the container emits
+ * "The suggested container configuration for 18+ is to place a single mount at
+ * /var/lib/postgresql" and enters `Restarting (1)`.
+ *
+ * The same file also hardcoded `container_name: libredb-postgres` and
+ * `5432:5432` — identical to `database-compose.yml`'s postgres service — so the
+ * two files could never run side by side, and `database-compose.yml` mounted no
+ * init scripts at all, so the two disagreed about what a development
+ * PostgreSQL is.
+ *
+ * These assertions pin the fixed shape structurally (parsed YAML, not text
+ * greps) so a future edit that reintroduces any of the three defects fails here
+ * rather than in someone's `docker compose up`.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { parse as parseYaml } from "yaml";
+
+type ComposeService = {
+  image?: string;
+  container_name?: string;
+  ports?: string[];
+  volumes?: string[];
+};
+
+type ComposeFile = {
+  services: Record<string, ComposeService>;
+  volumes?: Record<string, { name?: string } | null>;
+};
+
+async function load(path: string): Promise<ComposeFile> {
+  return parseYaml(await Bun.file(path).text()) as ComposeFile;
+}
+
+/** The host-side spec of the first port mapping of a service. Split on the LAST
+ * colon: the compose default-value syntax `${VAR:-5432}` itself contains one. */
+function publishedPort(service: ComposeService): string {
+  const first = service.ports?.[0];
+  expect(first).toBeString();
+  const spec = first as string;
+  return spec.slice(0, spec.lastIndexOf(":"));
+}
+
+describe("docker/postgres.yml (#792)", () => {
+  const file = load("docker/postgres.yml");
+
+  test("mounts the data volume at the postgres:18 expected path, not the pre-18 one", async () => {
+    const postgres = (await file).services.postgres;
+    expect(postgres.image).toBe("postgres:18");
+    const dataMounts = (postgres.volumes ?? []).filter((v) => v.includes("/var/lib/postgresql"));
+    expect(dataMounts.length).toBe(1);
+    // The 18 image refuses /var/lib/postgresql/data as a mount root: it restart-loops.
+    expect(dataMounts[0]).toContain(":/var/lib/postgresql");
+    expect(dataMounts[0]).not.toContain("/var/lib/postgresql/data");
+  });
+
+  test("applies the seed scripts in docker/postgres-init on first run", async () => {
+    const postgres = (await file).services.postgres;
+    expect(postgres.volumes ?? []).toContain("./postgres-init:/docker-entrypoint-initdb.d:ro");
+  });
+
+  test("parameterises container name, host port and volume name with today's values as defaults", async () => {
+    const postgres = (await file).services.postgres;
+    // Defaults keep the documented zero-config command working unchanged...
+    expect(postgres.container_name).toBe("${LIBREDB_CONTAINER_PREFIX:-libredb}-postgres");
+    expect(publishedPort(postgres)).toBe("${LIBREDB_POSTGRES_HOST_PORT:-5432}");
+    // ...while the prefix lets a contributor run this file next to their own
+    // PostgreSQL, or next to database-compose.yml, without a name collision.
+    const volumeName = (await file).volumes?.postgres_data?.name;
+    expect(volumeName).toBe("${LIBREDB_CONTAINER_PREFIX:-libredb}_postgres_data");
+  });
+});
+
+describe("database-compose.yml postgres service (#792)", () => {
+  const file = load("database-compose.yml");
+
+  test("applies the same seed scripts docker/postgres.yml does", async () => {
+    const postgres = (await file).services.postgres;
+    expect(postgres.image).toBe("postgres:18");
+    expect(postgres.volumes ?? []).toContain("./docker/postgres-init:/docker-entrypoint-initdb.d:ro");
+    // Its whole data story: no persistent volume at all (the fixture restarts
+    // stateless), so the init mount is its only one and the seed applies on
+    // every first-init — README's sample-data section now says so for this file
+    // too. Pin the absence so a future edit does not half-mount a data volume
+    // and silently make the seed first-run-only here.
+    expect((postgres.volumes ?? []).length).toBe(1);
+  });
+
+  test("the three files move together under one override (collision at defaults is by design)", async () => {
+    const postgres = (await file).services.postgres;
+    const standalone = (await load("docker/postgres.yml")).services.postgres;
+    const root = (await load("docker-compose.yml")).services["libredb-postgres"];
+    // All three resolve to the SAME container name and host port at their
+    // defaults — that collision is #792's own design choice, recorded in
+    // docs/providers/README.md, not a defect this test hides. What it guards
+    // is the coupling: ONE pair of overrides now separates all three fleets
+    // together; if anyone diverges one file's template, an override that looks
+    // global stops being one.
+    expect(postgres.container_name).toBe(standalone.container_name);
+    expect(publishedPort(postgres)).toBe(publishedPort(standalone));
+    expect(root.container_name).toBe(standalone.container_name);
+    expect(publishedPort(root)).toBe(publishedPort(standalone));
+  });
+});
+
+describe("docker-compose.yml libredb-postgres service (#792, same defect)", () => {
+  test("mounts the data volume at the postgres:18 expected path", async () => {
+    // The storage-backend Postgres at the repo root is active (not commented) and
+    // ran the identical image-plus-path pair; measured on a live daemon, the 18
+    // image exits on the old path exactly as docker/postgres.yml did.
+    const root = (await load("docker-compose.yml")) as ComposeFile & {
+      services: Record<string, ComposeService>;
+    };
+    const postgres = root.services["libredb-postgres"];
+    expect(postgres.image).toBe("postgres:18");
+    const dataMounts = (postgres.volumes ?? []).filter((v) => v.includes("/var/lib/postgresql"));
+    expect(dataMounts.length).toBe(1);
+    expect(dataMounts[0]).toContain(":/var/lib/postgresql");
+    expect(dataMounts[0]).not.toContain("/var/lib/postgresql/data");
+  });
+});


### PR DESCRIPTION
## Description

Closes #792: `docker/postgres.yml` declared `postgres:18` but mounted the data volume at `/var/lib/postgresql/data` — the pre-18 path. The 18 image moved its expected mount to `/var/lib/postgresql` (the data dir is a PGDATA subdirectory of it), so the documented `docker compose -f docker/postgres.yml up -d` restart-looped on a fresh volume, taking the repo's only engine seed (`docker/postgres-init/`) down with it. The issue's two adjacent facts are folded in, and the root `docker-compose.yml`'s active `libredb-postgres` service is fixed too — it carried the identical image-plus-path pair.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Closes #792

## Changes Made

- **docker/postgres.yml**: data mount moved to `/var/lib/postgresql`. Container name, host port and volume name parameterise via `LIBREDB_CONTAINER_PREFIX` / `LIBREDB_POSTGRES_HOST_PORT`, both defaulting to today's values (`libredb-postgres`, `5432`), so the zero-config command is unchanged. The volume `name:` carries the prefix, so two prefixed fleets cannot silently share one data directory. File header gains a one-line upgrade note (`down -v` once to clear a volume a restart-looping run may have left half-initialized).
- **database-compose.yml**: the `postgres` service now mounts `./docker/postgres-init/` at `/docker-entrypoint-initdb.d:ro` (adjacent fact 1 — both compose files apply the seed and agree about what a development PostgreSQL is), and shares the same name/port parameterisation (adjacent fact 2).
- **docker-compose.yml** (root): the active `libredb-postgres` storage-backend service had the same broken mount pair and exits the same way on a fresh volume (measured); moved to the 18 path **and** given the same parameterisation, so one override separates all three files at once — the collision note in `docs/providers/README.md` is updated to say so instead of prescribing a manual rename.
- **docker-compose.example.yml / docs/STORAGE.md**: the commented example block and the copy-pasted example follow the same mount path.
- **.env.example**: both new variables documented per CLAUDE.md's env rule, including the prefix-also-scopes-the-volume coupling and the `ip:port` host-spec caveat.
- **README.md**: the sample-data section notes `database-compose.yml` now seeds too.
- **tests/unit/docker-postgres-compose.test.ts**: new regression guard — 6 tests, structural (parsed YAML, not text greps): mount path per file, init-script mounts, the data-volume absence in database-compose.yml, parameterisation templates with today's defaults, and three-file override coupling.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests
- [ ] All existing tests pass — *locally the unit suite has 196 failures that are identical on clean `origin/main` (macOS environment-dependent chart/sqlite tests; `tests/run-core.sh` needs bash 4 `mapfile` and the macOS system bash is 3.2 — CI's Linux bash is unaffected). This branch adds exactly 6 passing tests and its own file is green: 6/6.*

- **Before (live Docker 29.4.3, 2026-09-11)**: reproduced exactly as the issue says — the container logs "The suggested container configuration for 18+ is to place a single mount at /var/lib/postgresql" and sits in `Restarting (1)`. A throwaway `docker run` proved the failure is the image-plus-path pair itself on a fresh volume, not a stale-data-dir artifact.
- **After**: `up -d` reaches `Up (healthy)`; the seed applies — 14 tables in `app`, `pg_stat_statements` loaded; the documented connection block works unchanged. Side-by-side run verified: default stack on 5432 plus `LIBREDB_CONTAINER_PREFIX=dev LIBREDB_POSTGRES_HOST_PORT=55432` stack on 55432, both healthy, each with its own volume and its own seeded database.
- **Mutation check** (committed state `c5c4332`): the test file run against `origin/main`'s compose files fails 4 of 6; the two passes are invariants that legitimately held before the fix (postgres.yml already had the seed mount; the old files were hardcoded, so they did "move together" by collision — the template assertions that fail old code live in the parameterisation test). All 6 pass on this branch.
- **Gate**: `format`, `lint`, `typecheck`, `knip`, `chart:check`, `channels:showcase:check`, `readme:check`, `security:check`, `env-documentation.test.ts` all pass locally; `docker compose config` validates all three compose files at defaults and with overrides.

### Test Environment
- **LibreDB Studio Version**: main @ `ce157a1`
- **Browser**: n/a (compose-level change)
- **OS**: macOS 26.5.2 (Docker Desktop 29.4.3)
- **Node.js/Bun Version**: bun 1.3.14
- **Database Type**: PostgreSQL 18 (postgres:18, official image)

## Screenshots (if applicable)

n/a

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes — *see Testing above: 196 pre-existing local (macOS) failures identical on clean HEAD; CI on Linux is the authority*
- [ ] The required CI test job passes the **100% line-coverage gate** — *this PR adds no executable `src/` lines (compose YAML, docs, one test file), so it cannot move the gate; left to CI*
- [ ] If I changed `src/lib/db/providers/`, I updated the matching `docs/providers/` documentation and `tests/integration/db/` tests in the same PR (provider triad) — *not applicable; no provider code touched*
- [x] Any dependent changes have been merged and published

## Additional Notes

- No new ports or widened bind addresses: the only port changes are parameterisations defaulting to the existing `5432` mapping. Dev-only fixed credentials untouched. A security review of the diff flagged one **low** item, now documented in `.env.example`: `LIBREDB_POSTGRES_HOST_PORT` interpolates into the full ports spec, so an operator *could* set it to an `ip:port` shape to pin the bind address — compose-standard behavior from developer-set environment, not a new attack surface.
- Existing users whose data volume was initialized under the old path keep working untouched; only the fresh-start path was broken (init scripts run on empty data directories, which restart-looped on 18, so the seed was unreachable by construction).
- Review context: this branch passed independent code review and security review (subagents); all five code-review findings (2 medium: root-compose parameterisation completeness, `.env.example` documentation; 3 low: upgrade note, test-name accuracy, seed-attribution docs) are addressed in the reviewed final commit `c5c4332`.
