### PR TITLE
chore: add conservative community moderation triage

### DIFF
--- a/.github/community-moderation-triage.md
+++ b/.github/community-moderation-triage.md
@@ -1,0 +1,55 @@
+# Community moderation triage proof of concept
+
+This is intentionally a conservative first step for helping maintainers identify suspicious community activity without automatically taking action against users.
+
+## What it does
+
+The workflow evaluates a small set of metadata signals for new or edited issues, pull requests, and comments. If the combined score reaches the configured threshold, it adds the `needs-human-review` label to the related issue or pull request.
+
+The current signals are deliberately simple and explainable:
+
+- very new or new GitHub account;
+- no repository association or first-time contributor status;
+- unusually many external links;
+- unusually many user mentions.
+
+These signals are not treated as proof of abuse. They only determine whether a maintainer should review the activity.
+
+## What it does not do
+
+The workflow does not:
+
+- block or ban users;
+- close issues or pull requests;
+- delete or hide comments;
+- post public accusations;
+- check out or execute code from pull requests;
+- use repository secrets.
+
+A maintainer always makes the final moderation decision.
+
+## Security model
+
+`pull_request_target` is used only so metadata-only triage can label pull requests from forks. The workflow never checks out the pull request head or executes contributor-controlled code.
+
+Permissions are limited to:
+
+- `contents: read`;
+- `issues: write`;
+- `pull-requests: write`.
+
+The workflow does not request access to repository secrets.
+
+## Tuning
+
+The default review threshold is `3`. Maintainers can override it with the repository variable `MODERATION_REVIEW_THRESHOLD` without editing the workflow.
+
+The initial rollout should remain label-only. After enough real examples have been reviewed, the signals and threshold can be adjusted based on false positives and missed cases.
+
+## Suggested rollout
+
+1. Run in label-only mode for at least a week.
+2. Review every flagged item manually.
+3. Record false positives and missed bot activity.
+4. Adjust weights or add repository-specific signals only when there is evidence they help.
+5. Keep destructive moderation actions out of the workflow unless maintainers explicitly decide otherwise after observing the data.

--- a/.github/workflows/community-moderation-triage.yml
+++ b/.github/workflows/community-moderation-triage.yml
@@ -1,0 +1,155 @@
+name: Community moderation triage
+
+# Conservative, review-only moderation support.
+# This workflow never blocks users, closes content, deletes content, or checks out
+# pull-request code. It only adds a review label when several metadata signals
+# cross a configurable threshold.
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: moderation-triage-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    env:
+      MODERATION_REVIEW_THRESHOLD: ${{ vars.MODERATION_REVIEW_THRESHOLD || '3' }}
+
+    steps:
+      - name: Evaluate metadata signals
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const payload = context.payload;
+            const eventName = context.eventName;
+
+            const subject = eventName === 'issue_comment'
+              ? payload.issue
+              : eventName === 'pull_request_target'
+                ? payload.pull_request
+                : payload.issue;
+
+            const author = eventName === 'issue_comment'
+              ? payload.comment?.user
+              : subject?.user;
+
+            const association = eventName === 'issue_comment'
+              ? payload.comment?.author_association
+              : subject?.author_association;
+
+            if (!subject || !author || author.type === 'Bot') {
+              core.info('Skipping: no supported human-authored subject found.');
+              return;
+            }
+
+            const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            if (trustedAssociations.has(association)) {
+              core.info(`Skipping trusted repository association: ${association}.`);
+              return;
+            }
+
+            const text = eventName === 'issue_comment'
+              ? (payload.comment?.body || '')
+              : `${subject.title || ''}\n${subject.body || ''}`;
+
+            const { data: profile } = await github.rest.users.getByUsername({
+              username: author.login,
+            });
+
+            const accountAgeDays = Math.max(
+              0,
+              (Date.now() - new Date(profile.created_at).getTime()) / 86_400_000,
+            );
+
+            let score = 0;
+            const reasons = [];
+
+            if (accountAgeDays < 7) {
+              score += 3;
+              reasons.push('very new account');
+            } else if (accountAgeDays < 30) {
+              score += 2;
+              reasons.push('new account');
+            }
+
+            if (!association || association === 'NONE') {
+              score += 1;
+              reasons.push('no repository association');
+            } else if (association === 'FIRST_TIME_CONTRIBUTOR') {
+              score += 1;
+              reasons.push('first-time contributor');
+            }
+
+            const externalLinks = text.match(/https?:\/\/[^\s)>\]]+/gi) || [];
+            if (externalLinks.length >= 4) {
+              score += 1;
+              reasons.push('many external links');
+            }
+
+            const mentions = text.match(/@[A-Za-z0-9-]+/g) || [];
+            if (mentions.length >= 6) {
+              score += 1;
+              reasons.push('many user mentions');
+            }
+
+            const configuredThreshold = Number(process.env.MODERATION_REVIEW_THRESHOLD);
+            const threshold = Number.isFinite(configuredThreshold) && configuredThreshold > 0
+              ? configuredThreshold
+              : 3;
+
+            core.info(`Moderation triage score: ${score}/${threshold}.`);
+
+            if (score < threshold) {
+              core.info('No review label added.');
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = subject.number;
+            const label = {
+              name: 'needs-human-review',
+              color: 'D4C5F9',
+              description: 'Automated triage signal; requires human review before any moderation action.',
+            };
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label.name });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+
+              try {
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              } catch (createError) {
+                // Another run may have created the shared label concurrently.
+                if (createError.status !== 422) throw createError;
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: [label.name],
+            });
+
+            await core.summary
+              .addHeading('Community moderation triage')
+              .addRaw(`Flagged #${issue_number} for human review.\n\n`)
+              .addRaw(`Signals: ${reasons.join(', ')}.\n\n`)
+              .addRaw('No user or content moderation action was taken automatically.')
+              .write();


### PR DESCRIPTION
## Summary

- add a review-only GitHub Actions workflow for suspicious community activity
- score a small set of explainable metadata signals and add `needs-human-review` only when the threshold is reached
- never block users, close/delete content, execute contributor code, or use repository secrets
- document the security model, tuning, and a label-only rollout plan

This is the proof of concept discussed after #735, where @cevheri asked to move the proposal into a PR for discussion.

## Security model

The workflow uses `pull_request_target` only for metadata-only triage on forked PRs. It does not check out or execute pull-request code. Permissions are limited to `contents: read`, `issues: write`, and `pull-requests: write`.

The default threshold is intentionally conservative and configurable with `MODERATION_REVIEW_THRESHOLD`. The final moderation decision always remains with a maintainer.

## Testing

This change is limited to a GitHub Actions workflow and its rollout documentation. The workflow is designed to remain label-only so its first real validation can be done safely against repository activity while maintainers inspect false positives and misses.